### PR TITLE
Show master status in AppVeyor Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # 🐑 schaapi
 [![Travis build status](https://img.shields.io/travis/cafejojo/schaapi/master.svg)](https://travis-ci.org/cafejojo/schaapi)
-[![AppVeyor](https://ci.appveyor.com/api/projects/status/github/cafejojo/schaapi?branch=master&svg=true)](https://ci.appveyor.com/project/CafeJojo/schaapi/branch/master)
+[![AppVeyor](https://img.shields.io/appveyor/ci/CafeJojo/schaapi/master.svg)](https://ci.appveyor.com/project/CafeJojo/schaapi/branch/master)
 [![Codacy Badge](https://img.shields.io/codacy/grade/f788539e0acb4f0eabd95ad38e099c42.svg)](https://www.codacy.com/app/casperboone/schaapi)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # 🐑 schaapi
 [![Travis build status](https://img.shields.io/travis/cafejojo/schaapi/master.svg)](https://travis-ci.org/cafejojo/schaapi)
-[![AppVeyor](https://img.shields.io/appveyor/ci/cafejojo/schaapi.svg)](https://ci.appveyor.com/project/CafeJojo/schaapi/)
+[![AppVeyor](https://ci.appveyor.com/api/projects/status/github/cafejojo/schaapi?branch=master&svg=true)](https://ci.appveyor.com/project/CafeJojo/schaapi/branch/master)
 [![Codacy Badge](https://img.shields.io/codacy/grade/f788539e0acb4f0eabd95ad38e099c42.svg)](https://www.codacy.com/app/casperboone/schaapi)


### PR DESCRIPTION
The current AppVeyor README badge shows the status of any branch (the latest build). Instead, the status of `master` should be shown, specifically.