### PR TITLE
Add .editorconfig and fix code style violations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/subprojects/project-compiler/src/test/resources/Project/dependencies-classes/src/main/java/org/cafejojo/schaapi/test/MyClass.java
+++ b/subprojects/project-compiler/src/test/resources/Project/dependencies-classes/src/main/java/org/cafejojo/schaapi/test/MyClass.java
@@ -13,7 +13,7 @@ public class MyClass {
         String myString = "asdfasdfasdf";
         String yourString = myString.substring(constant);
         String ourString = myString.substring(1).substring(3)
-                + yourString;
+            + yourString;
         return ourString;
     }
 }

--- a/subprojects/test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/EvoSuiteRunnerTest.kt
+++ b/subprojects/test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/EvoSuiteRunnerTest.kt
@@ -28,24 +28,24 @@ internal class EvoSuiteRunnerTest : Spek({
     describe("execution of the EvoSuite test generator") {
         it("generates tests for a test class") {
             val evoSuiteRunner = EvoSuiteRunner(
-                    "org.cafejojo.schaapi.test.EvoSuiteTestClass",
-                    classPath,
-                    classPath,
-                    generationTimeoutSeconds = 5
+                "org.cafejojo.schaapi.test.EvoSuiteTestClass",
+                classPath,
+                classPath,
+                generationTimeoutSeconds = 5
             )
 
             evoSuiteRunner.run()
 
             assertThat(File("${evoSuiteTestOutput.path}/org/cafejojo/schaapi/test/EvoSuiteTestClass_ESTest.java"))
-                    .exists()
+                .exists()
         }
 
         it("throws an exception when the class can't be found on the given class path") {
             val evoSuiteRunner = EvoSuiteRunner(
-                    "org.cafejojo.schaapi.test.EvoSuiteTestClass",
-                    ".",
-                    classPath,
-                    generationTimeoutSeconds = 5
+                "org.cafejojo.schaapi.test.EvoSuiteTestClass",
+                ".",
+                classPath,
+                generationTimeoutSeconds = 5
             )
 
             assertThatThrownBy {
@@ -55,10 +55,10 @@ internal class EvoSuiteRunnerTest : Spek({
 
         it("throws an exception when the class doesn't exist") {
             val evoSuiteRunner = EvoSuiteRunner(
-                    "no.way.this.exists.SampleClass",
-                    classPath,
-                    classPath,
-                    generationTimeoutSeconds = 5
+                "no.way.this.exists.SampleClass",
+                classPath,
+                classPath,
+                generationTimeoutSeconds = 5
             )
 
             assertThatThrownBy {

--- a/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/DotGraphRendererTest.kt
+++ b/subprojects/usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/usagegraphgenerator/DotGraphRendererTest.kt
@@ -63,5 +63,6 @@ private class TestNode(override val successors: MutableList<Node> = mutableListO
         id != other.id -> false
         else -> true
     }
+
     override fun toString() = "node-number-$id"
 }


### PR DESCRIPTION
Adds an `.editorconfig` file (a cross-editor config for basic code style configurations) and fixes a number of small left-over code style violations that somehow slipped through.