### PR TITLE
Add length pattern filter

### DIFF
--- a/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
+++ b/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
@@ -9,6 +9,7 @@ import org.apache.commons.cli.ParseException
 import org.cafejojo.schaapi.patterndetector.PathEnumerator
 import org.cafejojo.schaapi.patterndetector.PatternDetector
 import org.cafejojo.schaapi.patternfilter.IncompleteInitPatternFilter
+import org.cafejojo.schaapi.patternfilter.LengthPatternFilter
 import org.cafejojo.schaapi.projectcompiler.JavaMavenProject
 import org.cafejojo.schaapi.projectcompiler.MavenInstaller
 import org.cafejojo.schaapi.testgenerator.EvoSuiteRunner
@@ -51,7 +52,8 @@ fun main(args: Array<String>) {
         userPaths,
         cmd.getOptionOrDefault("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
     ).findFrequentSequences()
-        .filter { IncompleteInitPatternFilter.retain(it) }
+        .filter { IncompleteInitPatternFilter().retain(it) }
+        .filter { LengthPatternFilter().retain(it) }
 
     val classGenerator = SootClassGenerator(DEFAULT_PATTERN_CLASS_NAME)
     patterns.forEachIndexed { index, pattern ->

--- a/subprojects/pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/IncompleteInitPatternFilter.kt
+++ b/subprojects/pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/IncompleteInitPatternFilter.kt
@@ -9,7 +9,7 @@ import soot.jimple.internal.JSpecialInvokeExpr
 /**
  * Filters out patterns that start with `<init>` invokes but do not have a new statement.
  */
-object IncompleteInitPatternFilter : PatternFilter {
+class IncompleteInitPatternFilter : PatternFilter {
     override fun retain(pattern: List<Node>): Boolean {
         if (pattern.isEmpty()) return true
 

--- a/subprojects/pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilter.kt
+++ b/subprojects/pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilter.kt
@@ -8,9 +8,19 @@ private const val DEFAULT_MINIMUM_PATTERN_LENGTH = 2
 /**
  * Filters out patterns that are too short.
  *
- * @property minimumLength the minimum length a pattern should have for it to be retained.
+ * @property minimumLength the minimum length (inclusive) a pattern should have for it to be retained.
  * [DEFAULT_MINIMUM_PATTERN_LENGTH] by default
  */
 class LengthPatternFilter(private val minimumLength: Int = DEFAULT_MINIMUM_PATTERN_LENGTH) : PatternFilter {
+    init {
+        if (minimumLength < 1) throw TooSmallMinimumPatternLengthException(minimumLength)
+    }
+
     override fun retain(pattern: List<Node>): Boolean = pattern.size >= minimumLength
 }
+
+/**
+ * A [RuntimeException] occurring when the passed minimum length is less than 1.
+ */
+class TooSmallMinimumPatternLengthException(length: Int) :
+    RuntimeException("A minimum pattern length must be 1 or greater, was $length.")

--- a/subprojects/pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilter.kt
+++ b/subprojects/pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilter.kt
@@ -1,0 +1,16 @@
+package org.cafejojo.schaapi.patternfilter
+
+import org.cafejojo.schaapi.common.Node
+import org.cafejojo.schaapi.common.PatternFilter
+
+private const val DEFAULT_MINIMUM_PATTERN_LENGTH = 2
+
+/**
+ * Filters out patterns that start with `<init>` invokes but do not have a new statement.
+ *
+ * @property minimumLength the minimum length a pattern should have for it to be retained.
+ * [DEFAULT_MINIMUM_PATTERN_LENGTH] by default.
+ */
+class LengthPatternFilter(private val minimumLength: Int = DEFAULT_MINIMUM_PATTERN_LENGTH) : PatternFilter {
+    override fun retain(pattern: List<Node>): Boolean = pattern.size >= minimumLength
+}

--- a/subprojects/pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilter.kt
+++ b/subprojects/pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilter.kt
@@ -8,19 +8,13 @@ private const val DEFAULT_MINIMUM_PATTERN_LENGTH = 2
 /**
  * Filters out patterns that are too short.
  *
- * @property minimumLength the minimum length (inclusive) a pattern should have for it to be retained.
- * [DEFAULT_MINIMUM_PATTERN_LENGTH] by default
+ * @property minimumLength the minimum length (inclusive) a pattern should have for it to be retained, which must at
+ * least be 1. [DEFAULT_MINIMUM_PATTERN_LENGTH] by default
  */
 class LengthPatternFilter(private val minimumLength: Int = DEFAULT_MINIMUM_PATTERN_LENGTH) : PatternFilter {
     init {
-        if (minimumLength < 1) throw TooSmallMinimumPatternLengthException(minimumLength)
+        require(minimumLength > 0) { "The minimum pattern length must be 1 or greater, was $minimumLength." }
     }
 
     override fun retain(pattern: List<Node>): Boolean = pattern.size >= minimumLength
 }
-
-/**
- * A [RuntimeException] occurring when the passed minimum length is less than 1.
- */
-class TooSmallMinimumPatternLengthException(length: Int) :
-    RuntimeException("A minimum pattern length must be 1 or greater, was $length.")

--- a/subprojects/pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilter.kt
+++ b/subprojects/pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilter.kt
@@ -6,10 +6,10 @@ import org.cafejojo.schaapi.common.PatternFilter
 private const val DEFAULT_MINIMUM_PATTERN_LENGTH = 2
 
 /**
- * Filters out patterns that start with `<init>` invokes but do not have a new statement.
+ * Filters out patterns that are too short.
  *
  * @property minimumLength the minimum length a pattern should have for it to be retained.
- * [DEFAULT_MINIMUM_PATTERN_LENGTH] by default.
+ * [DEFAULT_MINIMUM_PATTERN_LENGTH] by default
  */
 class LengthPatternFilter(private val minimumLength: Int = DEFAULT_MINIMUM_PATTERN_LENGTH) : PatternFilter {
     override fun retain(pattern: List<Node>): Boolean = pattern.size >= minimumLength

--- a/subprojects/pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/IncompleteInitPatternFilterTest.kt
+++ b/subprojects/pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/IncompleteInitPatternFilterTest.kt
@@ -3,7 +3,6 @@ package org.cafejojo.schaapi.patternfilter
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
-import org.cafejojo.schaapi.common.Node
 import org.cafejojo.schaapi.usagegraphgenerator.SootNode
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
@@ -31,7 +30,7 @@ internal class IncompleteInitPatternFilterTest : Spek({
                 mock<ReturnVoidStmt>()
             ).map { SootNode(it) }
 
-            assertThat(IncompleteInitPatternFilter.retain(pattern)).isFalse()
+            assertThat(IncompleteInitPatternFilter().retain(pattern)).isFalse()
         }
 
         it("retains patterns that start with a special invoke, but not an init call") {
@@ -49,7 +48,7 @@ internal class IncompleteInitPatternFilterTest : Spek({
                 mock<ReturnVoidStmt>()
             ).map { SootNode(it) }
 
-            assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
+            assertThat(IncompleteInitPatternFilter().retain(pattern)).isTrue()
         }
 
         it("retains patterns that start with a regular invoke") {
@@ -62,7 +61,7 @@ internal class IncompleteInitPatternFilterTest : Spek({
                 mock<ReturnVoidStmt>()
             ).map { SootNode(it) }
 
-            assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
+            assertThat(IncompleteInitPatternFilter().retain(pattern)).isTrue()
         }
 
         it("retains patterns that do not start with an invoke") {
@@ -70,21 +69,19 @@ internal class IncompleteInitPatternFilterTest : Spek({
                 mock<ReturnVoidStmt>()
             ).map { SootNode(it) }
 
-            assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
+            assertThat(IncompleteInitPatternFilter().retain(pattern)).isTrue()
         }
 
         it("retains empty patterns") {
             val pattern = emptyList<SootNode>()
 
-            assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
+            assertThat(IncompleteInitPatternFilter().retain(pattern)).isTrue()
         }
 
         it("retains lists of non-Soot nodes") {
             val pattern = listOf(TestNode())
 
-            assertThat(IncompleteInitPatternFilter.retain(pattern)).isTrue()
+            assertThat(IncompleteInitPatternFilter().retain(pattern)).isTrue()
         }
     }
 })
-
-private class TestNode(override val successors: MutableList<Node> = arrayListOf()) : Node

--- a/subprojects/pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilterTest.kt
+++ b/subprojects/pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilterTest.kt
@@ -1,0 +1,22 @@
+package org.cafejojo.schaapi.patternfilter
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+
+class LengthPatternFilterTest : Spek({
+    describe("when filtering a pattern") {
+        it("should give true for a pattern equal to the default length") {
+            assertThat(LengthPatternFilter().retain(listOf(TestNode(), TestNode()))).isTrue()
+        }
+
+        it("should give false for a pattern shorter than the default length") {
+            assertThat(LengthPatternFilter().retain(listOf(TestNode()))).isFalse()
+        }
+
+        it("should give true for a pattern longer than the passed length") {
+            assertThat(LengthPatternFilter(1).retain(listOf(TestNode(), TestNode()))).isTrue()
+        }
+    }
+})

--- a/subprojects/pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilterTest.kt
+++ b/subprojects/pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilterTest.kt
@@ -1,22 +1,32 @@
 package org.cafejojo.schaapi.patternfilter
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
 class LengthPatternFilterTest : Spek({
     describe("when filtering a pattern") {
-        it("should give true for a pattern equal to the default length") {
+        it("should return true for a pattern equal to the default length") {
             assertThat(LengthPatternFilter().retain(listOf(TestNode(), TestNode()))).isTrue()
         }
 
-        it("should give false for a pattern shorter than the default length") {
+        it("should return false for a pattern shorter than the default length") {
             assertThat(LengthPatternFilter().retain(listOf(TestNode()))).isFalse()
         }
 
-        it("should give true for a pattern longer than the passed length") {
+        it("should return false for a pattern shorter than the default length") {
+            assertThat(LengthPatternFilter().retain(listOf(TestNode()))).isFalse()
+        }
+
+        it("should return true for a pattern longer than the passed length") {
             assertThat(LengthPatternFilter(1).retain(listOf(TestNode(), TestNode()))).isTrue()
+        }
+
+        it("should give an exception if the given pattern length is 0") {
+            assertThatThrownBy { LengthPatternFilter(0) }
+                .isInstanceOf(TooSmallMinimumPatternLengthException::class.java)
         }
     }
 })

--- a/subprojects/pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilterTest.kt
+++ b/subprojects/pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/LengthPatternFilterTest.kt
@@ -26,7 +26,7 @@ class LengthPatternFilterTest : Spek({
 
         it("should give an exception if the given pattern length is 0") {
             assertThatThrownBy { LengthPatternFilter(0) }
-                .isInstanceOf(TooSmallMinimumPatternLengthException::class.java)
+                .isInstanceOf(IllegalArgumentException::class.java)
         }
     }
 })

--- a/subprojects/pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/TestNode.kt
+++ b/subprojects/pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/TestNode.kt
@@ -1,0 +1,8 @@
+package org.cafejojo.schaapi.patternfilter
+
+import org.cafejojo.schaapi.common.Node
+
+/**
+ * A subclass of [Node] for testing purposes.
+ */
+internal class TestNode(override val successors: MutableList<Node> = mutableListOf()) : Node


### PR DESCRIPTION
Add a pattern filter which retains only patterns that have a certain minimum length. By default, a pattern should have at least length 2.

Also changes the `IncompletePatternFilter` to a `class` instead of an `object`. This was done for the following reasons:
* Singletons in general are ugly
* Some filters might have paramters, such as the new `LengthPatternFilter`, and as such for consistency they should ideally all be classes
* It more closely coincides with the project structure. Comparators are also `classes`