### PR TITLE
Add statement and value filters

### DIFF
--- a/subprojects/pattern-detector/build.gradle
+++ b/subprojects/pattern-detector/build.gradle
@@ -1,5 +1,9 @@
 mainClassName = "org.cafejojo.schaapi.patterndetector.PatternDetectorKt"
 
+repositories {
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+}
+
 dependencies {
     compile project(":usage-graph-generator")
 }

--- a/subprojects/usage-graph-generator/build.gradle
+++ b/subprojects/usage-graph-generator/build.gradle
@@ -5,9 +5,11 @@ repositories {
 }
 
 dependencies {
-    compile group: "ca.mcgill.sable", name: "soot", version: "3.1.0"
     compile group: "org.ow2.asm", name: "asm", version: asmVersion
     compile group: "org.ow2.asm", name: "asm-util", version: asmVersion
+
+    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion
+    testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
 
     // TODO: Find usages and remove this library
     compile group: "commons-lang", name: "commons-lang", version: commonsLangVersion

--- a/subprojects/usage-graph-generator/build.gradle
+++ b/subprojects/usage-graph-generator/build.gradle
@@ -1,6 +1,11 @@
 mainClassName = "org.cafejojo.schaapi.usagegraphgenerator.UsageGraphGeneratorKt"
 
+repositories {
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+}
+
 dependencies {
+    compile group: "ca.mcgill.sable", name: "soot", version: "3.1.0"
     compile group: "org.ow2.asm", name: "asm", version: asmVersion
     compile group: "org.ow2.asm", name: "asm-util", version: asmVersion
 

--- a/subprojects/usage-graph-generator/gradle.properties
+++ b/subprojects/usage-graph-generator/gradle.properties
@@ -1,2 +1,4 @@
-asmVersion         = 6.1.1
-commonsLangVersion = 2.6
+asmVersion           = 6.1.1
+commonsLangVersion   = 2.6
+sootVersion          = 3.1.0
+mockitoKotlinVersion = 1.5.0

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilter.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilter.kt
@@ -1,0 +1,34 @@
+package org.cafejojo.schaapi.usagegraphgenerator.filters
+
+import soot.Unit
+import soot.jimple.DefinitionStmt
+import soot.jimple.GotoStmt
+import soot.jimple.IfStmt
+import soot.jimple.InvokeStmt
+import soot.jimple.ReturnStmt
+import soot.jimple.ReturnVoidStmt
+import soot.jimple.SwitchStmt
+import soot.jimple.ThrowStmt
+
+/**
+ * Performs filtering of library using statements.
+ */
+object StatementFilter {
+    /**
+     * Filters out non library using statements.
+     *
+     * @param unit a statement.
+     * @return whether or not the statement should be kept.
+     */
+    fun retain(unit: Unit) = when (unit) {
+        is ThrowStmt -> ValueFilter.retain(unit.op)
+        is DefinitionStmt -> ValueFilter.retain(unit.rightOp)
+        is IfStmt -> throw UnsupportedOperationException("If statements are not supported at this time") // todo
+        is SwitchStmt -> throw UnsupportedOperationException("Switch statements are not supported at this time") // todo
+        is InvokeStmt -> ValueFilter.retain(unit.invokeExpr)
+        is ReturnStmt -> ValueFilter.retain(unit.op)
+        is GotoStmt -> true
+        is ReturnVoidStmt -> true
+        else -> false
+    }
+}

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilter.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilter.kt
@@ -11,11 +11,11 @@ import soot.jimple.SwitchStmt
 import soot.jimple.ThrowStmt
 
 /**
- * Performs filtering of library using statements.
+ * Performs filtering of library-using statements.
  */
 object StatementFilter {
     /**
-     * Filters out non library using statements.
+     * Filters out non library-using statements.
      *
      * @param unit a statement.
      * @return whether or not the statement should be kept.

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilter.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilter.kt
@@ -41,8 +41,8 @@ object ValueFilter {
         is Ref -> retainRef(value)
         is Immediate -> retainImmediate(value)
         is EquivalentValue -> retain(value.value)
-        is NewStaticLock -> false
-        is AbstractDataSource -> false
+        is NewStaticLock -> false // can never involve library usage
+        is AbstractDataSource -> false // is only used for analysis purposes
         else -> throwUnrecognizedValue(value)
     }
 

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilter.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilter.kt
@@ -1,0 +1,98 @@
+package org.cafejojo.schaapi.usagegraphgenerator.filters
+
+import soot.EquivalentValue
+import soot.Immediate
+import soot.Local
+import soot.Value
+import soot.jimple.AnyNewExpr
+import soot.jimple.ArrayRef
+import soot.jimple.BinopExpr
+import soot.jimple.CastExpr
+import soot.jimple.ConcreteRef
+import soot.jimple.Constant
+import soot.jimple.Expr
+import soot.jimple.FieldRef
+import soot.jimple.IdentityRef
+import soot.jimple.InstanceOfExpr
+import soot.jimple.InvokeExpr
+import soot.jimple.NewArrayExpr
+import soot.jimple.NewExpr
+import soot.jimple.NewMultiArrayExpr
+import soot.jimple.Ref
+import soot.jimple.UnopExpr
+import soot.jimple.internal.AbstractBinopExpr
+import soot.jimple.toolkits.infoflow.AbstractDataSource
+import soot.jimple.toolkits.thread.synchronization.NewStaticLock
+import soot.shimple.PhiExpr
+import soot.shimple.ShimpleExpr
+
+/**
+ * Performs filtering of library using values.
+ */
+object ValueFilter {
+    /**
+     * Filters out non library using values.
+     *
+     * @param value a value.
+     * @return whether or not the value should be kept.
+     */
+    fun retain(value: Value): Boolean = when (value) {
+        is Expr -> retainExpr(value)
+        is Ref -> retainRef(value)
+        is Immediate -> retainImmediate(value)
+        is EquivalentValue -> retain(value.value)
+        is NewStaticLock -> false
+        is AbstractDataSource -> false
+        else -> throwUnrecognizedValue(value)
+    }
+
+    private fun retainExpr(expr: Expr) = when (expr) {
+        is InvokeExpr -> isLibraryClass(expr.method.declaringClass.name)
+        is UnopExpr -> retain(expr.op)
+        is BinopExpr -> retain(expr.op1) || retain(expr.op2)
+        is AbstractBinopExpr -> retain(expr.op1) || retain(expr.op2)
+        is InstanceOfExpr -> retain(expr.op) && isLibraryClass(expr.checkType.toString())
+        is ShimpleExpr -> retainShimpleExpr(expr)
+        is AnyNewExpr -> retainAnyNewExpr(expr)
+        is CastExpr -> retain(expr.op)
+        else -> throwUnrecognizedValue(expr)
+    }
+
+    private fun retainShimpleExpr(expr: ShimpleExpr) = when (expr) {
+        is PhiExpr -> expr.values.filter { retain(it) }.any()
+        else -> throwUnrecognizedValue(expr)
+    }
+
+    private fun retainAnyNewExpr(expr: AnyNewExpr) = when (expr) {
+        is NewExpr -> isLibraryClass(expr.type.toString())
+        is NewArrayExpr -> false
+        is NewMultiArrayExpr -> false
+        else -> throwUnrecognizedValue(expr)
+    }
+
+    private fun retainRef(ref: Ref) = when (ref) {
+        is IdentityRef -> false
+        is ConcreteRef -> when (ref) {
+            is FieldRef -> isLibraryClass(ref.field.declaringClass.name)
+            is ArrayRef -> retain(ref.base)
+            else -> throwUnrecognizedValue(ref)
+        }
+        else -> throwUnrecognizedValue(ref)
+    }
+
+    private fun retainImmediate(immediate: Immediate) = when (immediate) {
+        is Local -> false
+        is Constant -> false
+        else -> throwUnrecognizedValue(immediate)
+    }
+
+    private fun isLibraryClass(className: String) = className.startsWith("testclasses.library")
+
+    private fun throwUnrecognizedValue(value: Value): Nothing =
+        throw UnsupportedValueException("Value of type ${value.javaClass} is not supported by the value filter.")
+}
+
+/**
+ * Exception for encountered values that are not supported by the [ValueFilter].
+ */
+class UnsupportedValueException(message: String) : Exception(message)

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilter.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilter.kt
@@ -27,11 +27,11 @@ import soot.shimple.PhiExpr
 import soot.shimple.ShimpleExpr
 
 /**
- * Performs filtering of library using values.
+ * Performs filtering of library-using values.
  */
 object ValueFilter {
     /**
-     * Filters out non library using values.
+     * Filters out non library-using values.
      *
      * @param value a value.
      * @return whether or not the value should be kept.

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilter.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilter.kt
@@ -86,7 +86,7 @@ object ValueFilter {
         else -> throwUnrecognizedValue(immediate)
     }
 
-    private fun isLibraryClass(className: String) = className.startsWith("testclasses.library")
+    private fun isLibraryClass(className: String) = className.startsWith("testclasses.library") // todo
 
     private fun throwUnrecognizedValue(value: Value): Nothing =
         throw UnsupportedValueException("Value of type ${value.javaClass} is not supported by the value filter.")

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilterTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilterTest.kt
@@ -1,0 +1,90 @@
+package org.cafejojo.schaapi.usagegraphgenerator.filters
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import soot.SootClass
+import soot.SootMethod
+import soot.Unit
+import soot.jimple.DefinitionStmt
+import soot.jimple.GotoStmt
+import soot.jimple.InvokeExpr
+import soot.jimple.InvokeStmt
+import soot.jimple.ReturnStmt
+import soot.jimple.ReturnVoidStmt
+import soot.jimple.ThrowStmt
+
+internal class StatementFilterTest : Spek({
+    describe("filters statements based on library usage") {
+        val libraryValue = constructInvokeExprMock("testclasses.library")
+        val nonLibraryValue = constructInvokeExprMock("org.cafejojo.schaapi")
+
+        it("filters throw statements") {
+            itRetains(mock<ThrowStmt> {
+                on { op } doReturn libraryValue
+            })
+            itDoesNotRetain(mock<ThrowStmt> {
+                on { op } doReturn nonLibraryValue
+            })
+        }
+
+        it("filters definition statements") {
+            itRetains(mock<DefinitionStmt> {
+                on { rightOp } doReturn libraryValue
+            })
+            itDoesNotRetain(mock<DefinitionStmt> {
+                on { rightOp } doReturn nonLibraryValue
+            })
+        }
+
+        it("filters if statements") {
+        }
+
+        it("filters switch statements") {
+        }
+
+        it("filters invoke statements") {
+            itRetains(mock<InvokeStmt> {
+                on { invokeExpr } doReturn libraryValue
+            })
+            itDoesNotRetain(mock<InvokeStmt> {
+                on { invokeExpr } doReturn nonLibraryValue
+            })
+        }
+
+        it("filters return statements") {
+            itRetains(mock<ReturnStmt> {
+                on { op } doReturn libraryValue
+            })
+            itDoesNotRetain(mock<ReturnStmt> {
+                on { op } doReturn nonLibraryValue
+            })
+        }
+
+        it("filters goto statements") {
+            itRetains(mock<GotoStmt>())
+        }
+
+        it("filters return void statements") {
+            itRetains(mock<ReturnVoidStmt>())
+        }
+    }
+})
+
+private fun constructInvokeExprMock(declaringClassName: String): InvokeExpr {
+    val clazz = mock<SootClass> {
+        on { name } doReturn declaringClassName
+    }
+    val method = mock<SootMethod> {
+        on { declaringClass } doReturn clazz
+    }
+    return mock {
+        on { getMethod() } doReturn method
+    }
+}
+
+private fun itRetains(unit: Unit) = assertThat(StatementFilter.retain(unit)).isTrue()
+private fun itDoesNotRetain(unit: Unit) = assertThat(StatementFilter.retain(unit)).isFalse()

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilterTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilterTest.kt
@@ -71,6 +71,10 @@ internal class StatementFilterTest : Spek({
         it("filters return void statements") {
             itRetains(mock<ReturnVoidStmt>())
         }
+
+        it("filters unknown statements") {
+            itDoesNotRetain(mock<Unit>())
+        }
     }
 })
 

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilterTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilterTest.kt
@@ -41,9 +41,11 @@ internal class StatementFilterTest : Spek({
         }
 
         it("filters if statements") {
+            // todo
         }
 
         it("filters switch statements") {
+            // todo
         }
 
         it("filters invoke statements") {

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilterTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/StatementFilterTest.kt
@@ -23,19 +23,19 @@ internal class StatementFilterTest : Spek({
         val nonLibraryValue = constructInvokeExprMock("org.cafejojo.schaapi")
 
         it("filters throw statements") {
-            itRetains(mock<ThrowStmt> {
+            assertThatItRetains(mock<ThrowStmt> {
                 on { op } doReturn libraryValue
             })
-            itDoesNotRetain(mock<ThrowStmt> {
+            assertThatItDoesNotRetain(mock<ThrowStmt> {
                 on { op } doReturn nonLibraryValue
             })
         }
 
         it("filters definition statements") {
-            itRetains(mock<DefinitionStmt> {
+            assertThatItRetains(mock<DefinitionStmt> {
                 on { rightOp } doReturn libraryValue
             })
-            itDoesNotRetain(mock<DefinitionStmt> {
+            assertThatItDoesNotRetain(mock<DefinitionStmt> {
                 on { rightOp } doReturn nonLibraryValue
             })
         }
@@ -49,33 +49,33 @@ internal class StatementFilterTest : Spek({
         }
 
         it("filters invoke statements") {
-            itRetains(mock<InvokeStmt> {
+            assertThatItRetains(mock<InvokeStmt> {
                 on { invokeExpr } doReturn libraryValue
             })
-            itDoesNotRetain(mock<InvokeStmt> {
+            assertThatItDoesNotRetain(mock<InvokeStmt> {
                 on { invokeExpr } doReturn nonLibraryValue
             })
         }
 
         it("filters return statements") {
-            itRetains(mock<ReturnStmt> {
+            assertThatItRetains(mock<ReturnStmt> {
                 on { op } doReturn libraryValue
             })
-            itDoesNotRetain(mock<ReturnStmt> {
+            assertThatItDoesNotRetain(mock<ReturnStmt> {
                 on { op } doReturn nonLibraryValue
             })
         }
 
         it("filters goto statements") {
-            itRetains(mock<GotoStmt>())
+            assertThatItRetains(mock<GotoStmt>())
         }
 
         it("filters return void statements") {
-            itRetains(mock<ReturnVoidStmt>())
+            assertThatItRetains(mock<ReturnVoidStmt>())
         }
 
         it("filters unknown statements") {
-            itDoesNotRetain(mock<Unit>())
+            assertThatItDoesNotRetain(mock<Unit>())
         }
     }
 })
@@ -92,5 +92,5 @@ private fun constructInvokeExprMock(declaringClassName: String): InvokeExpr {
     }
 }
 
-private fun itRetains(unit: Unit) = assertThat(StatementFilter.retain(unit)).isTrue()
-private fun itDoesNotRetain(unit: Unit) = assertThat(StatementFilter.retain(unit)).isFalse()
+private fun assertThatItRetains(unit: Unit) = assertThat(StatementFilter.retain(unit)).isTrue()
+private fun assertThatItDoesNotRetain(unit: Unit) = assertThat(StatementFilter.retain(unit)).isFalse()

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilterTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilterTest.kt
@@ -7,27 +7,33 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.junit.jupiter.api.assertThrows
+import soot.Immediate
 import soot.Local
 import soot.SootClass
 import soot.SootField
 import soot.SootMethod
 import soot.Type
 import soot.Value
+import soot.jimple.AnyNewExpr
 import soot.jimple.ArrayRef
 import soot.jimple.BinopExpr
 import soot.jimple.CastExpr
+import soot.jimple.ConcreteRef
 import soot.jimple.Constant
+import soot.jimple.Expr
 import soot.jimple.FieldRef
 import soot.jimple.IdentityRef
 import soot.jimple.InvokeExpr
 import soot.jimple.NewArrayExpr
 import soot.jimple.NewExpr
 import soot.jimple.NewMultiArrayExpr
+import soot.jimple.Ref
 import soot.jimple.UnopExpr
 import soot.jimple.internal.AbstractBinopExpr
 import soot.jimple.toolkits.infoflow.AbstractDataSource
 import soot.jimple.toolkits.thread.synchronization.NewStaticLock
 import soot.shimple.PhiExpr
+import soot.shimple.ShimpleExpr
 
 internal class ValueFilterTest : Spek({
     val libraryInvokeExpr = constructInvokeExprMock("testclasses.library")
@@ -51,6 +57,7 @@ internal class ValueFilterTest : Spek({
                 on { op } doReturn libraryInvokeExpr
             })
             itDoesNotRetain(mock<UnopExpr> {
+
                 on { op } doReturn nonLibraryInvokeExpr
             })
         }
@@ -102,6 +109,10 @@ internal class ValueFilterTest : Spek({
             })
         }
 
+        it("does not recognize unknown shimple expressions") {
+            itDoesNotRecognize(mock<ShimpleExpr>())
+        }
+
         it("filters new expressions") {
             itRetains(mock<NewExpr> {
                 on { type } doReturn libraryType
@@ -119,6 +130,10 @@ internal class ValueFilterTest : Spek({
             itDoesNotRetain(mock<NewMultiArrayExpr>())
         }
 
+        it("does not recognize unknown new expressions") {
+            itDoesNotRecognize(mock<AnyNewExpr>())
+        }
+
         it("filters cast expressions") {
             itRetains(mock<CastExpr> {
                 on { op } doReturn libraryInvokeExpr
@@ -126,6 +141,10 @@ internal class ValueFilterTest : Spek({
             itDoesNotRetain(mock<CastExpr> {
                 on { op } doReturn nonLibraryInvokeExpr
             })
+        }
+
+        it("does not recognize unknown expressions") {
+            itDoesNotRecognize(mock<Expr>())
         }
     }
 
@@ -161,14 +180,27 @@ internal class ValueFilterTest : Spek({
                 on { base } doReturn nonLibraryInvokeExpr
             })
         }
+
+        it("does not recognize unknown refs") {
+            itDoesNotRecognize(mock<Ref>())
+        }
+
+        it("does not recognize unknown concrete refs") {
+            itDoesNotRecognize(mock<ConcreteRef>())
+        }
     }
 
     describe("filtering of immediate values based on library usage") {
         it("filters local immediates") {
             itDoesNotRetain(mock<Local>())
         }
+
         it("filters constant immediates") {
             itDoesNotRetain(mock<Constant>())
+        }
+
+        it("does not recognize unknown immediates") {
+            itDoesNotRecognize(mock<Immediate>())
         }
     }
 
@@ -181,6 +213,12 @@ internal class ValueFilterTest : Spek({
     describe("filtering of data sources based on library usage") {
         it("filters data sources") {
             itDoesNotRetain(mock<AbstractDataSource>())
+        }
+    }
+
+    describe("filtering of unrecognized values based on library usage") {
+        it("does not recognize unknown values") {
+            itDoesNotRecognize(mock<Value>())
         }
     }
 })

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilterTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilterTest.kt
@@ -1,0 +1,206 @@
+package org.cafejojo.schaapi.usagegraphgenerator.filters
+
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.junit.jupiter.api.assertThrows
+import soot.Local
+import soot.SootClass
+import soot.SootField
+import soot.SootMethod
+import soot.Type
+import soot.Value
+import soot.jimple.ArrayRef
+import soot.jimple.BinopExpr
+import soot.jimple.CastExpr
+import soot.jimple.Constant
+import soot.jimple.FieldRef
+import soot.jimple.IdentityRef
+import soot.jimple.InvokeExpr
+import soot.jimple.NewArrayExpr
+import soot.jimple.NewExpr
+import soot.jimple.NewMultiArrayExpr
+import soot.jimple.UnopExpr
+import soot.jimple.internal.AbstractBinopExpr
+import soot.jimple.toolkits.infoflow.AbstractDataSource
+import soot.jimple.toolkits.thread.synchronization.NewStaticLock
+import soot.shimple.PhiExpr
+
+internal class ValueFilterTest : Spek({
+    val libraryInvokeExpr = constructInvokeExprMock("testclasses.library")
+    val nonLibraryInvokeExpr = constructInvokeExprMock("org.cafejojo.schaapi")
+
+    val libraryType = mock<Type> {
+        on { toString() } doReturn "testclasses.library"
+    }
+    val nonLibraryType = mock<Type> {
+        on { toString() } doReturn "org.cafejojo.schaapi"
+    }
+
+    describe("filtering of expression values based on library usage") {
+        it("filters invoke expressions") {
+            itRetains(libraryInvokeExpr)
+            itDoesNotRetain(nonLibraryInvokeExpr)
+        }
+
+        it("filters unary operation expression") {
+            itRetains(mock<UnopExpr> {
+                on { op } doReturn libraryInvokeExpr
+            })
+            itDoesNotRetain(mock<UnopExpr> {
+                on { op } doReturn nonLibraryInvokeExpr
+            })
+        }
+
+        it("filters binary operation expressions") {
+            itRetains(mock<BinopExpr> {
+                on { op1 } doReturn libraryInvokeExpr
+                on { op2 } doReturn libraryInvokeExpr
+            })
+            itRetains(mock<BinopExpr> {
+                on { op1 } doReturn libraryInvokeExpr
+                on { op2 } doReturn nonLibraryInvokeExpr
+            })
+            itRetains(mock<BinopExpr> {
+                on { op1 } doReturn nonLibraryInvokeExpr
+                on { op2 } doReturn libraryInvokeExpr
+            })
+            itDoesNotRetain(mock<BinopExpr> {
+                on { op1 } doReturn nonLibraryInvokeExpr
+                on { op2 } doReturn nonLibraryInvokeExpr
+            })
+        }
+
+        it("filters abstract binary operation expressions") {
+            itRetains(mock<AbstractBinopExpr> {
+                on { op1 } doReturn libraryInvokeExpr
+                on { op2 } doReturn libraryInvokeExpr
+            })
+            itRetains(mock<AbstractBinopExpr> {
+                on { op1 } doReturn libraryInvokeExpr
+                on { op2 } doReturn nonLibraryInvokeExpr
+            })
+            itRetains(mock<AbstractBinopExpr> {
+                on { op1 } doReturn nonLibraryInvokeExpr
+                on { op2 } doReturn libraryInvokeExpr
+            })
+            itDoesNotRetain(mock<AbstractBinopExpr> {
+                on { op1 } doReturn nonLibraryInvokeExpr
+                on { op2 } doReturn nonLibraryInvokeExpr
+            })
+        }
+
+        it("filters phi expressions") {
+            itRetains(mock<PhiExpr> {
+                on { values } doReturn listOf(libraryInvokeExpr, nonLibraryInvokeExpr)
+            })
+            itDoesNotRetain(mock<PhiExpr> {
+                on { values } doReturn listOf(nonLibraryInvokeExpr)
+            })
+        }
+
+        it("filters new expressions") {
+            itRetains(mock<NewExpr> {
+                on { type } doReturn libraryType
+            })
+            itDoesNotRetain(mock<NewExpr> {
+                on { type } doReturn nonLibraryType
+            })
+        }
+
+        it("filters new array expressions") {
+            itDoesNotRetain(mock<NewArrayExpr>())
+        }
+
+        it("filters new multi array expressions") {
+            itDoesNotRetain(mock<NewMultiArrayExpr>())
+        }
+
+        it("filters cast expressions") {
+            itRetains(mock<CastExpr> {
+                on { op } doReturn libraryInvokeExpr
+            })
+            itDoesNotRetain(mock<CastExpr> {
+                on { op } doReturn nonLibraryInvokeExpr
+            })
+        }
+    }
+
+    describe("filtering of ref values based on library usage") {
+        val libraryClass = constructDeclaringClass("testclasses.library")
+        val nonLibraryClass = constructDeclaringClass("org.cafejojo.schaapi")
+
+        val libraryField = mock<SootField> {
+            on { declaringClass } doReturn libraryClass
+        }
+        val nonLibraryField = mock<SootField> {
+            on { declaringClass } doReturn nonLibraryClass
+        }
+
+        it("filters identity refs") {
+            itDoesNotRetain(mock<IdentityRef>())
+        }
+
+        it("filters field refs") {
+            itRetains(mock<FieldRef> {
+                on { field } doReturn libraryField
+            })
+            itDoesNotRetain(mock<FieldRef> {
+                on { field } doReturn nonLibraryField
+            })
+        }
+
+        it("filters array refs") {
+            itRetains(mock<ArrayRef> {
+                on { base } doReturn libraryInvokeExpr
+            })
+            itDoesNotRetain(mock<ArrayRef> {
+                on { base } doReturn nonLibraryInvokeExpr
+            })
+        }
+    }
+
+    describe("filtering of immediate values based on library usage") {
+        it("filters local immediates") {
+            itDoesNotRetain(mock<Local>())
+        }
+        it("filters constant immediates") {
+            itDoesNotRetain(mock<Constant>())
+        }
+    }
+
+    describe("filtering of static lock values based on library usage") {
+        it("filters new static locks") {
+            itDoesNotRetain(mock<NewStaticLock>())
+        }
+    }
+
+    describe("filtering of data sources based on library usage") {
+        it("filters data sources") {
+            itDoesNotRetain(mock<AbstractDataSource>())
+        }
+    }
+})
+
+private fun constructDeclaringClass(declaringClassName: String) = mock<SootClass> {
+    on { name } doReturn declaringClassName
+}
+
+private fun constructInvokeExprMock(declaringClassName: String): InvokeExpr {
+    val clazz = mock<SootClass> {
+        on { name } doReturn declaringClassName
+    }
+    val method = mock<SootMethod> {
+        on { declaringClass } doReturn clazz
+    }
+    return mock {
+        on { getMethod() } doReturn method
+    }
+}
+
+private fun itDoesNotRecognize(value: Value) = assertThrows<UnsupportedValueException> { ValueFilter.retain(value) }
+private fun itRetains(value: Value) = assertThat(ValueFilter.retain(value)).isTrue()
+private fun itDoesNotRetain(value: Value) = assertThat(ValueFilter.retain(value)).isFalse()

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilterTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/filters/ValueFilterTest.kt
@@ -48,103 +48,103 @@ internal class ValueFilterTest : Spek({
 
     describe("filtering of expression values based on library usage") {
         it("filters invoke expressions") {
-            itRetains(libraryInvokeExpr)
-            itDoesNotRetain(nonLibraryInvokeExpr)
+            assertThatItRetains(libraryInvokeExpr)
+            assertThatItDoesNotRetain(nonLibraryInvokeExpr)
         }
 
         it("filters unary operation expression") {
-            itRetains(mock<UnopExpr> {
+            assertThatItRetains(mock<UnopExpr> {
                 on { op } doReturn libraryInvokeExpr
             })
-            itDoesNotRetain(mock<UnopExpr> {
+            assertThatItDoesNotRetain(mock<UnopExpr> {
 
                 on { op } doReturn nonLibraryInvokeExpr
             })
         }
 
         it("filters binary operation expressions") {
-            itRetains(mock<BinopExpr> {
+            assertThatItRetains(mock<BinopExpr> {
                 on { op1 } doReturn libraryInvokeExpr
                 on { op2 } doReturn libraryInvokeExpr
             })
-            itRetains(mock<BinopExpr> {
+            assertThatItRetains(mock<BinopExpr> {
                 on { op1 } doReturn libraryInvokeExpr
                 on { op2 } doReturn nonLibraryInvokeExpr
             })
-            itRetains(mock<BinopExpr> {
+            assertThatItRetains(mock<BinopExpr> {
                 on { op1 } doReturn nonLibraryInvokeExpr
                 on { op2 } doReturn libraryInvokeExpr
             })
-            itDoesNotRetain(mock<BinopExpr> {
+            assertThatItDoesNotRetain(mock<BinopExpr> {
                 on { op1 } doReturn nonLibraryInvokeExpr
                 on { op2 } doReturn nonLibraryInvokeExpr
             })
         }
 
         it("filters abstract binary operation expressions") {
-            itRetains(mock<AbstractBinopExpr> {
+            assertThatItRetains(mock<AbstractBinopExpr> {
                 on { op1 } doReturn libraryInvokeExpr
                 on { op2 } doReturn libraryInvokeExpr
             })
-            itRetains(mock<AbstractBinopExpr> {
+            assertThatItRetains(mock<AbstractBinopExpr> {
                 on { op1 } doReturn libraryInvokeExpr
                 on { op2 } doReturn nonLibraryInvokeExpr
             })
-            itRetains(mock<AbstractBinopExpr> {
+            assertThatItRetains(mock<AbstractBinopExpr> {
                 on { op1 } doReturn nonLibraryInvokeExpr
                 on { op2 } doReturn libraryInvokeExpr
             })
-            itDoesNotRetain(mock<AbstractBinopExpr> {
+            assertThatItDoesNotRetain(mock<AbstractBinopExpr> {
                 on { op1 } doReturn nonLibraryInvokeExpr
                 on { op2 } doReturn nonLibraryInvokeExpr
             })
         }
 
         it("filters phi expressions") {
-            itRetains(mock<PhiExpr> {
+            assertThatItRetains(mock<PhiExpr> {
                 on { values } doReturn listOf(libraryInvokeExpr, nonLibraryInvokeExpr)
             })
-            itDoesNotRetain(mock<PhiExpr> {
+            assertThatItDoesNotRetain(mock<PhiExpr> {
                 on { values } doReturn listOf(nonLibraryInvokeExpr)
             })
         }
 
         it("does not recognize unknown shimple expressions") {
-            itDoesNotRecognize(mock<ShimpleExpr>())
+            assertThatItDoesNotRecognize(mock<ShimpleExpr>())
         }
 
         it("filters new expressions") {
-            itRetains(mock<NewExpr> {
+            assertThatItRetains(mock<NewExpr> {
                 on { type } doReturn libraryType
             })
-            itDoesNotRetain(mock<NewExpr> {
+            assertThatItDoesNotRetain(mock<NewExpr> {
                 on { type } doReturn nonLibraryType
             })
         }
 
         it("filters new array expressions") {
-            itDoesNotRetain(mock<NewArrayExpr>())
+            assertThatItDoesNotRetain(mock<NewArrayExpr>())
         }
 
         it("filters new multi array expressions") {
-            itDoesNotRetain(mock<NewMultiArrayExpr>())
+            assertThatItDoesNotRetain(mock<NewMultiArrayExpr>())
         }
 
         it("does not recognize unknown new expressions") {
-            itDoesNotRecognize(mock<AnyNewExpr>())
+            assertThatItDoesNotRecognize(mock<AnyNewExpr>())
         }
 
         it("filters cast expressions") {
-            itRetains(mock<CastExpr> {
+            assertThatItRetains(mock<CastExpr> {
                 on { op } doReturn libraryInvokeExpr
             })
-            itDoesNotRetain(mock<CastExpr> {
+            assertThatItDoesNotRetain(mock<CastExpr> {
                 on { op } doReturn nonLibraryInvokeExpr
             })
         }
 
         it("does not recognize unknown expressions") {
-            itDoesNotRecognize(mock<Expr>())
+            assertThatItDoesNotRecognize(mock<Expr>())
         }
     }
 
@@ -160,65 +160,65 @@ internal class ValueFilterTest : Spek({
         }
 
         it("filters identity refs") {
-            itDoesNotRetain(mock<IdentityRef>())
+            assertThatItDoesNotRetain(mock<IdentityRef>())
         }
 
         it("filters field refs") {
-            itRetains(mock<FieldRef> {
+            assertThatItRetains(mock<FieldRef> {
                 on { field } doReturn libraryField
             })
-            itDoesNotRetain(mock<FieldRef> {
+            assertThatItDoesNotRetain(mock<FieldRef> {
                 on { field } doReturn nonLibraryField
             })
         }
 
         it("filters array refs") {
-            itRetains(mock<ArrayRef> {
+            assertThatItRetains(mock<ArrayRef> {
                 on { base } doReturn libraryInvokeExpr
             })
-            itDoesNotRetain(mock<ArrayRef> {
+            assertThatItDoesNotRetain(mock<ArrayRef> {
                 on { base } doReturn nonLibraryInvokeExpr
             })
         }
 
         it("does not recognize unknown refs") {
-            itDoesNotRecognize(mock<Ref>())
+            assertThatItDoesNotRecognize(mock<Ref>())
         }
 
         it("does not recognize unknown concrete refs") {
-            itDoesNotRecognize(mock<ConcreteRef>())
+            assertThatItDoesNotRecognize(mock<ConcreteRef>())
         }
     }
 
     describe("filtering of immediate values based on library usage") {
         it("filters local immediates") {
-            itDoesNotRetain(mock<Local>())
+            assertThatItDoesNotRetain(mock<Local>())
         }
 
         it("filters constant immediates") {
-            itDoesNotRetain(mock<Constant>())
+            assertThatItDoesNotRetain(mock<Constant>())
         }
 
         it("does not recognize unknown immediates") {
-            itDoesNotRecognize(mock<Immediate>())
+            assertThatItDoesNotRecognize(mock<Immediate>())
         }
     }
 
     describe("filtering of static lock values based on library usage") {
         it("filters new static locks") {
-            itDoesNotRetain(mock<NewStaticLock>())
+            assertThatItDoesNotRetain(mock<NewStaticLock>())
         }
     }
 
     describe("filtering of data sources based on library usage") {
         it("filters data sources") {
-            itDoesNotRetain(mock<AbstractDataSource>())
+            assertThatItDoesNotRetain(mock<AbstractDataSource>())
         }
     }
 
     describe("filtering of unrecognized values based on library usage") {
         it("does not recognize unknown values") {
-            itDoesNotRecognize(mock<Value>())
+            assertThatItDoesNotRecognize(mock<Value>())
         }
     }
 })
@@ -239,6 +239,11 @@ private fun constructInvokeExprMock(declaringClassName: String): InvokeExpr {
     }
 }
 
-private fun itDoesNotRecognize(value: Value) = assertThrows<UnsupportedValueException> { ValueFilter.retain(value) }
-private fun itRetains(value: Value) = assertThat(ValueFilter.retain(value)).isTrue()
-private fun itDoesNotRetain(value: Value) = assertThat(ValueFilter.retain(value)).isFalse()
+private fun assertThatItDoesNotRecognize(value: Value) =
+    assertThrows<UnsupportedValueException> { ValueFilter.retain(value) }
+
+private fun assertThatItRetains(value: Value) =
+    assertThat(ValueFilter.retain(value)).isTrue()
+
+private fun assertThatItDoesNotRetain(value: Value) =
+    assertThat(ValueFilter.retain(value)).isFalse()


### PR DESCRIPTION
This PR allows to filters Soot statements based on library usage.

It covers all known and expected statements and values, except for `if`s and `switch`es. These will be added it a future PR.

At the moment `isLibraryClass` in the `ValueFilter` is based on a hardcoded string, this will change once #23 is available to use.