### PR TITLE
Set working directory for Maven invoker

### DIFF
--- a/subprojects/project-compiler/src/main/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProject.kt
+++ b/subprojects/project-compiler/src/main/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProject.kt
@@ -72,6 +72,7 @@ class JavaMavenProject(override val projectDir: File) : JavaProject, MavenProjec
         val invoker = DefaultInvoker().apply {
             setOutputHandler(null)
             mavenHome = MavenInstaller.DEFAULT_MAVEN_HOME
+            workingDirectory = projectDir
         }
 
         val result = invoker.execute(request)


### PR DESCRIPTION
Resolves an issue with the Maven compiler where it would not compile projects because the working directory was incorrect.

Thanks @gandreadis for reporting and investigating.
