### PR TITLE
Move equals to SootNode class

### DIFF
--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
@@ -21,7 +21,7 @@ class SootNode(val unit: Unit, override val successors: MutableList<Node> = arra
     override fun toString() = unit.toString()
 
     /**
-     * A [SootNode] equals another [SootNode] if the [Unit] is of the same type, and they have the same amount of
+     * A [SootNode] equals another [SootNode] if the [Unit] is of the same type, they have the same amount of
      * values, and each value at their respective positions having the same type.
      *
      * @return true iff [Unit] of same type and values in the same order and of the same type
@@ -46,11 +46,15 @@ class SootNode(val unit: Unit, override val successors: MutableList<Node> = arra
     }
 
     /**
-     * Generates a hashcode based on the values of the contained [Unit].
+     * Generates a hashcode based on the values of the contained [Unit], and their order.
      *
      * @return hashcode based on hashcode of the values contained in the contained [Unit]
      */
-    override fun hashCode(): Int = getValues().sumBy { it.type.hashCode() }
+    override fun hashCode(): Int {
+        var hash = 0
+        getValues().forEachIndexed { index, value -> hash += (index + 1) * value.type.hashCode() }
+        return hash
+    }
 
     /**
      * Extract the values from the contained [Unit] based on its type.

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
@@ -21,10 +21,10 @@ class SootNode(val unit: Unit, override val successors: MutableList<Node> = arra
     override fun toString() = unit.toString()
 
     /**
-     * A [SootNode] equals another [SootNode] if the [Unit] is of the same type, they have the same amount of
+     * A [SootNode] equals another [SootNode] if the [unit] is of the same type, they have the same amount of
      * values, and each value at their respective positions has the same type.
      *
-     * @return true iff the [Unit] is of same type and the values are in the same order and of the same type
+     * @return true iff the [unit] is of same type and the values are in the same order and of the same type
      */
     override fun equals(other: Any?): Boolean {
         if (other !is SootNode || this.unit::class != other.unit::class) return false

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
@@ -1,13 +1,51 @@
 package org.cafejojo.schaapi.usagegraphgenerator
 
 import org.cafejojo.schaapi.common.Node
+import org.cafejojo.schaapi.usagegraphgenerator.compare.isSubclassOf
 import soot.Unit
+import soot.jimple.DefinitionStmt
+import soot.jimple.GotoStmt
+import soot.jimple.IfStmt
+import soot.jimple.InvokeStmt
+import soot.jimple.ReturnStmt
+import soot.jimple.ReturnVoidStmt
+import soot.jimple.SwitchStmt
+import soot.jimple.ThrowStmt
 
 /**
  * Represents a statement node.
  *
  * Contains references to the successor nodes.
  */
-data class SootNode(val unit: Unit, override val successors: MutableList<Node> = arrayListOf()) : Node {
+class SootNode(val unit: Unit, override val successors: MutableList<Node> = arrayListOf()) : Node {
     override fun toString() = unit.toString()
+
+    override fun equals(other: Any?): Boolean {
+        if (other !is SootNode || this.unit::class != other.unit::class) return false
+
+        val thisTypes = this.getValues().map { it.type }
+        val otherTypes = other.getValues().map { it.type }
+
+        otherTypes.forEachIndexed { index, templateType ->
+            val instanceType = thisTypes[index]
+            if (!templateType.isSubclassOf(instanceType) && !instanceType.isSubclassOf(templateType)) return false
+        }
+
+        return true
+    }
+
+    override fun hashCode(): Int = getValues().sumBy { it.hashCode() }
+
+    private fun getValues() =
+        when (unit) {
+            is ThrowStmt -> listOf(unit.op)
+            is DefinitionStmt -> listOf(unit.leftOp, unit.rightOp)
+            is IfStmt -> listOf(unit.condition)
+            is SwitchStmt -> listOf(unit.key)
+            is InvokeStmt -> listOf(unit.invokeExpr)
+            is ReturnStmt -> listOf(unit.op)
+            is GotoStmt -> emptyList()
+            is ReturnVoidStmt -> emptyList()
+            else -> emptyList()
+        }
 }

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
@@ -22,9 +22,9 @@ class SootNode(val unit: Unit, override val successors: MutableList<Node> = arra
 
     /**
      * A [SootNode] equals another [SootNode] if the [Unit] is of the same type, they have the same amount of
-     * values, and each value at their respective positions having the same type.
+     * values, and each value at their respective positions has the same type.
      *
-     * @return true iff [Unit] of same type and values in the same order and of the same type
+     * @return true iff the [Unit] is of same type and the values are in the same order and of the same type
      */
     override fun equals(other: Any?): Boolean {
         if (other !is SootNode || this.unit::class != other.unit::class) return false
@@ -48,7 +48,7 @@ class SootNode(val unit: Unit, override val successors: MutableList<Node> = arra
     /**
      * Generates a hashcode based on the values of the contained [Unit], and their order.
      *
-     * @return hashcode based on hashcode of the values contained in the contained [Unit]
+     * @return hashcode based on the hashcodes of the values contained in the contained [Unit]
      */
     override fun hashCode(): Int {
         var hash = 0

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
@@ -21,6 +21,24 @@ class SootNode(val unit: Unit, override val successors: MutableList<Node> = arra
     override fun toString() = unit.toString()
 
     /**
+     * Extract the values from the contained [Unit] based on its type.
+     *
+     * @return all values of the contained [Unit] based on the type of the [Unit]
+     */
+    fun getValues() =
+        when (unit) {
+            is ThrowStmt -> listOf(unit.op)
+            is DefinitionStmt -> listOf(unit.leftOp, unit.rightOp)
+            is IfStmt -> listOf(unit.condition)
+            is SwitchStmt -> listOf(unit.key)
+            is InvokeStmt -> listOf(unit.invokeExpr)
+            is ReturnStmt -> listOf(unit.op)
+            is GotoStmt -> emptyList()
+            is ReturnVoidStmt -> emptyList()
+            else -> emptyList()
+        }
+
+    /**
      * A [SootNode] equals another [SootNode] if the [unit] is of the same type, they have the same amount of
      * values, and each value at their respective positions has the same type.
      *
@@ -55,22 +73,4 @@ class SootNode(val unit: Unit, override val successors: MutableList<Node> = arra
         getValues().forEachIndexed { index, value -> hash += (index + 1) * value.type.hashCode() }
         return hash
     }
-
-    /**
-     * Extract the values from the contained [Unit] based on its type.
-     *
-     * @return all values of the contained [Unit] based on the type of the [Unit]
-     */
-    fun getValues() =
-        when (unit) {
-            is ThrowStmt -> listOf(unit.op)
-            is DefinitionStmt -> listOf(unit.leftOp, unit.rightOp)
-            is IfStmt -> listOf(unit.condition)
-            is SwitchStmt -> listOf(unit.key)
-            is InvokeStmt -> listOf(unit.invokeExpr)
-            is ReturnStmt -> listOf(unit.op)
-            is GotoStmt -> emptyList()
-            is ReturnVoidStmt -> emptyList()
-            else -> emptyList()
-        }
 }

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNode.kt
@@ -20,6 +20,12 @@ import soot.jimple.ThrowStmt
 class SootNode(val unit: Unit, override val successors: MutableList<Node> = arrayListOf()) : Node {
     override fun toString() = unit.toString()
 
+    /**
+     * A [SootNode] equals another [SootNode] if the [Unit] is of the same type, and they have the same amount of
+     * values, and each value at their respective positions having the same type.
+     *
+     * @return true iff [Unit] of same type and values in the same order and of the same type
+     */
     override fun equals(other: Any?): Boolean {
         if (other !is SootNode || this.unit::class != other.unit::class) return false
 
@@ -28,15 +34,30 @@ class SootNode(val unit: Unit, override val successors: MutableList<Node> = arra
 
         otherTypes.forEachIndexed { index, templateType ->
             val instanceType = thisTypes[index]
-            if (!templateType.isSubclassOf(instanceType) && !instanceType.isSubclassOf(templateType)) return false
+            if (instanceType != templateType &&
+                !templateType.isSubclassOf(instanceType) &&
+                !instanceType.isSubclassOf(templateType)
+            ) {
+                return false
+            }
         }
 
         return true
     }
 
-    override fun hashCode(): Int = getValues().sumBy { it.hashCode() }
+    /**
+     * Generates a hashcode based on the values of the contained [Unit].
+     *
+     * @return hashcode based on hashcode of the values contained in the contained [Unit]
+     */
+    override fun hashCode(): Int = getValues().sumBy { it.type.hashCode() }
 
-    private fun getValues() =
+    /**
+     * Extract the values from the contained [Unit] based on its type.
+     *
+     * @return all values of the contained [Unit] based on the type of the [Unit]
+     */
+    fun getValues() =
         when (unit) {
             is ThrowStmt -> listOf(unit.op)
             is DefinitionStmt -> listOf(unit.leftOp, unit.rightOp)

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/compare/GeneralizedSootComparator.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/compare/GeneralizedSootComparator.kt
@@ -43,22 +43,8 @@ class GeneralizedSootComparator : GeneralizedNodeComparator {
         if (template !is SootNode || instance !is SootNode) {
             throw IllegalArgumentException("GeneralizedSootComparator cannot handle non-SootNodes.")
         }
-        if (template.unit::class != instance.unit::class) {
-            return false
-        }
 
-        val templateTypes = template.getValues().map { it.type }
-        val instanceTypes = instance.getValues().map { it.type }
-
-        templateTypes.forEachIndexed { index, templateType ->
-            val instanceType = instanceTypes[index]
-
-            if (!templateType.isSubclassOf(instanceType) && !instanceType.isSubclassOf(templateType)) {
-                return false
-            }
-        }
-
-        return true
+        return template == instance
     }
 
     /**

--- a/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/compare/GeneralizedSootComparator.kt
+++ b/subprojects/usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/usagegraphgenerator/compare/GeneralizedSootComparator.kt
@@ -6,14 +6,6 @@ import soot.Scene
 import soot.Type
 import soot.Unit
 import soot.Value
-import soot.jimple.DefinitionStmt
-import soot.jimple.GotoStmt
-import soot.jimple.IfStmt
-import soot.jimple.InvokeStmt
-import soot.jimple.ReturnStmt
-import soot.jimple.ReturnVoidStmt
-import soot.jimple.SwitchStmt
-import soot.jimple.ThrowStmt
 
 /**
  * Comparator of [Unit]s by structure and generalized values.
@@ -55,8 +47,8 @@ class GeneralizedSootComparator : GeneralizedNodeComparator {
             return false
         }
 
-        val templateTypes = getValues(template.unit).map { it.type }
-        val instanceTypes = getValues(instance.unit).map { it.type }
+        val templateTypes = template.getValues().map { it.type }
+        val instanceTypes = instance.getValues().map { it.type }
 
         templateTypes.forEachIndexed { index, templateType ->
             val instanceType = instanceTypes[index]
@@ -87,8 +79,8 @@ class GeneralizedSootComparator : GeneralizedNodeComparator {
             throw IllegalArgumentException("GeneralizedSootComparator cannot handle non-SootNodes.")
         }
 
-        val templateValues = getValues(template.unit)
-        val instanceValues = getValues(instance.unit)
+        val templateValues = template.getValues()
+        val instanceValues = instance.getValues()
 
         templateValues.forEachIndexed { index, templateValue ->
             val instanceValue = instanceValues[index]
@@ -118,25 +110,6 @@ class GeneralizedSootComparator : GeneralizedNodeComparator {
 
         return true
     }
-
-    /**
-     * Returns a list of the [Value]s contained in [Unit] as fields.
-     *
-     * @param unit a [Unit]
-     * @return a list of the [Value]s contained in [Unit] as fields
-     */
-    private fun getValues(unit: Unit) =
-        when (unit) {
-            is ThrowStmt -> listOf(unit.op)
-            is DefinitionStmt -> listOf(unit.leftOp, unit.rightOp)
-            is IfStmt -> listOf(unit.condition)
-            is SwitchStmt -> listOf(unit.key)
-            is InvokeStmt -> listOf(unit.invokeExpr)
-            is ReturnStmt -> listOf(unit.op)
-            is GotoStmt -> emptyList()
-            is ReturnVoidStmt -> emptyList()
-            else -> emptyList()
-        }
 
     private fun createNewTag() = tagOrigins.size
 

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNodeTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNodeTest.kt
@@ -11,7 +11,7 @@ import soot.Value
 import soot.jimple.DefinitionStmt
 
 internal class SootNodeTest : Spek({
-    describe("when checking whether two sootnodes are equal") {
+    describe("when checking whether two Soot nodes are equal") {
         fun mockDefinitionStmt(leftType: Type, rightType: Type): SootNode {
             val leftOp = mock<Value> { on { it.type } doReturn leftType }
             val rightOp = mock<Value> { on { it.type } doReturn rightType }

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNodeTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNodeTest.kt
@@ -1,104 +1,75 @@
 package org.cafejojo.schaapi.usagegraphgenerator
 
+import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import soot.Type
-import soot.jimple.IntConstant
-import soot.jimple.Jimple
-import soot.jimple.StringConstant
+import soot.Value
+import soot.jimple.DefinitionStmt
 
 internal class SootNodeTest : Spek({
     describe("when checking whether two sootnodes are equal") {
+        fun mockDefinitionStmt(leftType: Type, rightType: Type): SootNode {
+            val leftOp = mock<Value> { on { it.type } doReturn leftType }
+            val rightOp = mock<Value> { on { it.type } doReturn rightType }
+
+            return SootNode(mock<DefinitionStmt> {
+                on { it.leftOp } doReturn leftOp
+                on { it.rightOp } doReturn rightOp
+            })
+        }
+
         it("should be equal if the values are in the same order and of the same type") {
-            val type = mock<Type> {}
-            val local1 = Jimple.v().newLocal("local1", type)
-            val local2 = Jimple.v().newLocal("local2", type)
+            val type1 = mock<Type> {}
+            val type2 = mock<Type> {}
 
-            val node1 = SootNode(
-                Jimple.v().newAssignStmt(
-                    local1,
-                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
-                )
-            )
-
-            val node2 = SootNode(
-                Jimple.v().newAssignStmt(
-                    local2,
-                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
-                )
-            )
+            val node1 = mockDefinitionStmt(type1, type2)
+            val node2 = mockDefinitionStmt(type1, type2)
 
             assertThat(node1).isEqualTo(node2)
         }
 
         it("should have the same hashcode if they are equal") {
-            val type = mock<Type> {}
-            val local1 = Jimple.v().newLocal("local1", type)
-            val local2 = Jimple.v().newLocal("local2", type)
+            val type1 = mock<Type> {}
+            val type2 = mock<Type> {}
 
-            val node1 = SootNode(
-                Jimple.v().newAssignStmt(
-                    local1,
-                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
-                )
-            )
-
-            val node2 = SootNode(
-                Jimple.v().newAssignStmt(
-                    local2,
-                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
-                )
-            )
+            val node1 = mockDefinitionStmt(type1, type2)
+            val node2 = mockDefinitionStmt(type1, type2)
 
             assertThat(node1.hashCode()).isEqualTo(node2.hashCode())
         }
 
         it("should not be equal if the values are not the same type") {
-            val type = mock<Type> {}
-            val local1 = Jimple.v().newLocal("local1", type)
-            val local2 = Jimple.v().newLocal("local2", type)
+            val type1 = mock<Type> {}
+            val type2 = mock<Type> {}
+            val type3 = mock<Type> {}
 
-            val node1 = SootNode(
-                Jimple.v().newAssignStmt(
-                    local1,
-                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
-                )
-            )
-
-            val node2 = SootNode(
-                Jimple.v().newAssignStmt(
-                    local2,
-                    Jimple.v().newAddExpr(IntConstant.v(10), StringConstant.v("asdf"))
-                )
-            )
+            val node1 = mockDefinitionStmt(type1, type2)
+            val node2 = mockDefinitionStmt(type1, type3)
 
             assertThat(node1).isNotEqualTo(node2)
-            assertThat(node1.hashCode()).isNotEqualTo(node2.hashCode())
         }
 
         it("should not have the same hashcode if they are not equal") {
-            val type = mock<Type> {}
-            val local1 = Jimple.v().newLocal("local1", type)
-            val local2 = Jimple.v().newLocal("local2", type)
+            val type1 = mock<Type> {}
+            val type2 = mock<Type> {}
+            val type3 = mock<Type> {}
 
-            val node1 = SootNode(
-                Jimple.v().newAssignStmt(
-                    local1,
-                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
-                )
-            )
+            val node1 = mockDefinitionStmt(type1, type2)
+            val node2 = mockDefinitionStmt(type1, type3)
 
-            val node2 = SootNode(
-                Jimple.v().newAssignStmt(
-                    local2,
-                    Jimple.v().newAddExpr(
-                        IntConstant.v(10), StringConstant.v("asdf")
-                    )
-                )
-            )
+            assertThat(node1.hashCode()).isNotEqualTo(node2.hashCode())
+        }
+
+        it("should not have the same hashcode if they have the same value types but in a different order") {
+            val type1 = mock<Type> {}
+            val type2 = mock<Type> {}
+
+            val node1 = mockDefinitionStmt(type1, type2)
+            val node2 = mockDefinitionStmt(type2, type1)
 
             assertThat(node1.hashCode()).isNotEqualTo(node2.hashCode())
         }

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNodeTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/SootNodeTest.kt
@@ -1,0 +1,106 @@
+package org.cafejojo.schaapi.usagegraphgenerator
+
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import soot.Type
+import soot.jimple.IntConstant
+import soot.jimple.Jimple
+import soot.jimple.StringConstant
+
+internal class SootNodeTest : Spek({
+    describe("when checking whether two sootnodes are equal") {
+        it("should be equal if the values are in the same order and of the same type") {
+            val type = mock<Type> {}
+            val local1 = Jimple.v().newLocal("local1", type)
+            val local2 = Jimple.v().newLocal("local2", type)
+
+            val node1 = SootNode(
+                Jimple.v().newAssignStmt(
+                    local1,
+                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
+                )
+            )
+
+            val node2 = SootNode(
+                Jimple.v().newAssignStmt(
+                    local2,
+                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
+                )
+            )
+
+            assertThat(node1).isEqualTo(node2)
+        }
+
+        it("should have the same hashcode if they are equal") {
+            val type = mock<Type> {}
+            val local1 = Jimple.v().newLocal("local1", type)
+            val local2 = Jimple.v().newLocal("local2", type)
+
+            val node1 = SootNode(
+                Jimple.v().newAssignStmt(
+                    local1,
+                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
+                )
+            )
+
+            val node2 = SootNode(
+                Jimple.v().newAssignStmt(
+                    local2,
+                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
+                )
+            )
+
+            assertThat(node1.hashCode()).isEqualTo(node2.hashCode())
+        }
+
+        it("should not be equal if the values are not the same type") {
+            val type = mock<Type> {}
+            val local1 = Jimple.v().newLocal("local1", type)
+            val local2 = Jimple.v().newLocal("local2", type)
+
+            val node1 = SootNode(
+                Jimple.v().newAssignStmt(
+                    local1,
+                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
+                )
+            )
+
+            val node2 = SootNode(
+                Jimple.v().newAssignStmt(
+                    local2,
+                    Jimple.v().newAddExpr(IntConstant.v(10), StringConstant.v("asdf"))
+                )
+            )
+
+            assertThat(node1).isNotEqualTo(node2)
+            assertThat(node1.hashCode()).isNotEqualTo(node2.hashCode())
+        }
+
+        it("should not have the same hashcode if they are not equal") {
+            val type = mock<Type> {}
+            val local1 = Jimple.v().newLocal("local1", type)
+            val local2 = Jimple.v().newLocal("local2", type)
+
+            val node1 = SootNode(
+                Jimple.v().newAssignStmt(
+                    local1,
+                    Jimple.v().newAddExpr(IntConstant.v(10), IntConstant.v(20))
+                )
+            )
+
+            val node2 = SootNode(
+                Jimple.v().newAssignStmt(
+                    local2,
+                    Jimple.v().newAddExpr(
+                        IntConstant.v(10), StringConstant.v("asdf")
+                    )
+                )
+            )
+
+            assertThat(node1.hashCode()).isNotEqualTo(node2.hashCode())
+        }
+    }
+})

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/compare/GeneralizedSootComparatorStructureTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/compare/GeneralizedSootComparatorStructureTest.kt
@@ -124,13 +124,13 @@ internal class GeneralizedSootComparatorStructureTest : Spek({
             assertThat(comparator.satisfies(template, instance)).isFalse()
         }
 
-        it("finds inequality on dinges") {
+        it("finds inequality on statements with types that are not subclasses of each other") {
             @SuppressWarnings("EqualsWithHashCodeExist")
             class NullType : Type() {
                 override fun toString() = "null"
 
                 @SuppressWarnings("EqualsAlwaysReturnsTrueOrFalse")
-                override fun equals(other: Any?) = true
+                override fun equals(other: Any?) = false
             }
 
             val templateValue = mock<Value> {


### PR DESCRIPTION
Add `equals` and `hashcode` methods to `SootNode`, which means better encapsulation.

Two `SootNodes` are considered equal iff:
* Their respective `Unit` classes are the same
* The values of the operation are the same, meaning
    * The amount of values are identical
    * The types of the values are identical at their respective positions

Hashcodes are generated using the sum of the hashcodes of the respective types, times the index.

During the writing of this I discovered that there is a possible bug in the current implementation of the equals. Namely, the `getValues` does not recursively traverse statements, meaning that nested statements are taken as-is and not decomposed. I'm not sure if this is intended behaviour but I thought that I'd mention it.