### PR TITLE
Add CI logos to build status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🐑 schaapi
-[![Travis build status](https://img.shields.io/travis/cafejojo/schaapi/master.svg?style=for-the-badge)](https://travis-ci.org/cafejojo/schaapi)
-[![AppVeyor](https://img.shields.io/appveyor/ci/CafeJojo/schaapi/master.svg?style=for-the-badge)](https://ci.appveyor.com/project/CafeJojo/schaapi/branch/master)
+[![Travis build status](https://img.shields.io/travis/cafejojo/schaapi/master.svg?style=for-the-badge&logo=travis)](https://travis-ci.org/cafejojo/schaapi)
+[![AppVeyor build status](https://img.shields.io/appveyor/ci/CafeJojo/schaapi/master.svg?style=for-the-badge&logo=appveyor)](https://ci.appveyor.com/project/CafeJojo/schaapi/branch/master)
 [![CodeCov](https://img.shields.io/codecov/c/github/cafejojo/schaapi/master.svg?style=for-the-badge)](https://codecov.io/gh/cafejojo/schaapi/)
 [![Schaap](https://img.shields.io/badge/Contains-%F0%9F%90%91-FF69B4.svg?style=for-the-badge)](https://github.com/cafejojo/schaapi)
 [![Built with love](https://img.shields.io/badge/built%20with-%E2%9D%A4%EF%B8%8F-red.svg?style=for-the-badge)](https://github.com/cafejojo/)


### PR DESCRIPTION
Also fixes the inconsistency between the two build badge captions.

See [here](https://github.com/cafejojo/schaapi/blob/readme-badge-logos/README.md) for a live demo.