### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+## Java/Kotlin
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+
+
+## Gradle
+.gradle
+/build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar
+
+# Cache of project
+.gradletasknamecache
+
+# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
+# gradle/wrapper/gradle-wrapper.properties
+
+
+
+## Custom
+# Nothing here yet

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ hs_err_pid*
 ## Gradle
 .gradle
 /build/
+/subprojects/*/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
Adds a `.gitignore` containing the rules for Java/Kotlin and Gradle found in the [gitignore repo](https://github.com/github/gitignore).

It does not contain rules for JetBrains because these rules should go into your own global gitignore: If we don't want any editor-specific files in the repo, why would we want editor-specific ignore rules?
