### PR TITLE
Add first version of Prefix Space Algorithm

### DIFF
--- a/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
+++ b/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
@@ -18,12 +18,12 @@ class PatternDetector(private val allPaths: Collection<List<Node>>) {
          */
         internal fun pathContainsSequence(path: List<Node>, sequence: List<Node>): Boolean {
             for (pathPos in 0 until path.size) {
-                for (patternPos in 0 until sequence.size) {
-                    if (pathPos + patternPos > path.size - 1 ||
-                        path[pathPos + patternPos] != sequence[patternPos]
-                    ) break
+                for (sequencePos in 0 until sequence.size) {
+                    val endOfPathOrNodeUnequal =
+                        pathPos + sequencePos > path.size - 1 || path[pathPos + sequencePos] != sequence[sequencePos]
 
-                    if (patternPos == sequence.size - 1) return true
+                    if (endOfPathOrNodeUnequal) break
+                    if (sequencePos == sequence.size - 1) return true
                 }
             }
 

--- a/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
+++ b/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
@@ -85,7 +85,7 @@ class PatternDetector(private val allPaths: Collection<List<Node>>) {
         frequentItems.forEach { frequentItem ->
             val aPathContainsPrefixPlusFrequentItem = projectedPaths.any { path ->
                 pathContainsSequence(path, prefix + frequentItem) ||
-                    (prefix.isNotEmpty() && pathContainsSequence(path, listOf(prefix.last(), frequentItem)))
+                    prefix.isNotEmpty() && pathContainsSequence(path, listOf(prefix.last(), frequentItem))
             }
 
             if (aPathContainsPrefixPlusFrequentItem) {

--- a/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
+++ b/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
@@ -1,18 +1,111 @@
 package org.cafejojo.schaapi.patterndetector
 
-/**
- * Placeholder main method.
- */
-fun main(args: Array<String>) {
-    println("I am the pattern detector!")
-}
+import org.cafejojo.schaapi.usagegraphgenerator.Node
 
 /**
- * Placeholder testable class.
+ * Pattern detector class, which aims to find all the frequent sequences of [Node]s in the given collection of paths.
+ *
+ * @param allPaths all paths in which patterns should be detected. Each path is a list of [Node]s.
  */
-class PatternDetector {
+class PatternDetector(private val allPaths: Collection<List<Node>>) {
+
     /**
-     * Placeholder testable method.
+     * Find all the frequent sequences of [Node]s in the given collection of paths set using the prefix space algorithm
+     * by Pei et al.
+     *
+     * The algorithm operates on the 'divide and conquer' principle. During each iteration, a new prefix is generated.
+     * All sequences which start with this prefix are then mined during the next iteration. However, only their suffixes
+     * need to be mined as they have a common prefix.
+     *
+     * Below is a pseudocode representation of the algorithm.
+     *
+     * ```
+     * Procedure PrefixSpace(frequent_items, all_paths)
+     *   return PrefixSpace([], frequent_items, all_paths, [])
+     * EndProcedure
+     *
+     * SubProcedure PrefixSpace(prefix, frequent_items, projected_paths, frequent_sequences)
+     *   for all item in frequent_items
+     *     if (prefix + item) contained in a path in projected_paths or
+     *        (prefix.last + item) contained in a path in projected_paths
+     *
+     *       new_prefix <- prefix + item
+     *       frequent_sequences <- frequent_sequences U new_prefix
+     *       new_projected_paths <- empty set
+     *
+     *       for all sequence in projected_paths
+     *         if item starts with new_prefix
+     *           new_projected_paths <- new_projected_paths U (item - new_prefix)
+     *         end if
+     *       end for
+     *
+     *       PrefixSpace(new_prefix, frequent_items, new_projected_paths, frequent_sequences)
+     *     end if
+     *   end for
+     *
+     *   return frequent_sequences
+     * SubEndProcedure
+     * ```
+     *
+     * @param initialMinimumCount The minimum amount of times a node must appear in allPaths for it to be
+     * considered a frequent item. These nodes are passed as the ```frequent_items``` argument in the above algorithm.
+     * @return List of sequences, each a list of nodes, that are common within the given paths.
      */
-    fun testMe(foo: String): String = foo + foo
+    fun frequentPatterns(initialMinimumCount: Int) = prefixSpace(frequentItems = frequentItems(initialMinimumCount))
+
+    private fun prefixSpace(
+        prefix: List<Node> = emptyList(),
+        frequentItems: Set<Node>,
+        projectedPaths: Collection<List<Node>> = allPaths,
+        frequentSequences: MutableList<List<Node>> = mutableListOf()
+    ): List<List<Node>> {
+        frequentItems.forEach { frequentItem ->
+            val newPrefix = prefix + frequentItem
+            val lastCharNewPrefix = if (prefix.isEmpty()) listOf(frequentItem) else listOf(prefix.last(), frequentItem)
+
+            if (newPrefix.isEmpty() || projectedPaths.any { pathContainsPattern(it, newPrefix) } ||
+                projectedPaths.any { pathContainsPattern(it, lastCharNewPrefix) }
+            ) {
+                frequentSequences += newPrefix
+
+                val newProjectedDataSet: MutableList<List<Node>> = mutableListOf()
+                projectedPaths.forEach { sequence ->
+                    val extractedPrefix = sequence.subList(0, newPrefix.size)
+                    if (extractedPrefix == newPrefix && sequence.size > newPrefix.size) {
+                        newProjectedDataSet += sequence.subList(newPrefix.size + 1, sequence.size)
+                    }
+                }
+
+                prefixSpace(newPrefix, frequentItems, projectedPaths, frequentSequences)
+            }
+        }
+
+        return frequentSequences
+    }
+
+    private fun pathContainsPattern(path: List<Node>, pattern: List<Node>): Boolean {
+       for (pathPos in 0 until path.size) {
+           for (patternPos in 0 until pattern.size) {
+               if (pathPos + patternPos > path.size - 1 || path[pathPos + patternPos] != pattern[patternPos]) break
+               else if (patternPos == pattern.size - 1) return true
+           }
+        }
+
+       return false
+    }
+
+    private fun frequentItems(minimumCount: Int): Set<Node> {
+        val values: MutableMap<Node, Int> = HashMap()
+        allPaths.forEach { sequence ->
+            sequence.forEach { node ->
+                if (!values.containsKey(node)) values[node] = 1
+                values[node]?.inc()
+            }
+        }
+
+        val items: MutableSet<Node> = HashSet()
+        values.forEach { node, amount -> if (amount >= minimumCount) items += node }
+
+        return items
+    }
 }

--- a/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
+++ b/subprojects/pattern-detector/src/main/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetector.kt
@@ -73,7 +73,8 @@ class PatternDetector(private val allPaths: Collection<List<Node>>) {
      * considered a frequent item. These nodes are passed as the ```frequent_items``` argument in the above algorithm.
      * @return the list of sequences, each a list of nodes, that are common within the given paths.
      */
-    fun findFrequentPatterns(initialMinimumCount: Int) = prefixSpace(frequentItems = getFrequentItems(initialMinimumCount))
+    fun findFrequentPatterns(initialMinimumCount: Int) =
+        prefixSpace(frequentItems = getFrequentItems(initialMinimumCount))
 
     private fun prefixSpace(
         prefix: List<Node> = emptyList(),
@@ -83,9 +84,8 @@ class PatternDetector(private val allPaths: Collection<List<Node>>) {
     ): List<List<Node>> {
         frequentItems.forEach { frequentItem ->
             val aPathContainsPrefixPlusFrequentItem = projectedPaths.any { path ->
-                pathContainsSequence(path, prefix + frequentItem) or
-                    prefix.isNotEmpty() and
-                    pathContainsSequence(path, listOf(prefix.last(), frequentItem))
+                pathContainsSequence(path, prefix + frequentItem) ||
+                    (prefix.isNotEmpty() && pathContainsSequence(path, listOf(prefix.last(), frequentItem)))
             }
 
             if (aPathContainsPrefixPlusFrequentItem) {

--- a/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
+++ b/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
@@ -1,20 +1,7 @@
 package org.cafejojo.schaapi.patterndetector
 
-import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.describe
-import org.jetbrains.spek.api.dsl.it
 
 internal class PatternDetectorTest : Spek({
-    describe("Schaapi") {
-        it("should work for strings") {
-            assertThat(PatternDetector().testMe("hWR3L"))
-                .isEqualTo("hWR3LhWR3L")
-        }
 
-        it("should work for empty strings") {
-            assertThat(PatternDetector().testMe(""))
-                .isEqualTo("")
-        }
-    }
 })

--- a/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
+++ b/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
@@ -1,6 +1,7 @@
 package org.cafejojo.schaapi.patterndetector
 
 import org.assertj.core.api.Assertions.assertThat
+import org.cafejojo.schaapi.patterndetector.PatternDetector.Companion.pathContainsSequence
 import org.cafejojo.schaapi.usagegraphgenerator.CustomNodeId
 import org.cafejojo.schaapi.usagegraphgenerator.EntryNode
 import org.cafejojo.schaapi.usagegraphgenerator.ExitNode
@@ -10,6 +11,71 @@ import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
 internal class PatternDetectorTest : Spek({
+    describe("when looking for a pattern in a path") {
+        it("it should find a sequence in a path of length 1") {
+            val node1 = EntryNode(id = CustomNodeId(1))
+            val path = listOf(node1)
+
+            assertThat(pathContainsSequence(path, listOf(node1))).isTrue()
+        }
+
+        it("it should not find a sequence that isn't in the path") {
+            val node1 = EntryNode(id = CustomNodeId(1))
+            val node2 = EntryNode(id = CustomNodeId(2))
+            val path = listOf(node1)
+
+            assertThat(pathContainsSequence(path, listOf(node2))).isFalse()
+        }
+
+        it("it should find a sequence at the start of a path") {
+            val node1 = EntryNode(id = CustomNodeId(1))
+            val node2 = EntryNode(id = CustomNodeId(2))
+            val node3 = EntryNode(id = CustomNodeId(3))
+            val node4 = EntryNode(id = CustomNodeId(4))
+            val node5 = EntryNode(id = CustomNodeId(5))
+            val node6 = EntryNode(id = CustomNodeId(6))
+            val path = listOf(node1, node2, node3, node4, node5, node6)
+
+            assertThat(pathContainsSequence(path, listOf(node1, node2))).isTrue()
+        }
+
+        it("it should find a sequence in the middle of a path") {
+            val node1 = EntryNode(id = CustomNodeId(1))
+            val node2 = EntryNode(id = CustomNodeId(2))
+            val node3 = EntryNode(id = CustomNodeId(3))
+            val node4 = EntryNode(id = CustomNodeId(4))
+            val node5 = EntryNode(id = CustomNodeId(5))
+            val node6 = EntryNode(id = CustomNodeId(6))
+            val path = listOf(node1, node2, node3, node4, node5, node6)
+
+            assertThat(pathContainsSequence(path, listOf(node3, node4, node5))).isTrue()
+        }
+
+        it("it should find a sequence at the end of a path") {
+            val node1 = EntryNode(id = CustomNodeId(1))
+            val node2 = EntryNode(id = CustomNodeId(2))
+            val node3 = EntryNode(id = CustomNodeId(3))
+            val node4 = EntryNode(id = CustomNodeId(4))
+            val node5 = EntryNode(id = CustomNodeId(5))
+            val node6 = EntryNode(id = CustomNodeId(6))
+            val path = listOf(node1, node2, node3, node4, node5, node6)
+
+            assertThat(pathContainsSequence(path, listOf(node5, node6))).isTrue()
+        }
+
+        it("it should not find a out of order sequence that is not in a path") {
+            val node1 = EntryNode(id = CustomNodeId(1))
+            val node2 = EntryNode(id = CustomNodeId(2))
+            val node3 = EntryNode(id = CustomNodeId(3))
+            val node4 = EntryNode(id = CustomNodeId(4))
+            val node5 = EntryNode(id = CustomNodeId(5))
+            val node6 = EntryNode(id = CustomNodeId(6))
+            val path = listOf(node1, node2, node3, node4, node5, node6)
+
+            assertThat(pathContainsSequence(path, listOf(node5, node4))).isFalse()
+        }
+    }
+
     describe("detecting patterns in a set of paths") {
         it("should find the entire pattern in one path") {
             val node1 = EntryNode(id = CustomNodeId(1))
@@ -57,7 +123,6 @@ internal class PatternDetectorTest : Spek({
             val paths = listOf(path)
             val frequent = PatternDetector(paths).frequentPatterns(2)
 
-            assertThat(frequent).hasSize(6)
             assertThat(frequent).contains(listOf(node1, node2, node3))
         }
 
@@ -80,7 +145,6 @@ internal class PatternDetectorTest : Spek({
             val paths = listOf(path1, path2, path3)
             val frequent = PatternDetector(paths).frequentPatterns(2)
 
-            assertThat(frequent).hasSize(6)
             assertThat(frequent).contains(path1)
         }
     }

--- a/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
+++ b/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
@@ -11,18 +11,77 @@ import org.jetbrains.spek.api.dsl.it
 
 internal class PatternDetectorTest : Spek({
     describe("detecting patterns in a set of paths") {
-        it("Should find the entire pattern in one path") {
+        it("should find the entire pattern in one path") {
             val node1 = EntryNode(id = CustomNodeId(1))
             val node2 = StatementNode(id = CustomNodeId(2))
             val node3 = ExitNode(id = CustomNodeId(3))
 
             val path = listOf(node1, node2, node3)
-            val paths = listOf(path)
 
+            val paths = listOf(path)
             val frequent = PatternDetector(paths).frequentPatterns(1)
 
             assertThat(frequent).hasSize(6)
             assertThat(frequent).contains(path)
+        }
+
+        it("should not find a pattern in a set of random nodes with support 2") {
+            val node1 = EntryNode(id = CustomNodeId(1))
+            val node2 = StatementNode(id = CustomNodeId(2))
+            val node3 = ExitNode(id = CustomNodeId(3))
+            val node4 = EntryNode(id = CustomNodeId(4))
+            val node5 = StatementNode(id = CustomNodeId(5))
+            val node6 = ExitNode(id = CustomNodeId(6))
+            val node7 = EntryNode(id = CustomNodeId(7))
+            val node8 = StatementNode(id = CustomNodeId(8))
+            val node9 = StatementNode(id = CustomNodeId(9))
+            val node10 = ExitNode(id = CustomNodeId(10))
+
+            val path1 = listOf(node1, node2, node3)
+            val path2 = listOf(node4, node5, node6)
+            val path3 = listOf(node7, node8, node9, node10)
+
+            val paths = listOf(path1, path2, path3)
+            val frequent = PatternDetector(paths).frequentPatterns(2)
+
+            assertThat(frequent).hasSize(0)
+        }
+
+        it("should find a pattern that occurs twice in the same path") {
+            val node1 = EntryNode(id = CustomNodeId(1))
+            val node2 = StatementNode(id = CustomNodeId(4))
+            val node3 = ExitNode(id = CustomNodeId(7))
+
+            val path = listOf(node1, node2, node3, node1, node2, node3)
+
+            val paths = listOf(path)
+            val frequent = PatternDetector(paths).frequentPatterns(2)
+
+            assertThat(frequent).hasSize(6)
+            assertThat(frequent).contains(listOf(node1, node2, node3))
+        }
+
+        it("should find a pattern that occurs twice in two different paths") {
+            val node1 = EntryNode(id = CustomNodeId(1))
+            val node2 = StatementNode(id = CustomNodeId(2))
+            val node3 = ExitNode(id = CustomNodeId(3))
+            val node4 = EntryNode(id = CustomNodeId(4))
+            val node5 = StatementNode(id = CustomNodeId(5))
+            val node6 = ExitNode(id = CustomNodeId(6))
+            val node7 = EntryNode(id = CustomNodeId(7))
+            val node8 = StatementNode(id = CustomNodeId(8))
+            val node9 = StatementNode(id = CustomNodeId(9))
+            val node10 = ExitNode(id = CustomNodeId(10))
+
+            val path1 = listOf(node1, node2, node3)
+            val path2 = listOf(node4, node5, node6)
+            val path3 = listOf(node7, node8, node9, node10, node1, node2, node3)
+
+            val paths = listOf(path1, path2, path3)
+            val frequent = PatternDetector(paths).frequentPatterns(2)
+
+            assertThat(frequent).hasSize(6)
+            assertThat(frequent).contains(path1)
         }
     }
 })

--- a/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
+++ b/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
@@ -1,7 +1,28 @@
 package org.cafejojo.schaapi.patterndetector
 
+import org.assertj.core.api.Assertions.assertThat
+import org.cafejojo.schaapi.usagegraphgenerator.CustomNodeId
+import org.cafejojo.schaapi.usagegraphgenerator.EntryNode
+import org.cafejojo.schaapi.usagegraphgenerator.ExitNode
+import org.cafejojo.schaapi.usagegraphgenerator.StatementNode
 import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
 
 internal class PatternDetectorTest : Spek({
+    describe("detecting patterns in a set of paths") {
+        it("Should find the entire pattern in one path") {
+            val node1 = EntryNode(id = CustomNodeId(1))
+            val node2 = StatementNode(id = CustomNodeId(2))
+            val node3 = ExitNode(id = CustomNodeId(3))
 
+            val path = listOf(node1, node2, node3)
+            val paths = listOf(path)
+
+            val frequent = PatternDetector(paths).frequentPatterns(1)
+
+            assertThat(frequent).hasSize(6)
+            assertThat(frequent).contains(path)
+        }
+    }
 })

--- a/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
+++ b/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
@@ -74,6 +74,16 @@ internal class PatternDetectorTest : Spek({
 
             assertThat(pathContainsSequence(path, listOf(node5, node4))).isFalse()
         }
+
+        it("it should not find a non-consecutive sequence that is not in a path") {
+            val node2 = EntryNode(id = CustomNodeId(2))
+            val node3 = EntryNode(id = CustomNodeId(3))
+            val node4 = EntryNode(id = CustomNodeId(4))
+            val node5 = EntryNode(id = CustomNodeId(5))
+            val path = listOf(node2, node3, node4, node5)
+
+            assertThat(pathContainsSequence(path, listOf(node2, node4, node5))).isFalse()
+        }
     }
 
     describe("detecting patterns in a set of paths") {

--- a/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
+++ b/subprojects/pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/PatternDetectorTest.kt
@@ -85,7 +85,7 @@ internal class PatternDetectorTest : Spek({
             val path = listOf(node1, node2, node3)
 
             val paths = listOf(path)
-            val frequent = PatternDetector(paths).frequentPatterns(1)
+            val frequent = PatternDetector(paths).findFrequentPatterns(1)
 
             assertThat(frequent).hasSize(6)
             assertThat(frequent).contains(path)
@@ -108,7 +108,7 @@ internal class PatternDetectorTest : Spek({
             val path3 = listOf(node7, node8, node9, node10)
 
             val paths = listOf(path1, path2, path3)
-            val frequent = PatternDetector(paths).frequentPatterns(2)
+            val frequent = PatternDetector(paths).findFrequentPatterns(2)
 
             assertThat(frequent).hasSize(0)
         }
@@ -121,7 +121,7 @@ internal class PatternDetectorTest : Spek({
             val path = listOf(node1, node2, node3, node1, node2, node3)
 
             val paths = listOf(path)
-            val frequent = PatternDetector(paths).frequentPatterns(2)
+            val frequent = PatternDetector(paths).findFrequentPatterns(2)
 
             assertThat(frequent).contains(listOf(node1, node2, node3))
         }
@@ -143,7 +143,7 @@ internal class PatternDetectorTest : Spek({
             val path3 = listOf(node7, node8, node9, node10, node1, node2, node3)
 
             val paths = listOf(path1, path2, path3)
-            val frequent = PatternDetector(paths).frequentPatterns(2)
+            val frequent = PatternDetector(paths).findFrequentPatterns(2)
 
             assertThat(frequent).contains(path1)
         }


### PR DESCRIPTION
For finding frequent (sub)sequences the PrefixSpan algorithm by Pei et al. (2004) is used. The algorithm uses the 'divide and conquer' principle, and is partially inspired by the FP-tree structure used to mine sets of unordered items.

During each iteration, a new prefix is generated based on the current prefix and  nodes observed to be frequent in the set of paths. If this prefix is observed in the set of paths it is added to the set of frequent sequences. 
After this, all suffixes of sequences which start with this prefix are then mined recursively, with the suffix of a sequence being everything that follows said prefix. This improves upon the a priori method by foregoing the need to generate candidate sequences during each iteration. A pseudocode representation is given below.

```
Procedure PrefixSpace(all_paths, minimum_support)
  frequent_items = all nodes in all_paths with occurrence >= minimum_support
  return PrefixSpace([], frequent_items, all_paths, [])
EndProcedure

SubProcedure PrefixSpace(prefix, frequent_items, projected_paths, frequent_sequences)
  for all item in frequent_items
    if (prefix + item) in a path in projected_paths or
      (prefix.last + item) in a path in projected_paths

      new_prefix <- prefix + item
      frequent_sequences <- frequent_sequences U new_prefix
      new_projected_paths <- empty_set

      for all sequence in projected_paths
        if item starts with prefix
          new_projected_paths <- new_projected_paths U (item - prefix)
        end if
      end for

      PrefixSpace(new_prefix, frequent_items, new_projected_paths, frequent_sequences)
    end if
  end for

  return frequent_sequences
SubEndProcedure
```

This implementation could in future by improved in a number of ways, which will likely be done in future:
- By making it in place, using indexes to identify sequences as opposed to constructing new lists
- By making it non-recursive.