### PR TITLE
Tool setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,12 @@
 buildscript {
     repositories {
         mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "com.diffplug.spotless:spotless-plugin-gradle:$spotlessVersion"
     }
 }
 
@@ -14,6 +16,7 @@ allprojects {
     apply plugin: "application"
     apply plugin: "java"
     apply plugin: "kotlin"
+    apply plugin: "com.diffplug.gradle.spotless"
 
     // Dependencies
     repositories {
@@ -41,6 +44,12 @@ allprojects {
     test {
         useJUnitPlatform() {
             includeEngines "spek"
+        }
+    }
+
+    spotless {
+        kotlin {
+            ktlint()
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -8,28 +8,42 @@ buildscript {
     }
 }
 
-
+// Shared config
 allprojects {
+    // Plugins
     apply plugin: "application"
     apply plugin: "java"
     apply plugin: "kotlin"
 
+    // Dependencies
     repositories {
         mavenCentral()
     }
 
     dependencies {
         compile group: "org.jetbrains.kotlin", name: "kotlin-stdlib-jdk8", version: kotlinVersion
+        compile group: "org.jetbrains.kotlin", name: "kotlin-reflect", version: kotlinVersion
 
-        testCompile group: "junit", name: "junit", version: junitVersion
+        testCompile group: "org.assertj", name: "assertj-core", version: assertjVersion
+        testCompile group: "org.jetbrains.spek", name: "spek-api", version: spekVersion
+        testRuntime group: "org.jetbrains.spek", name: "spek-junit-platform-engine", version: spekVersion
+        testCompile group: "org.junit.jupiter", name: "junit-jupiter-engine", version: junitVersion
     }
 
+    // Tasks
     compileKotlin {
         kotlinOptions.jvmTarget = "1.8"
     }
     compileTestKotlin {
         kotlinOptions.jvmTarget = "1.8"
     }
+
+    test {
+        useJUnitPlatform() {
+            includeEngines "spek"
+        }
+    }
 }
 
+// Root project config
 mainClassName = "org.cafejojo.schaapi.SchaapiKt"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,7 @@ version             = 0.0.1
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-junitVersion  = 4.12
-kotlinVersion = 1.2.41
+assertjVersion = 3.9.0
+junitVersion   = 5.2.0
+kotlinVersion  = 1.2.41
+spekVersion    = 1.1.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,8 @@ version             = 0.0.1
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
-assertjVersion = 3.9.0
-junitVersion   = 5.2.0
-kotlinVersion  = 1.2.41
-spekVersion    = 1.1.5
+assertjVersion  = 3.9.0
+junitVersion    = 5.2.0
+kotlinVersion   = 1.2.41
+spekVersion     = 1.1.5
+spotlessVersion = 3.10.0

--- a/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
+++ b/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
@@ -1,10 +1,8 @@
 package org.cafejojo.schaapi
 
-
 fun main(args: Array<String>) {
     println("I am the main main class!")
 }
-
 
 class Schaapi {
     fun testMe(foo: Int): Int {

--- a/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
+++ b/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
@@ -4,3 +4,10 @@ package org.cafejojo.schaapi
 fun main(args: Array<String>) {
     println("I am the main main class!")
 }
+
+
+class Schaapi {
+    fun testMe(foo: Int): Int {
+        return 2 * foo
+    }
+}

--- a/src/test/kotlin/org/cafejojo/schaapi/SchaapiTest.kt
+++ b/src/test/kotlin/org/cafejojo/schaapi/SchaapiTest.kt
@@ -5,7 +5,6 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
-
 internal class SchaapiTest : Spek({
     describe("Schaapi") {
         it("should work for negative numbers") {

--- a/src/test/kotlin/org/cafejojo/schaapi/SchaapiTest.kt
+++ b/src/test/kotlin/org/cafejojo/schaapi/SchaapiTest.kt
@@ -1,0 +1,26 @@
+package org.cafejojo.schaapi
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+
+
+internal class SchaapiTest : Spek({
+    describe("Schaapi") {
+        it("should work for negative numbers") {
+            assertThat(Schaapi().testMe(-49643))
+                .isEqualTo(-99286)
+        }
+
+        it("should work for 0") {
+            assertThat(Schaapi().testMe(0))
+                .isEqualTo(0)
+        }
+
+        it("should work for positive numbers") {
+            assertThat(Schaapi().testMe(27280))
+                .isEqualTo(54560)
+        }
+    }
+})

--- a/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
+++ b/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
@@ -4,3 +4,10 @@ package org.cafejojo.schaapi.patterndetector
 fun main(args: Array<String>) {
     println("I am the pattern detector!")
 }
+
+
+class PatternDetector {
+    fun testMe(foo: String): String {
+        return foo + foo
+    }
+}

--- a/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
+++ b/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
@@ -1,10 +1,8 @@
 package org.cafejojo.schaapi.patterndetector
 
-
 fun main(args: Array<String>) {
     println("I am the pattern detector!")
 }
-
 
 class PatternDetector {
     fun testMe(foo: String): String {

--- a/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
+++ b/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
@@ -5,7 +5,6 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
-
 internal class PatternDetectorTest : Spek({
     describe("Schaapi") {
         it("should work for strings") {

--- a/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
+++ b/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
@@ -1,0 +1,21 @@
+package org.cafejojo.schaapi.patterndetector
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+
+
+internal class PatternDetectorTest : Spek({
+    describe("Schaapi") {
+        it("should work for strings") {
+            assertThat(PatternDetector().testMe("hWR3L"))
+                .isEqualTo("hWR3LhWR3L")
+        }
+
+        it("should work for empty strings") {
+            assertThat(PatternDetector().testMe(""))
+                .isEqualTo("")
+        }
+    }
+})

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/UsageGraphGenerator.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/UsageGraphGenerator.kt
@@ -1,6 +1,5 @@
 package org.cafejojo.schaapi.usagegraphgenerator
 
-
 fun main(args: Array<String>) {
     println("I am the usage graph generator!")
 }


### PR DESCRIPTION
Configures [Spek](http://spekframework.org/) and [ktlint](https://ktlint.github.io/).

## Spek
Spek was configured in 057748d. The setup uses Spek's own JUnit engine to find the tests, and uses the default Jupiter engine to run the tests. The commit also contains a number of tests to show that it works.

## ktlint
ktlint was configured in c47f5d7. The setup uses [Spotless](https://github.com/diffplug/spotless), which is a general tool for linters. The reason that Spotless was used is that its Gradle plugin looks way more developed and maintained than ktlint's own (unofficial) plugins.

ktlint enforces the Kotlin style guide. You can configure IntelliJ to conform to this style using the following instructions:

![Enforcing Kotling style guide in IntelliJ](https://user-images.githubusercontent.com/13442533/39429721-146c3db6-4c8c-11e8-9345-b6b04a92762c.png)

ktlint has two tasks: `spotlessCheck` and `spotlessApply`. The former checks that the code conforms to the required style, and the latter changes the code to conform. The `spotlessCheck` is executed as part of `gradle check`, and results in build warnings.

## Detekt
I was unable to configure [Detekt](https://github.com/arturbosch/detekt) because it looks like there are some bugs with the configuration. It kept complaining about missing repositories even though they were there. I'll postpone this to some later date.
