### PR TITLE
Use `for-the-badge` style for Shields.io badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # 🐑 schaapi
-[![Travis build status](https://img.shields.io/travis/cafejojo/schaapi/master.svg)](https://travis-ci.org/cafejojo/schaapi)
-[![AppVeyor](https://img.shields.io/appveyor/ci/CafeJojo/schaapi/master.svg)](https://ci.appveyor.com/project/CafeJojo/schaapi/branch/master)
-[![CodeCov](https://img.shields.io/codecov/c/github/cafejojo/schaapi/master.svg)](https://codecov.io/gh/cafejojo/schaapi/)
+[![Travis build status](https://img.shields.io/travis/cafejojo/schaapi/master.svg?style=for-the-badge)](https://travis-ci.org/cafejojo/schaapi)
+[![AppVeyor](https://img.shields.io/appveyor/ci/CafeJojo/schaapi/master.svg?style=for-the-badge)](https://ci.appveyor.com/project/CafeJojo/schaapi/branch/master)
+[![CodeCov](https://img.shields.io/codecov/c/github/cafejojo/schaapi/master.svg?style=for-the-badge)](https://codecov.io/gh/cafejojo/schaapi/)


### PR DESCRIPTION
This is a very important PR! /s

It changes the style of the badges to be larger and more square. I think it makes it easier to read because the original buttons were too small. You can see a live example of this style [here](https://github.com/cafejojo/schaapi/blob/readme-badge-style/README.md).

<sup>It just looks cool so merge it OK?</sup>