### PR TITLE
Create README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+# 🐑 schaapi
+[![Travis build status](https://img.shields.io/travis/cafejojo/schaapi/master.svg)](https://travis-ci.org/cafejojo/schaapi)


### PR DESCRIPTION
Adds a README.md with a Travis CI badge. The badge won't work until #5 has been merged. You can find a live, rendered version of this README [here](https://github.com/cafejojo/schaapi/tree/readme).