### PR TITLE
Set up Detekt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
   - ./gradlew -version
 
 script:
- - ./gradlew check
+ - ./gradlew detektCheck check
 
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
 build_script:
 - cmd: gradlew assemble
 test_script:
-- cmd: gradlew check
+- cmd: gradlew detektCheck --project-cache-dir=../cache check
 
 
 # Caching

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
 build_script:
 - cmd: gradlew assemble
 test_script:
-- cmd: gradlew detektCheck --project-cache-dir=../cache check
+- cmd: gradlew detektCheck --project-cache-dir=../schaapi-cache check
 
 
 # Caching

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,11 @@ buildscript {
 
     dependencies {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
+        classpath "gradle.plugin.io.gitlab.arturbosch.detekt:detekt-gradle-plugin:$detektVersion"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:$spotlessVersion"
     }
 }
+
 
 // Shared config
 allprojects {
@@ -53,6 +55,16 @@ allprojects {
         }
     }
 }
+
+
+// Detekt
+// Should be applied only to the root project, and will automatically analyse the remaining projects
+apply plugin: "io.gitlab.arturbosch.detekt"
+
+detekt {
+    //
+}
+
 
 // Root project config
 mainClassName = "org.cafejojo.schaapi.SchaapiKt"

--- a/build.gradle
+++ b/build.gradle
@@ -57,13 +57,7 @@ allprojects {
 }
 
 
-// Detekt
-// Should be applied only to the root project, and will automatically analyse the remaining projects
-apply plugin: "io.gitlab.arturbosch.detekt"
-
-detekt {
-    //
-}
+apply from: "gradle/detekt.gradle"
 
 
 // Root project config

--- a/config/detekt/detekt-config.yml
+++ b/config/detekt/detekt-config.yml
@@ -1,4 +1,4 @@
-#failFast: true
+failFast: true
 
 test-pattern:
   active: true

--- a/config/detekt/detekt-config.yml
+++ b/config/detekt/detekt-config.yml
@@ -1,0 +1,11 @@
+failFast: true
+
+test-pattern:
+  active: true
+  patterns:
+    - ".*/test/.*"
+  exclude-rule-sets:
+    - "comments"
+  exclude-rules:
+    - "MagicNumber"
+    - "TooManyFunctions"

--- a/config/detekt/detekt-config.yml
+++ b/config/detekt/detekt-config.yml
@@ -1,4 +1,4 @@
-failFast: true
+#failFast: true
 
 test-pattern:
   active: true

--- a/config/detekt/detekt-config.yml
+++ b/config/detekt/detekt-config.yml
@@ -3,7 +3,7 @@ failFast: true
 test-pattern:
   active: true
   patterns:
-    - ".*/test/.*"
+    - ".*[/\\\\]test[/\\\\].*"
   exclude-rule-sets:
     - "comments"
   exclude-rules:

--- a/config/detekt/detekt-config.yml
+++ b/config/detekt/detekt-config.yml
@@ -1,5 +1,22 @@
 failFast: true
 
+comments:
+  CommentOverPrivateFunction:
+    active: false
+
+complexity:
+  ComplexMethod:
+    threshold: 16
+
+style:
+  ReturnCount:
+    active: false
+  UnnecessaryAbstractClass:
+    active: false
+  UnusedPrivateMember:
+    active: false
+
+
 test-pattern:
   active: true
   patterns:

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 assertjVersion  = 3.9.0
+detektVersion   = 1.0.0.RC6-4
 junitVersion    = 5.2.0
 kotlinVersion   = 1.2.41
 spekVersion     = 1.1.5

--- a/gradle/detekt.gradle
+++ b/gradle/detekt.gradle
@@ -1,0 +1,21 @@
+/// Detekt applies itself to all subprojects
+// https://github.com/arturbosch/detekt/issues/420
+// https://github.com/arturbosch/detekt/issues/540
+apply plugin: "io.gitlab.arturbosch.detekt"
+
+
+/// Configure profile
+// https://arturbosch.github.io/detekt/kotlindsl.html
+detekt {
+    defaultProfile {
+        config = file("$rootDir/config/detekt/detekt-config.yml")
+    }
+}
+
+
+/// Remove "--config-resource" directory that magically appears
+// https://github.com/arturbosch/detekt/issues/854
+task detektCleanUp(type: Delete) {
+    delete "--config-resource"
+}
+detektCheck.finalizedBy detektCleanUp

--- a/gradle/detekt.gradle
+++ b/gradle/detekt.gradle
@@ -13,9 +13,10 @@ detekt {
 }
 
 
-/// Remove "--config-resource" directory that magically appears
+/// Remove directories that magically appear
 // https://github.com/arturbosch/detekt/issues/854
 task detektCleanUp(type: Delete) {
+    delete "--config"
     delete "--config-resource"
 }
 detektCheck.finalizedBy detektCleanUp

--- a/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
+++ b/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
@@ -1,11 +1,18 @@
 package org.cafejojo.schaapi
 
+/**
+ * Placeholder main method.
+ */
 fun main(args: Array<String>) {
     println("I am the main main class!")
 }
 
+/**
+ * Placeholder testable class.
+ */
 class Schaapi {
-    fun testMe(foo: Int): Int {
-        return 2 * foo
-    }
+    /**
+     * Placeholder testable method.
+     */
+    fun testMe(foo: Int): Int = 2 * foo
 }

--- a/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
+++ b/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
@@ -1,11 +1,18 @@
 package org.cafejojo.schaapi.patterndetector
 
+/**
+ * Placeholder main method.
+ */
 fun main(args: Array<String>) {
     println("I am the pattern detector!")
 }
 
+/**
+ * Placeholder testable class.
+ */
 class PatternDetector {
-    fun testMe(foo: String): String {
-        return foo + foo
-    }
+    /**
+     * Placeholder testable method.
+     */
+    fun testMe(foo: String): String = foo + foo
 }

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/InstructionGrouper.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/InstructionGrouper.kt
@@ -34,7 +34,7 @@ class InstructionGrouper(private val cfg: ControlFlowGraph) {
         }
 
         if (!isProcessableBlock(block)) {
-            block.edges.filter { it.dst != block }.forEach({ groupToStatements(it.dst, predecessor) })
+            block.edges.filter { it.dst != block }.forEach { groupToStatements(it.dst, predecessor) }
             return null
         }
 
@@ -48,7 +48,7 @@ class InstructionGrouper(private val cfg: ControlFlowGraph) {
 
         firstNodeOfVisitedBlocks[block] = first
 
-        block.edges.filter { it.dst != block }.forEach({ groupToStatements(it.dst, last) })
+        block.edges.filter { it.dst != block }.forEach { groupToStatements(it.dst, last) }
 
         return first
     }

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/UsageGraphGenerator.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/UsageGraphGenerator.kt
@@ -1,5 +1,8 @@
 package org.cafejojo.schaapi.usagegraphgenerator
 
+/**
+ * Placeholder main method.
+ */
 fun main(args: Array<String>) {
     println("I am the usage graph generator!")
 }


### PR DESCRIPTION
Adds [Detekt](https://github.com/arturbosch/detekt/) to the project.

There's a number of peculiarities with Detekt, which initially made it hard to configure. Those issues have been resolved or hacked around.

## Features
* Detekts stuff!
* A number of rules has been ignored specifically for tests. This configuration happens in `/config/detekt/detekt-config.yml`.
* I have resolved a number of Detekt/Codacy issues that have been here since the beginning.

## Bugs
* Detekt **fails** on Windows unless the cache directory is set somewhere outside of the project. To work around this, always run Detekt with a relocated cache: `gradle detektCheck  --project-cache-dir=../schaapi-cache`. This extra argument should not be necessary on Unix. Yes, this also means that you will get an annoying `schaapi-cache` directory as a sibling to your `schaapi` repo directory.
* Because of the issue above, the `check` task does **not** rely on `detectCheck`. If you want to run all tests and verification, run `gradle detektCheck --project-cache-dir=../schaapi-cache check`. Again, the extra argument should not be necessary on Unix.
* Detekt should be applied only to the root project (in the `build.gradle`, that is), not to the individual subprojects. It is therefore currently not possible to change the configuration of Detekt per module. This also means that you cannot run `gradle :subproject:detectCheck`, but luckily `gradle :detectCheck` already checks all the modules, including the subprojects.
* Detekt creates the directories `--config` and `--config-config-resource` for some reason. This is a bug. I have configured Gradle to remove these directories after running Detekt.
* It doesn't work on Travis for some reason. Luckily, we also have AppVeyor.
