### PR TITLE
Add parameter to write EvoSuite errors to

### DIFF
--- a/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/EvoSuiteRunner.kt
+++ b/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/EvoSuiteRunner.kt
@@ -49,25 +49,26 @@ class EvoSuiteRunner(
         process.waitFor()
 
         if (!lastLine.toLowerCase().contains("computation finished")) {
-            throw EvoSuiteRuntimeException("EvoSuite did not terminate successfully. " +
-                "The last line of its output reads: $lastLine")
+            throw EvoSuiteRuntimeException(
+                "EvoSuite did not terminate successfully. The last line of its output reads: \"$lastLine\""
+            )
         }
 
         if (process.exitValue() != 0) {
             val errorOutput = String(process.errorStream.readBytes(), Charset.defaultCharset())
-            throw EvoSuiteRuntimeException("EvoSuite exited with non-zero exit code: " +
-                "${process.exitValue()} - $errorOutput")
+            throw EvoSuiteRuntimeException(
+                "EvoSuite exited with non-zero exit code: ${process.exitValue()}\n$errorOutput"
+            )
         }
     }
 
     private fun pipeAllLines(input: InputStream, output: PrintStream?): String {
         var lastLine = ""
 
-        BufferedReader(InputStreamReader(input)).lines()
-            .forEach {
-                output?.println(it)
-                lastLine = it
-            }
+        BufferedReader(InputStreamReader(input)).forEachLine {
+            output?.println(it)
+            lastLine = it
+        }
 
         return lastLine
     }

--- a/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/EvoSuiteRunner.kt
+++ b/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/EvoSuiteRunner.kt
@@ -1,6 +1,7 @@
 package org.cafejojo.schaapi.testgenerator
 
 import java.io.BufferedReader
+import java.io.InputStream
 import java.io.InputStreamReader
 import java.io.PrintStream
 import java.nio.charset.Charset
@@ -14,14 +15,16 @@ import java.nio.charset.Charset
  * @property classPath the class path on which to find the class that should be tested
  * @property outputDirectory the output directory path for the generated EvoSuite tests
  * @property generationTimeoutSeconds how long to let the EvoSuite test generator run (in seconds)
- * @property evoSuitePrintStream a stream to output EvoSuite's logs to (the caller has the responsibility to close this)
+ * @property processStandardStream a stream to output EvoSuite's standard messages to
+ * @property processErrorStream a stream to output EvoSuite's error messages to
  */
 class EvoSuiteRunner(
-        private val fullyQualifiedClassName: String,
-        private val classPath: String,
-        private val outputDirectory: String,
-        private val generationTimeoutSeconds: Int = 60,
-        private val evoSuitePrintStream: PrintStream? = null
+    private val fullyQualifiedClassName: String,
+    private val classPath: String,
+    private val outputDirectory: String,
+    private val generationTimeoutSeconds: Int = 60,
+    private val processStandardStream: PrintStream? = null,
+    private val processErrorStream: PrintStream? = null
 ) {
     /**
      * Runs the EvoSuite test generator in a new process.
@@ -29,37 +32,44 @@ class EvoSuiteRunner(
     fun run() = receiveProcessOutput(buildProcess())
 
     private fun buildProcess() = ProcessBuilder(
-            "java",
-            "-cp", System.getProperty("java.class.path"),
-            "org.evosuite.EvoSuite",
-            "-class", fullyQualifiedClassName,
-            "-base_dir", outputDirectory,
-            "-projectCP", classPath,
-            "-Dsearch_budget=$generationTimeoutSeconds",
-            "-Dstatistics_backend=NONE"
+        "java",
+        "-cp", System.getProperty("java.class.path"),
+        "org.evosuite.EvoSuite",
+        "-class", fullyQualifiedClassName,
+        "-base_dir", outputDirectory,
+        "-projectCP", classPath,
+        "-Dsearch_budget=$generationTimeoutSeconds",
+        "-Dstatistics_backend=NONE"
     ).start()
 
     private fun receiveProcessOutput(process: Process) {
-        val bufferedReader = BufferedReader(InputStreamReader(process.inputStream))
-        var lastLine = ""
-
-        bufferedReader.forEachLine {
-            evoSuitePrintStream?.println(it)
-            lastLine = it
-        }
+        val lastLine = pipeAllLines(process.inputStream, processStandardStream)
+        pipeAllLines(process.errorStream, processErrorStream)
 
         process.waitFor()
 
         if (!lastLine.toLowerCase().contains("computation finished")) {
             throw EvoSuiteRuntimeException("EvoSuite did not terminate successfully. " +
-                    "The last line of its output reads: $lastLine")
+                "The last line of its output reads: $lastLine")
         }
 
         if (process.exitValue() != 0) {
             val errorOutput = String(process.errorStream.readBytes(), Charset.defaultCharset())
             throw EvoSuiteRuntimeException("EvoSuite exited with non-zero exit code: " +
-                    "${process.exitValue()} - $errorOutput")
+                "${process.exitValue()} - $errorOutput")
         }
+    }
+
+    private fun pipeAllLines(input: InputStream, output: PrintStream?): String {
+        var lastLine = ""
+
+        BufferedReader(InputStreamReader(input)).lines()
+            .forEach {
+                output?.println(it)
+                lastLine = it
+            }
+
+        return lastLine
     }
 }
 


### PR DESCRIPTION
Adds an `InputStream` parameter to the `EvoSuite` constructor that is used to write EvoSuite's `errorStream` to.

Additionally:
* The behaviour of reading a stream and writing it to a parameter has been extracted into a helper method.
* The continuation indent has been changed from 8 to 4, as is required according to the the ktlint setup (refer to the Wiki article).
