### PR TITLE
Use OS temporary dirs to store SUT files in

### DIFF
--- a/subprojects/common/src/main/kotlin/org/cafejojo/schaapi/common/JavaProject.kt
+++ b/subprojects/common/src/main/kotlin/org/cafejojo/schaapi/common/JavaProject.kt
@@ -65,6 +65,11 @@ interface JavaProject : Project {
  */
 interface MavenProject : Project {
     /**
+     * The directory where Maven is installed.
+     */
+    val mavenDir: File
+
+    /**
      * The Maven configuration file.
      */
     val pomFile: File

--- a/subprojects/project-compiler/src/main/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProject.kt
+++ b/subprojects/project-compiler/src/main/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProject.kt
@@ -30,7 +30,10 @@ fun main(args: Array<String>) {
  * A Java project using Maven.
  */
 @SuppressWarnings("LateinitUsage") // Refer to PR #23
-class JavaMavenProject(override val projectDir: File) : JavaProject, MavenProject {
+class JavaMavenProject(
+    override val projectDir: File,
+    override val mavenDir: File = MavenInstaller.DEFAULT_MAVEN_HOME
+) : JavaProject, MavenProject {
     override val pomFile = File(projectDir, "pom.xml")
     override val classDir = File(projectDir, "target/classes")
     override val dependencyDir = File(projectDir, "target/dependency")
@@ -75,15 +78,16 @@ class JavaMavenProject(override val projectDir: File) : JavaProject, MavenProjec
     private fun runMaven() {
         val request = DefaultInvocationRequest().apply {
             baseDirectory = projectDir
-            pomFile = pomFile
             goals = listOf("clean", "install", "dependency:copy-dependencies")
             isBatchMode = true
             javaHome = File(System.getProperty("java.home"))
+            pomFile = pomFile
         }
 
         val invoker = DefaultInvoker().apply {
             setOutputHandler(null)
-            mavenHome = MavenInstaller.DEFAULT_MAVEN_HOME
+            mavenHome = mavenDir
+            workingDirectory = projectDir
         }
 
         val result = invoker.execute(request)

--- a/subprojects/project-compiler/src/test/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProjectTest.kt
+++ b/subprojects/project-compiler/src/test/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProjectTest.kt
@@ -18,8 +18,16 @@ internal class JavaMavenProjectTest : Spek({
         MavenInstaller().installMaven(mavenHome)
     }
 
+    afterGroup {
+        mavenHome.deleteRecursively()
+    }
+
     beforeEachTest {
         target = Files.createTempDirectory("schaapi-test").toFile()
+    }
+
+    afterEachTest {
+        target.deleteRecursively()
     }
 
     describe("Java Maven project validation") {

--- a/subprojects/project-compiler/src/test/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProjectTest.kt
+++ b/subprojects/project-compiler/src/test/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProjectTest.kt
@@ -10,11 +10,12 @@ import java.io.FileNotFoundException
 import java.nio.file.Files
 
 internal class JavaMavenProjectTest : Spek({
+    lateinit var mavenHome: File
     lateinit var target: File
 
     beforeGroup {
-        val mavenTarget = Files.createTempDirectory("schaapi-maven").toFile()
-        MavenInstaller().installMaven(mavenTarget)
+        mavenHome = Files.createTempDirectory("schaapi-maven").toFile()
+        MavenInstaller().installMaven(mavenHome)
     }
 
     beforeEachTest {
@@ -24,13 +25,13 @@ internal class JavaMavenProjectTest : Spek({
     describe("Java Maven project validation") {
         it("detects non-existing directories") {
             assertThrows<IllegalArgumentException> {
-                JavaMavenProject(File("./invalid-path"))
+                JavaMavenProject(File("./invalid-path"), mavenHome)
             }
         }
 
         it("detects non-maven directories") {
             assertThrows<IllegalArgumentException> {
-                JavaMavenProject(target)
+                JavaMavenProject(target, mavenHome)
             }
         }
     }
@@ -39,7 +40,7 @@ internal class JavaMavenProjectTest : Spek({
         it("compiles codeless projects") {
             setUpTestFiles("/ProjectCompiler/no-sources", target)
 
-            val project = JavaMavenProject(target)
+            val project = JavaMavenProject(target, mavenHome)
             project.compile()
 
             assertThat(project.projectDir).isEqualTo(target)
@@ -54,7 +55,7 @@ internal class JavaMavenProjectTest : Spek({
         it("compiles simple projects") {
             setUpTestFiles("/ProjectCompiler/simple", target)
 
-            val project = JavaMavenProject(target)
+            val project = JavaMavenProject(target, mavenHome)
             project.compile()
 
             assertThat(project.projectDir).isEqualTo(target)
@@ -73,7 +74,7 @@ internal class JavaMavenProjectTest : Spek({
         it("compiles projects with dependencies") {
             setUpTestFiles("/ProjectCompiler/dependencies", target)
 
-            val project = JavaMavenProject(target)
+            val project = JavaMavenProject(target, mavenHome)
             project.compile()
 
             assertThat(project.projectDir).isEqualTo(target)

--- a/subprojects/project-compiler/src/test/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProjectTest.kt
+++ b/subprojects/project-compiler/src/test/kotlin/org/cafejojo/schaapi/projectcompiler/JavaMavenProjectTest.kt
@@ -7,15 +7,21 @@ import org.jetbrains.spek.api.dsl.it
 import org.junit.jupiter.api.assertThrows
 import java.io.File
 import java.io.FileNotFoundException
+import java.nio.file.Files
 
 internal class JavaMavenProjectTest : Spek({
+    lateinit var target: File
+
+    beforeGroup {
+        val mavenTarget = Files.createTempDirectory("schaapi-maven").toFile()
+        MavenInstaller().installMaven(mavenTarget)
+    }
+
+    beforeEachTest {
+        target = Files.createTempDirectory("schaapi-test").toFile()
+    }
+
     describe("Java Maven project validation") {
-        val target = File("test/")
-
-        afterEachTest {
-            target.deleteRecursively()
-        }
-
         it("detects non-existing directories") {
             assertThrows<IllegalArgumentException> {
                 JavaMavenProject(File("./invalid-path"))
@@ -30,16 +36,6 @@ internal class JavaMavenProjectTest : Spek({
     }
 
     describe("Java Maven project compilation") {
-        val target = File("./test")
-
-        beforeGroup {
-            MavenInstaller().installMaven(MavenInstaller.DEFAULT_MAVEN_HOME)
-        }
-
-        afterEachTest {
-            target.deleteRecursively()
-        }
-
         it("compiles codeless projects") {
             setUpTestFiles("/ProjectCompiler/no-sources", target)
 

--- a/subprojects/project-compiler/src/test/kotlin/org/cafejojo/schaapi/projectcompiler/MavenInstallerTest.kt
+++ b/subprojects/project-compiler/src/test/kotlin/org/cafejojo/schaapi/projectcompiler/MavenInstallerTest.kt
@@ -14,6 +14,10 @@ internal class MavenInstallerTest : Spek({
         target = Files.createTempDirectory("schaapi-test").toFile()
     }
 
+    afterEachTest {
+        target.deleteRecursively()
+    }
+
     describe("Maven installer") {
         it("installs Maven") {
             MavenInstaller().installMaven(target)

--- a/subprojects/project-compiler/src/test/kotlin/org/cafejojo/schaapi/projectcompiler/MavenInstallerTest.kt
+++ b/subprojects/project-compiler/src/test/kotlin/org/cafejojo/schaapi/projectcompiler/MavenInstallerTest.kt
@@ -5,19 +5,16 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import java.io.File
+import java.nio.file.Files
 
 internal class MavenInstallerTest : Spek({
+    lateinit var target: File
+
+    beforeEachTest {
+        target = Files.createTempDirectory("schaapi-test").toFile()
+    }
+
     describe("Maven installer") {
-        val target = File("./test/")
-
-        beforeGroup {
-            target.deleteRecursively()
-        }
-
-        afterEachTest {
-            target.deleteRecursively()
-        }
-
         it("installs Maven") {
             MavenInstaller().installMaven(target)
 


### PR DESCRIPTION
Rather than working in a directory `test` in the project's root, the `project-compiler` tests now use temporary file structures using `Files.createTempDirectory` to work in. Because directory names are now randomly generated, there is also no chance of accidentally working with the files from a previous run, and ~~the clean-up is done (or rather, _should_ be done) by the OS automatically~~ the clean-up is done manually because the OS does not do it automatically.

Additionally, this PR fixes a bug where it a `JavaMavenProject` would always look for Maven in the default directory.

There are some other test classes that also work in a `test` directory (or something similarly named), but I did not change those because they also use test-compiled classes and I want to work on those in a separate PR.
