### PR TITLE
Explicitly set JAVA_HOME in Maven project compilation

### DIFF
--- a/subprojects/project-compiler/src/main/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProject.kt
+++ b/subprojects/project-compiler/src/main/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProject.kt
@@ -77,6 +77,8 @@ class JavaMavenProject(override val projectDir: File) : JavaProject, MavenProjec
             baseDirectory = projectDir
             pomFile = pomFile
             goals = listOf("clean", "install", "dependency:copy-dependencies")
+            isBatchMode = true
+            javaHome = File(System.getProperty("java.home"))
         }
 
         val invoker = DefaultInvoker().apply {


### PR DESCRIPTION
My own global `JAVA_HOME` environment variable was not set properly, which is how I came across this issue. Because setting that variable is not essential to a Java installation, I don't believe we should require our users to have it set, seeing as the rest of our program runs fine without it. This PR fixes this by retrieving the value from a system property and setting it in the invokation request.

This PR also enables 'batch mode' in the maven install invocation, which is more appropriate for our situation (see [this SO question](https://stackoverflow.com/questions/25896081/what-is-the-diffrence-between-interactive-and-batch-mode-in-maven)).