### PR TITLE
More Soot class generator fixes

### DIFF
--- a/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/EvoSuiteRunner.kt
+++ b/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/EvoSuiteRunner.kt
@@ -12,7 +12,7 @@ import java.nio.charset.Charset
  * Executes the EvoSuite test generator on a new process and returns once that process finishes.
  *
  * @property fullyQualifiedClassName the class that EvoSuite should generate tests for
- * @property classPath the class path on which to find the class that should be tested
+ * @property classpath the class path on which to find the class that should be tested
  * @property outputDirectory the output directory path for the generated EvoSuite tests
  * @property generationTimeoutSeconds how long to let the EvoSuite test generator run (in seconds)
  * @property processStandardStream a stream to output EvoSuite's standard messages to
@@ -20,7 +20,7 @@ import java.nio.charset.Charset
  */
 class EvoSuiteRunner(
     private val fullyQualifiedClassName: String,
-    private val classPath: String,
+    private val classpath: String,
     private val outputDirectory: String,
     private val generationTimeoutSeconds: Int = 60,
     private val processStandardStream: PrintStream? = null,
@@ -37,7 +37,7 @@ class EvoSuiteRunner(
         "org.evosuite.EvoSuite",
         "-class", fullyQualifiedClassName,
         "-base_dir", outputDirectory,
-        "-projectCP", classPath,
+        "-projectCP", classpath,
         "-Dsearch_budget=$generationTimeoutSeconds",
         "-Dstatistics_backend=NONE"
     ).start()

--- a/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/SootClassGenerator.kt
+++ b/subprojects/test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/SootClassGenerator.kt
@@ -3,6 +3,7 @@ package org.cafejojo.schaapi.testgenerator
 import soot.Body
 import soot.Local
 import soot.Modifier
+import soot.Scene
 import soot.SootClass
 import soot.SootMethod
 import soot.Type
@@ -25,7 +26,13 @@ import soot.jimple.internal.VariableBox
  * @param className name of [SootClass] to be generated
  */
 class SootClassGenerator(className: String) {
-    val sootClass = SootClass(className, Modifier.PUBLIC)
+    init {
+        Scene.v().loadClassAndSupport("java.lang.Object")
+    }
+
+    val sootClass = SootClass(className, Modifier.PUBLIC).apply {
+        superclass = Scene.v().getSootClass("java.lang.Object")
+    }
 
     /**
      * Generates a non-static soot method for the given [SootClass] with a body written in Jimple IR, and add it to the


### PR DESCRIPTION
The continuation of #47, providing another set of bug fixes found during manual integration tests.

Also, it renames the variable `classPath` to `classpath` in the `EvoSuiteRunner`.