### PR TITLE
Disable Travis email notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,8 @@ cache:
   directories:
     - $HOME/.gradle/caches/
     - $HOME/.gradle/wrapper/
+
+
+# Notifications
+notifications:
+  email: false


### PR DESCRIPTION
Disables the automatic sending of emails for each build status.