### PR TITLE
Add interface for test generation and move test generation logic away from Schaapi class

### DIFF
--- a/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/Pattern.kt
+++ b/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/Pattern.kt
@@ -1,0 +1,3 @@
+package org.cafejojo.schaapi.common
+
+typealias Pattern = List<Node>

--- a/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/TestGenerator.kt
+++ b/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/TestGenerator.kt
@@ -1,0 +1,16 @@
+package org.cafejojo.schaapi.common
+
+import java.io.OutputStream
+
+/**
+ * Represents the test generator that generates tests based on patterns.
+ */
+interface TestGenerator {
+    /**
+     * Generates tests based on patterns.
+     *
+     * @param patterns a list of patterns
+     * @return a test file containing all generated tests
+     */
+    fun generate(patterns: List<Pattern>): OutputStream
+}

--- a/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
@@ -1,0 +1,80 @@
+package org.cafejojo.schaapi.testgenerator.jimpleevosuite
+
+import java.io.BufferedReader
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.PrintStream
+import java.nio.charset.Charset
+
+/**
+ * EvoSuite launcher.
+ *
+ * Executes the EvoSuite test generator on a new process and returns once that process finishes.
+ *
+ * @property fullyQualifiedClassName the class that EvoSuite should generate tests for
+ * @property classpath the class path on which to find the class that should be tested
+ * @property outputDirectory the output directory path for the generated EvoSuite tests
+ * @property generationTimeoutSeconds how long to let the EvoSuite test generator run (in seconds)
+ * @property processStandardStream a stream to output EvoSuite's standard messages to
+ * @property processErrorStream a stream to output EvoSuite's error messages to
+ */
+class EvoSuiteTestGenerator(
+    private val fullyQualifiedClassName: String,
+    private val classpath: String,
+    private val outputDirectory: String,
+    private val generationTimeoutSeconds: Int = 60,
+    private val processStandardStream: PrintStream? = null,
+    private val processErrorStream: PrintStream? = null
+) {
+    /**
+     * Runs the EvoSuite test generator in a new process.
+     */
+    fun run() = receiveProcessOutput(buildProcess())
+
+    private fun buildProcess() = ProcessBuilder(
+        "java",
+        "-cp", System.getProperty("java.class.path"),
+        "org.evosuite.EvoSuite",
+        "-class", fullyQualifiedClassName,
+        "-base_dir", outputDirectory,
+        "-projectCP", classpath,
+        "-Dsearch_budget=$generationTimeoutSeconds",
+        "-Dstatistics_backend=NONE"
+    ).start()
+
+    private fun receiveProcessOutput(process: Process) {
+        val lastLine = pipeAllLines(process.inputStream, processStandardStream)
+        pipeAllLines(process.errorStream, processErrorStream)
+
+        process.waitFor()
+
+        if (!lastLine.toLowerCase().contains("computation finished")) {
+            throw EvoSuiteRuntimeException(
+                "EvoSuite did not terminate successfully. The last line of its output reads: \"$lastLine\""
+            )
+        }
+
+        if (process.exitValue() != 0) {
+            val errorOutput = String(process.errorStream.readBytes(), Charset.defaultCharset())
+            throw EvoSuiteRuntimeException(
+                "EvoSuite exited with non-zero exit code: ${process.exitValue()}\n$errorOutput"
+            )
+        }
+    }
+
+    private fun pipeAllLines(input: InputStream, output: PrintStream?): String {
+        var lastLine = ""
+
+        BufferedReader(InputStreamReader(input)).forEachLine {
+            output?.println(it)
+            lastLine = it
+        }
+
+        return lastLine
+    }
+}
+
+/**
+ * A [RuntimeException] occurring during the execution of the EvoSuite test generation tool.
+ */
+class EvoSuiteRuntimeException(message: String? = null) : RuntimeException(message)

--- a/modules/pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/jimpleevosuite/TestGeneratorTest.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/jimpleevosuite/TestGeneratorTest.kt
@@ -27,7 +27,7 @@ internal class TestGeneratorTest : Spek({
 
     describe("execution of the EvoSuite test generator") {
         it("generates tests for a test class") {
-            val evoSuiteRunner = TestGenerator(
+            val evoSuiteRunner = EvoSuiteTestGenerator(
                 "org.cafejojo.schaapi.test.EvoSuiteTestClass",
                 classPath,
                 classPath,
@@ -41,7 +41,7 @@ internal class TestGeneratorTest : Spek({
         }
 
         it("throws an exception when the class can't be found on the given class path") {
-            val evoSuiteRunner = TestGenerator(
+            val evoSuiteRunner = EvoSuiteTestGenerator(
                 "org.cafejojo.schaapi.test.EvoSuiteTestClass",
                 ".",
                 classPath,
@@ -54,7 +54,7 @@ internal class TestGeneratorTest : Spek({
         }
 
         it("throws an exception when the class doesn't exist") {
-            val evoSuiteRunner = TestGenerator(
+            val evoSuiteRunner = EvoSuiteTestGenerator(
                 "no.way.this.exists.SampleClass",
                 classPath,
                 classPath,


### PR DESCRIPTION
This PR adds a `TestGenerator` interface and moves the logic for writing testables and generating evosuite tests to its own class within the test generation module.

See Mattermost for reasoning behind not splitting testable writing and test generation in two modules.