### PR TITLE
Add incomplete-init-pattern filter

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -14,6 +14,7 @@ rootProject.name = "schaapi"
 
 includeModule "common"
 includeModule "pattern-detector"
+includeModule "pattern-filter"
 includeModule "project-compiler"
 includeModule "test-generator"
 includeModule "usage-graph-generator"

--- a/subprojects/common/src/main/kotlin/PatternFilter.kt
+++ b/subprojects/common/src/main/kotlin/PatternFilter.kt
@@ -5,10 +5,10 @@ import org.cafejojo.schaapi.common.Node
  */
 interface PatternFilter {
     /**
-     * Determines if a generated [pattern] should be retained.
+     * Determines if [pattern] should be retained.
      *
      * @param pattern a generated pattern
-     * @return whether the pattern should be retained
+     * @return true if the pattern should be retained
      */
     fun retain(pattern: List<Node>): Boolean
 }

--- a/subprojects/common/src/main/kotlin/PatternFilter.kt
+++ b/subprojects/common/src/main/kotlin/PatternFilter.kt
@@ -1,0 +1,14 @@
+import org.cafejojo.schaapi.common.Node
+
+/**
+ * Represents a filter for generated patterns.
+ */
+interface PatternFilter {
+    /**
+     * Determines if a generated [pattern] should be retained.
+     *
+     * @param pattern a generated pattern
+     * @return whether the pattern should be retained
+     */
+    fun retain(pattern: List<Node>): Boolean
+}

--- a/subprojects/pattern-filter/build.gradle
+++ b/subprojects/pattern-filter/build.gradle
@@ -1,0 +1,11 @@
+repositories {
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+}
+
+dependencies {
+    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion
+    testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
+
+    compile project(":common")
+    compile project(":usage-graph-generator")
+}

--- a/subprojects/pattern-filter/gradle.properties
+++ b/subprojects/pattern-filter/gradle.properties
@@ -1,0 +1,2 @@
+sootVersion          = 3.1.0
+mockitoKotlinVersion = 1.5.0

--- a/subprojects/pattern-filter/gradle.properties
+++ b/subprojects/pattern-filter/gradle.properties
@@ -1,2 +1,2 @@
-sootVersion          = 3.1.0
 mockitoKotlinVersion = 1.5.0
+sootVersion          = 3.1.0

--- a/subprojects/pattern-filter/src/main/kotlin/IncompleteInitPatternFilter.kt
+++ b/subprojects/pattern-filter/src/main/kotlin/IncompleteInitPatternFilter.kt
@@ -1,0 +1,18 @@
+import org.cafejojo.schaapi.common.Node
+import org.cafejojo.schaapi.usagegraphgenerator.SootNode
+import soot.jimple.InvokeStmt
+import soot.jimple.internal.JSpecialInvokeExpr
+
+/**
+ * Filters out patterns that start with `<init>` invokes but do not have a new statement.
+ */
+object IncompleteInitPatternFilter : PatternFilter {
+    override fun retain(pattern: List<Node>): Boolean {
+        if (pattern.isEmpty()) return true
+
+        val firstStatement = pattern[0] as? SootNode ?: return true
+        val unit = firstStatement.unit as? InvokeStmt ?: return true
+
+        return unit.invokeExpr !is JSpecialInvokeExpr || unit.invokeExpr.method.name !== "<init>"
+    }
+}

--- a/subprojects/pattern-filter/src/main/kotlin/IncompleteInitPatternFilter.kt
+++ b/subprojects/pattern-filter/src/main/kotlin/IncompleteInitPatternFilter.kt
@@ -11,8 +11,8 @@ object IncompleteInitPatternFilter : PatternFilter {
         if (pattern.isEmpty()) return true
 
         val firstStatement = pattern[0] as? SootNode ?: return true
-        val unit = firstStatement.unit as? InvokeStmt ?: return true
+        val firstUnit = firstStatement.unit as? InvokeStmt ?: return true
 
-        return unit.invokeExpr !is JSpecialInvokeExpr || unit.invokeExpr.method.name !== "<init>"
+        return firstUnit.invokeExpr !is JSpecialInvokeExpr || firstUnit.invokeExpr.method.name !== "<init>"
     }
 }

--- a/subprojects/pattern-filter/src/test/kotlin/IncompleteInitPatternFilterTest.kt
+++ b/subprojects/pattern-filter/src/test/kotlin/IncompleteInitPatternFilterTest.kt
@@ -1,0 +1,88 @@
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.cafejojo.schaapi.common.Node
+import org.cafejojo.schaapi.usagegraphgenerator.SootNode
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import soot.SootMethod
+import soot.jimple.InvokeExpr
+import soot.jimple.InvokeStmt
+import soot.jimple.ReturnVoidStmt
+import soot.jimple.internal.JSpecialInvokeExpr
+
+internal class IncompleteInitPatternFilterTest : Spek({
+    describe("filtering of init calls without new") {
+        it("rejects patterns starting with init calls") {
+            val initMethod = mock<SootMethod> {
+                on { name } doReturn "<init>"
+            }
+            val invokeExpression = mock<JSpecialInvokeExpr> {
+                on { method } doReturn initMethod
+            }
+
+            val pattern = listOf(
+                mock<InvokeStmt> {
+                    on { invokeExpr } doReturn invokeExpression
+                },
+                mock<ReturnVoidStmt>()
+            ).map { SootNode(it) }
+
+            assertThat(IncompleteInitPatternFilter.retain(pattern)).isFalse()
+        }
+
+        it("retains patterns that do start with a special invoke, but not an init call") {
+            val initMethod = mock<SootMethod> {
+                on { name } doReturn "not-init"
+            }
+            val invokeExpression = mock<JSpecialInvokeExpr> {
+                on { method } doReturn initMethod
+            }
+
+            val pattern = listOf(
+                mock<InvokeStmt> {
+                    on { invokeExpr } doReturn invokeExpression
+                },
+                mock<ReturnVoidStmt>()
+            ).map { SootNode(it) }
+
+            assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
+        }
+
+        it("retains patterns that do start with a regular invoke") {
+            val invokeExpression = mock<InvokeExpr>()
+
+            val pattern = listOf(
+                mock<InvokeStmt> {
+                    on { invokeExpr } doReturn invokeExpression
+                },
+                mock<ReturnVoidStmt>()
+            ).map { SootNode(it) }
+
+            assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
+        }
+
+        it("retains patterns that do not start with an invoke") {
+            val pattern = listOf(
+                mock<ReturnVoidStmt>()
+            ).map { SootNode(it) }
+
+            assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
+        }
+
+        it("retains empty patterns") {
+            val pattern = emptyList<SootNode>()
+
+            assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
+        }
+
+        it("retains lists of non soot nodes") {
+            val pattern = listOf(TestNode())
+
+            assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
+        }
+    }
+})
+
+private class TestNode(override val successors: MutableList<Node> = arrayListOf()) : Node

--- a/subprojects/pattern-filter/src/test/kotlin/IncompleteInitPatternFilterTest.kt
+++ b/subprojects/pattern-filter/src/test/kotlin/IncompleteInitPatternFilterTest.kt
@@ -32,7 +32,7 @@ internal class IncompleteInitPatternFilterTest : Spek({
             assertThat(IncompleteInitPatternFilter.retain(pattern)).isFalse()
         }
 
-        it("retains patterns that do start with a special invoke, but not an init call") {
+        it("retains patterns that start with a special invoke, but not an init call") {
             val initMethod = mock<SootMethod> {
                 on { name } doReturn "not-init"
             }
@@ -50,7 +50,7 @@ internal class IncompleteInitPatternFilterTest : Spek({
             assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
         }
 
-        it("retains patterns that do start with a regular invoke") {
+        it("retains patterns that start with a regular invoke") {
             val invokeExpression = mock<InvokeExpr>()
 
             val pattern = listOf(
@@ -77,7 +77,7 @@ internal class IncompleteInitPatternFilterTest : Spek({
             assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
         }
 
-        it("retains lists of non soot nodes") {
+        it("retains lists of non-Soot nodes") {
             val pattern = listOf(TestNode())
 
             assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()


### PR DESCRIPTION
(the filter itself is complete 😉)

This PR adds a filter to filter out patterns with incomplete initializations of objects.

It also adds a general interface for these kind of filters.