### PR TITLE
Add a class for writing SootClasses to .class files

### DIFF
--- a/subprojects/test-generator/build.gradle
+++ b/subprojects/test-generator/build.gradle
@@ -2,6 +2,11 @@ apply plugin: "application"
 
 mainClassName = "org.cafejojo.schaapi.testgenerator.TestGeneratorKt"
 
+repositories {
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+}
+
 dependencies {
     compile group: "org.evosuite", name: "evosuite-master", version: evosuiteMasterVersion
+    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion
 }

--- a/subprojects/test-generator/gradle.properties
+++ b/subprojects/test-generator/gradle.properties
@@ -1,2 +1,2 @@
 evosuiteMasterVersion = 1.0.6
-sootVersion = 3.1.0
+sootVersion           = 3.1.0

--- a/subprojects/test-generator/gradle.properties
+++ b/subprojects/test-generator/gradle.properties
@@ -1,1 +1,2 @@
 evosuiteMasterVersion = 1.0.6
+sootVersion = 3.1.0

--- a/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriter.kt
+++ b/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriter.kt
@@ -4,34 +4,47 @@ import soot.SootClass
 import soot.jimple.JasminClass
 import soot.util.JasminOutputStream
 import java.io.FileOutputStream
+import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.io.PrintWriter
 import java.nio.file.Paths
 
 /**
- * Writes a [SootClass] to a JVM bytecode class file.
- *
- * @property targetDirectory the path to the base directory in which to place the class file structure
+ * Functionality for serializing a [SootClass] to JVM bytecode.
  */
-class SootClassWriter(private val targetDirectory: String) {
+object SootClassWriter {
     /**
      * Writes the given [sootClass] to a class file.
      *
      * Creates the necessary package structure (based on the fully qualified name of the class) on the file system.
      * Creates all non-existing directories on the generated path.
      *
-     * @param sootClass the class to write to a file
+     * @param sootClass the class to write to file
+     * @param targetDirectory the path to the base directory in which to place the class file structure
      */
-    fun writeFile(sootClass: SootClass) {
+    fun writeToFile(sootClass: SootClass, targetDirectory: String) {
         val outputFile = Paths.get(targetDirectory, generateClassFilePath(sootClass.name)).toFile()
         outputFile.parentFile.mkdirs()
-        val outputStream = JasminOutputStream(FileOutputStream(outputFile))
-        val outputWriter = PrintWriter(OutputStreamWriter(outputStream))
+        val outputStream = FileOutputStream(outputFile)
+
+        writeToOutputStream(sootClass, outputStream)
+
+        outputStream.close()
+    }
+
+    /**
+     *  Writes the given [sootClass] to the given [outputStream].
+     *
+     * @param sootClass the class to write to a file
+     * @param outputStream the [OutputStream] to write the bytecode to
+     */
+    fun writeToOutputStream(sootClass: SootClass, outputStream: OutputStream) {
+        val jasminOutputStream = JasminOutputStream(outputStream)
+        val outputWriter = PrintWriter(OutputStreamWriter(jasminOutputStream))
 
         JasminClass(sootClass).print(outputWriter)
 
         outputWriter.flush()
-        outputStream.close()
     }
 
     private fun generateClassFilePath(fullyQualifiedName: String) = "${fullyQualifiedName.replace(".", "/")}.class"

--- a/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriter.kt
+++ b/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriter.kt
@@ -1,0 +1,38 @@
+package org.cafejojo.schaapi.testgenerator
+
+import soot.SootClass
+import soot.jimple.JasminClass
+import soot.util.JasminOutputStream
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.nio.file.Paths
+
+/**
+ * Writes a [SootClass] to a JVM bytecode class file.
+ *
+ * @property targetDirectory the path to the base directory in which to place the class file structure
+ */
+class SootClassWriter(private val targetDirectory: String) {
+    /**
+     * Writes the given [sootClass] to a class file.
+     *
+     * Creates the necessary package structure (based on the fully qualified name of the class) on the file system.
+     * Creates all non-existing directories on the generated path.
+     *
+     * @param sootClass the class to write to a file
+     */
+    fun writeFile(sootClass: SootClass) {
+        val outputFile = Paths.get(targetDirectory, generateClassFilePath(sootClass.name)).toFile()
+        outputFile.parentFile.mkdirs()
+        val outputStream = JasminOutputStream(FileOutputStream(outputFile))
+        val outputWriter = PrintWriter(OutputStreamWriter(outputStream))
+
+        JasminClass(sootClass).print(outputWriter)
+
+        outputWriter.flush()
+        outputStream.close()
+    }
+
+    private fun generateClassFilePath(fullyQualifiedName: String) = "${fullyQualifiedName.replace(".", "/")}.class"
+}

--- a/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriter.kt
+++ b/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriter.kt
@@ -26,10 +26,9 @@ object SootClassWriter {
         val outputFile = Paths.get(targetDirectory, generateClassFilePath(sootClass.name)).toFile()
         outputFile.parentFile.mkdirs()
         val outputStream = FileOutputStream(outputFile)
-
-        writeToOutputStream(sootClass, outputStream)
-
-        outputStream.close()
+        outputStream.use {
+            writeToOutputStream(sootClass, outputStream)
+        }
     }
 
     /**

--- a/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriter.kt
+++ b/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriter.kt
@@ -25,9 +25,8 @@ object SootClassWriter {
     fun writeToFile(sootClass: SootClass, targetDirectory: String) {
         val outputFile = Paths.get(targetDirectory, generateClassFilePath(sootClass.name)).toFile()
         outputFile.parentFile.mkdirs()
-        val outputStream = FileOutputStream(outputFile)
-        outputStream.use {
-            writeToOutputStream(sootClass, outputStream)
+        FileOutputStream(outputFile).use {
+            writeToOutputStream(sootClass, it)
         }
     }
 

--- a/subprojects/test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriterTest.kt
+++ b/subprojects/test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriterTest.kt
@@ -1,11 +1,14 @@
 package org.cafejojo.schaapi.testgenerator
 
+import com.sun.xml.internal.messaging.saaj.util.ByteOutputStream
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import soot.Scene
 import java.nio.file.Paths
+import java.util.*
+import javax.xml.bind.DatatypeConverter
 
 internal class SootClassWriterTest : Spek({
     val classPath = Paths.get(SootClassWriterTest::class.java.getResource("../../../../").toURI()).toString()
@@ -29,8 +32,7 @@ internal class SootClassWriterTest : Spek({
         it("outputs a class file in the root directory") {
             val testClassName = "MyTestClass"
 
-            val sootClassWriter = SootClassWriter(classOutputDirectory.path)
-            sootClassWriter.writeFile(Scene.v().makeSootClass(testClassName))
+            SootClassWriter.writeToFile(Scene.v().makeSootClass(testClassName), classOutputDirectory.path)
 
             assertThat(Paths.get(classOutputDirectory.absolutePath, "$testClassName.class")).exists()
         }
@@ -39,9 +41,8 @@ internal class SootClassWriterTest : Spek({
             val testClassName1 = "MyFirstTestClass"
             val testClassName2 = "MySecondTestClass"
 
-            val sootClassWriter = SootClassWriter(classOutputDirectory.path)
-            sootClassWriter.writeFile(Scene.v().makeSootClass(testClassName1))
-            sootClassWriter.writeFile(Scene.v().makeSootClass(testClassName2))
+            SootClassWriter.writeToFile(Scene.v().makeSootClass(testClassName1), classOutputDirectory.path)
+            SootClassWriter.writeToFile(Scene.v().makeSootClass(testClassName2), classOutputDirectory.path)
 
             assertThat(Paths.get(classOutputDirectory.absolutePath, "$testClassName1.class")).exists()
             assertThat(Paths.get(classOutputDirectory.absolutePath, "$testClassName2.class")).exists()
@@ -50,10 +51,21 @@ internal class SootClassWriterTest : Spek({
         it("outputs a class file in a directory structure") {
             val testClassName = "org.test.MyTestClass"
 
-            val sootClassWriter = SootClassWriter(classOutputDirectory.path)
-            sootClassWriter.writeFile(Scene.v().makeSootClass(testClassName))
+            SootClassWriter.writeToFile(Scene.v().makeSootClass(testClassName), classOutputDirectory.path)
 
             assertThat(Paths.get(classOutputDirectory.absolutePath, "org", "test", "MyTestClass.class")).exists()
+        }
+
+        it("outputs the same bytecode for a simple class, consistently") {
+            val testClassName = "MyTestClass"
+
+            val byteOutputStream = ByteOutputStream()
+            SootClassWriter.writeToOutputStream(Scene.v().makeSootClass(testClassName), byteOutputStream)
+
+            assertThat(DatatypeConverter.printBase64Binary(byteOutputStream.bytes))
+                    .isEqualTo("yv66vgAAAC4AAwcAAgEAC015VGVzdENsYXNzACAAAQ" +
+                            Collections.nCopies(1324, "A").joinToString(separator = "") { it } +
+                            "==")
         }
     }
 })

--- a/subprojects/test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriterTest.kt
+++ b/subprojects/test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriterTest.kt
@@ -1,0 +1,59 @@
+package org.cafejojo.schaapi.testgenerator
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import soot.Scene
+import java.nio.file.Paths
+
+internal class SootClassWriterTest : Spek({
+    val classPath = Paths.get(SootClassWriterTest::class.java.getResource("../../../../").toURI()).toString()
+    val classOutputDirectory = Paths.get(classPath, "class-writer-test/").toFile()
+
+    fun deleteClassFileOutput() {
+        if (classOutputDirectory.exists()) {
+            classOutputDirectory.deleteRecursively()
+        }
+    }
+
+    beforeGroup {
+        deleteClassFileOutput()
+    }
+
+    afterEachTest {
+        deleteClassFileOutput()
+    }
+
+    describe("writing SootClasses to .class files") {
+        it("outputs a class file in the root directory") {
+            val testClassName = "MyTestClass"
+
+            val sootClassWriter = SootClassWriter(classOutputDirectory.path)
+            sootClassWriter.writeFile(Scene.v().makeSootClass(testClassName))
+
+            assertThat(Paths.get(classOutputDirectory.absolutePath, "$testClassName.class")).exists()
+        }
+
+        it("outputs two class files in the root directory") {
+            val testClassName1 = "MyFirstTestClass"
+            val testClassName2 = "MySecondTestClass"
+
+            val sootClassWriter = SootClassWriter(classOutputDirectory.path)
+            sootClassWriter.writeFile(Scene.v().makeSootClass(testClassName1))
+            sootClassWriter.writeFile(Scene.v().makeSootClass(testClassName2))
+
+            assertThat(Paths.get(classOutputDirectory.absolutePath, "$testClassName1.class")).exists()
+            assertThat(Paths.get(classOutputDirectory.absolutePath, "$testClassName2.class")).exists()
+        }
+
+        it("outputs a class file in a directory structure") {
+            val testClassName = "org.test.MyTestClass"
+
+            val sootClassWriter = SootClassWriter(classOutputDirectory.path)
+            sootClassWriter.writeFile(Scene.v().makeSootClass(testClassName))
+
+            assertThat(Paths.get(classOutputDirectory.absolutePath, "org", "test", "MyTestClass.class")).exists()
+        }
+    }
+})

--- a/subprojects/test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriterTest.kt
+++ b/subprojects/test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriterTest.kt
@@ -7,7 +7,6 @@ import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import soot.Scene
 import java.nio.file.Paths
-import java.util.Collections
 import javax.xml.bind.DatatypeConverter
 
 internal class SootClassWriterTest : Spek({
@@ -63,9 +62,7 @@ internal class SootClassWriterTest : Spek({
             SootClassWriter.writeToOutputStream(Scene.v().makeSootClass(testClassName), byteOutputStream)
 
             assertThat(DatatypeConverter.printBase64Binary(byteOutputStream.bytes))
-                .isEqualTo("yv66vgAAAC4AAwcAAgEAC015VGVzdENsYXNzACAAAQ"
-                    + Collections.nCopies(1324, "A").joinToString(separator = "") { it }
-                    + "==")
+                .isEqualTo("yv66vgAAAC4AAwcAAgEAC015VGVzdENsYXNzACAAAQ${"A".repeat(1324)}==")
         }
     }
 })

--- a/subprojects/test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriterTest.kt
+++ b/subprojects/test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/SootClassWriterTest.kt
@@ -7,7 +7,7 @@ import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import soot.Scene
 import java.nio.file.Paths
-import java.util.*
+import java.util.Collections
 import javax.xml.bind.DatatypeConverter
 
 internal class SootClassWriterTest : Spek({
@@ -63,9 +63,9 @@ internal class SootClassWriterTest : Spek({
             SootClassWriter.writeToOutputStream(Scene.v().makeSootClass(testClassName), byteOutputStream)
 
             assertThat(DatatypeConverter.printBase64Binary(byteOutputStream.bytes))
-                    .isEqualTo("yv66vgAAAC4AAwcAAgEAC015VGVzdENsYXNzACAAAQ" +
-                            Collections.nCopies(1324, "A").joinToString(separator = "") { it } +
-                            "==")
+                .isEqualTo("yv66vgAAAC4AAwcAAgEAC015VGVzdENsYXNzACAAAQ"
+                    + Collections.nCopies(1324, "A").joinToString(separator = "") { it }
+                    + "==")
         }
     }
 })


### PR DESCRIPTION
The class takes an output base directory as property and creates the right package structure within that base directory for each function call (based on the fully qualified name of the class).

Also, I think I won the record for the highest number of `class`es in a schaapi PR title. 🏆 