### PR TITLE
Reduce zt-zip output by avoiding calls to it

### DIFF
--- a/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
+++ b/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
@@ -37,7 +37,9 @@ fun main(args: Array<String>) {
     val library = JavaMavenProject(File(cmd.getOptionValue('l')), mavenDir)
     val users = cmd.getOptionValues('u').map { JavaMavenProject(File(it), mavenDir) }
 
-    MavenInstaller().installMaven(mavenDir)
+    if (!mavenDir.resolve("bin/mvn").exists() || cmd.hasOption("repair_maven")) {
+        MavenInstaller().installMaven(mavenDir)
+    }
 
     library.compile()
     users.forEach { it.compile() }
@@ -97,8 +99,13 @@ private fun buildOptions(): Options =
         .addOption(Option
             .builder()
             .longOpt("maven_dir")
-            .desc("The directory to install Maven in.")
+            .desc("The directory to run Maven from.")
             .hasArg()
+            .build())
+        .addOption(Option
+            .builder()
+            .longOpt("repair_maven")
+            .desc("Repairs the Maven installation.")
             .build())
         .addOption(Option
             .builder()


### PR DESCRIPTION
I tried to suppress all (debug) output by [zt-zip](https://github.com/zeroturnaround/zt-zip), but was unable to do that. I tried the following solutions:

* Run with `-Dorg.slf4j.simpleLogger.defaultLogLevel=error`. The messages still appeared.
* Call `System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "error");`. The messages still appeared.
* Set `systemProp.org.slf4j.simpleLogger.defaultLogLevel = error` in `gradle.properties`. The messages still appeared.
* Exclude the `slf4j-simple` dependency added by Soot. The zt-zip messages no longer appeared, but EvoSuite could no longer output messages, so we could not find out whether it had exited successfully.
* Add a dependency to `slf4j-nop`. Again, the zt-zip messages no longer appeared, but EvoSuite could no longer output messages.
* Remove all code. For some reason, all the tests failed when I did this.

Therefore, I decided to take another route: Simply avoid calling zt-zip each time the program is run, and instead call it only when necessary.
