### PR TITLE
Codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,21 @@
+# Properties
 language: java
+jdk: oraclejdk8
 
-jdk:
-  - oraclejdk8
 
+# Configuration
 install:
   - ./gradlew -version
 
 script:
  - ./gradlew detektCheck check
+ - ./gradlew jacocoRootReport
 
+after_success:
+  - bash <(curl -s https://codecov.io/bash)
+
+
+# Caching
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
   - rm -fr $HOME/.gradle/caches/*/plugin-resolution/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # 🐑 schaapi
 [![Travis build status](https://img.shields.io/travis/cafejojo/schaapi/master.svg)](https://travis-ci.org/cafejojo/schaapi)
 [![AppVeyor](https://img.shields.io/appveyor/ci/CafeJojo/schaapi/master.svg)](https://ci.appveyor.com/project/CafeJojo/schaapi/branch/master)
-[![CodeCov](https://img.shields.io/codecov/c/github/codecov/example-python/master.svg)](https://codecov.io/gh/cafejojo/schaapi/)
+[![CodeCov](https://img.shields.io/codecov/c/github/cafejojo/schaapi/master.svg)](https://codecov.io/gh/cafejojo/schaapi/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # 🐑 schaapi
 [![Travis build status](https://img.shields.io/travis/cafejojo/schaapi/master.svg)](https://travis-ci.org/cafejojo/schaapi)
 [![AppVeyor](https://img.shields.io/appveyor/ci/CafeJojo/schaapi/master.svg)](https://ci.appveyor.com/project/CafeJojo/schaapi/branch/master)
-[![Codacy Badge](https://img.shields.io/codacy/grade/f788539e0acb4f0eabd95ad38e099c42.svg)](https://www.codacy.com/app/casperboone/schaapi)
+[![CodeCov](https://img.shields.io/codecov/c/github/codecov/example-python/master.svg)](https://codecov.io/gh/cafejojo/schaapi/)

--- a/build.gradle
+++ b/build.gradle
@@ -14,15 +14,21 @@ buildscript {
 
 // Shared config
 allprojects {
-    // Plugins
+    /// Plugins
+    // Compilation
     apply plugin: "application"
     apply plugin: "java"
     apply plugin: "kotlin"
-    apply plugin: "com.diffplug.gradle.spotless"
 
-    // Dependencies
+    // Static analysis
+    apply plugin: "com.diffplug.gradle.spotless"
+    apply plugin: "jacoco"
+
+
+    /// Dependencies
     repositories {
         mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
 
     dependencies {
@@ -35,7 +41,9 @@ allprojects {
         testCompile group: "org.junit.jupiter", name: "junit-jupiter-engine", version: junitVersion
     }
 
-    // Tasks
+
+    /// Configuration
+    // Kotlin
     compileKotlin {
         kotlinOptions.jvmTarget = "1.8"
     }
@@ -43,15 +51,37 @@ allprojects {
         kotlinOptions.jvmTarget = "1.8"
     }
 
+    // JUnit / Spek
     test {
         useJUnitPlatform() {
             includeEngines "spek"
         }
     }
 
+    // Spotless
     spotless {
         kotlin {
             ktlint()
+        }
+    }
+
+    // Jacoco
+    test {
+        jacoco {
+            append = true
+            destinationFile = file("$rootProject.buildDir/jacoco/test.exec")
+        }
+    }
+
+    jacocoTestReport {
+        additionalSourceDirs = files(sourceSets.main.allSource.srcDirs)
+        sourceDirectories = files(sourceSets.main.allSource.srcDirs)
+        classDirectories = files(sourceSets.main.output)
+
+        reports {
+            csv.enabled = false
+            html.enabled = true
+            xml.enabled = true
         }
     }
 }
@@ -62,3 +92,26 @@ apply from: "gradle/detekt.gradle"
 
 // Root project config
 mainClassName = "org.cafejojo.schaapi.SchaapiKt"
+
+// Jacoco report combining all reports
+task jacocoRootReport(type: JacocoReport) {
+    dependsOn = allprojects.test
+    additionalSourceDirs = files(allprojects.sourceSets.main.allSource.srcDirs)
+    sourceDirectories = files(allprojects.sourceSets.main.allSource.srcDirs)
+    classDirectories = files(allprojects.sourceSets.main.output)
+    executionData = files(allprojects.jacocoTestReport.executionData)
+
+    reports {
+        html.enabled = true
+        xml.enabled = true
+        csv.enabled = false
+    }
+
+    doFirst {
+        executionData = files(executionData.findAll {
+            it.exists()
+        })
+    }
+
+    onlyIf = { true }
+}


### PR DESCRIPTION
Configures Jacoco and sets up ~Codacy~ [Codecov](https://codecov.io/gh/cafejojo/schaapi) to track the coverage.

Jacoco gathers the execution data during the tests into a `test.exec` for each module, and then the custom `jacocoRootReport` task combines this data into a single XML. The `after_success` task in the `.travis.yml` then downloads the Codecov upload script and uses it to send the root report to Codecov.

As evidenced by the Codecov comment below, it works.