### PR TITLE
Restructure pattern filters

### DIFF
--- a/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/PatternFilter.kt
+++ b/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/PatternFilter.kt
@@ -1,14 +1,16 @@
 package org.cafejojo.schaapi.common
 
 /**
- * Represents a filter for generated patterns.
+ * Represents a pattern filter.
+ *
+ * @property rules rules that indicated whether a pattern should be retained or not
  */
-interface PatternFilter {
+class PatternFilter(private vararg val rules: PatternFilterRule ) {
     /**
-     * Determines if [pattern] should be retained.
+     * Performs filtering of patterns based on the gives list of filtering rules.
      *
-     * @param pattern a generated pattern
-     * @return true if the pattern should be retained
+     * @param patterns list of patterns to be filtered
+     * @return list of filtered patterns
      */
-    fun retain(pattern: List<Node>): Boolean
+    fun filter(patterns: List<Pattern>) = patterns.filter { pattern -> rules.map { it.retain(pattern) }.all { it } }
 }

--- a/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/PatternFilter.kt
+++ b/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/PatternFilter.kt
@@ -7,7 +7,7 @@ package org.cafejojo.schaapi.common
  */
 class PatternFilter(private vararg val rules: PatternFilterRule) {
     /**
-     * Performs filtering of patterns based on the gives list of filtering rules.
+     * Performs filtering of patterns based on the given list of filtering rules.
      *
      * @param patterns list of patterns to be filtered
      * @return list of filtered patterns

--- a/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/PatternFilter.kt
+++ b/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/PatternFilter.kt
@@ -3,7 +3,7 @@ package org.cafejojo.schaapi.common
 /**
  * Represents a pattern filter.
  *
- * @property rules rules that indicated whether a pattern should be retained or not
+ * @property rules rules that indicate whether a pattern should be retained or not
  */
 class PatternFilter(private vararg val rules: PatternFilterRule) {
     /**

--- a/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/PatternFilter.kt
+++ b/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/PatternFilter.kt
@@ -5,12 +5,12 @@ package org.cafejojo.schaapi.common
  *
  * @property rules rules that indicated whether a pattern should be retained or not
  */
-class PatternFilter(private vararg val rules: PatternFilterRule ) {
+class PatternFilter(private vararg val rules: PatternFilterRule) {
     /**
      * Performs filtering of patterns based on the gives list of filtering rules.
      *
      * @param patterns list of patterns to be filtered
      * @return list of filtered patterns
      */
-    fun filter(patterns: List<Pattern>) = patterns.filter { pattern -> rules.map { it.retain(pattern) }.all { it } }
+    fun filter(patterns: List<Pattern>) = patterns.filter { pattern -> rules.all { rule -> rule.retain(pattern) } }
 }

--- a/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/PatternFilterRule.kt
+++ b/modules/common/src/main/kotlin/org/cafejojo/schaapi/common/PatternFilterRule.kt
@@ -1,0 +1,14 @@
+package org.cafejojo.schaapi.common
+
+/**
+ * Represents a filter for generated patterns.
+ */
+interface PatternFilterRule {
+    /**
+     * Determines if [pattern] should be retained.
+     *
+     * @param pattern a generated pattern
+     * @return true if the pattern should be retained
+     */
+    fun retain(pattern: List<Node>): Boolean
+}

--- a/modules/common/src/test/kotlin/org/cafejojo/schaapi/common/PatternFilterTest.kt
+++ b/modules/common/src/test/kotlin/org/cafejojo/schaapi/common/PatternFilterTest.kt
@@ -1,0 +1,47 @@
+package org.cafejojo.schaapi.common
+
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+
+internal object PatternFilterTest : Spek({
+    describe("the pattern filter") {
+        it("retains all patterns if no rules given") {
+            val patterns = listOf(
+                listOf(FakeNode()),
+                listOf(FakeNode())
+            )
+
+            val filteredPatterns = PatternFilter().filter(patterns)
+
+            assertThat(filteredPatterns).isEqualTo(patterns)
+        }
+
+        it("retains all patterns that are in accordance with the given rules") {
+            val lengthTwoPattern = listOf(FakeNode(), FakeNode())
+            val patterns = listOf(
+                listOf(FakeNode()),
+                lengthTwoPattern,
+                emptyList()
+            )
+
+            val filteredPatterns = PatternFilter(
+                NoEmptyPatternFilterRule(),
+                NoLengthOnePatternFilterRule()
+            ).filter(patterns)
+
+            assertThat(filteredPatterns).containsExactly(lengthTwoPattern)
+        }
+    }
+})
+
+private class NoLengthOnePatternFilterRule : PatternFilterRule {
+    override fun retain(pattern: List<Node>) = pattern.size != 1
+}
+
+private class NoEmptyPatternFilterRule : PatternFilterRule {
+    override fun retain(pattern: List<Node>) = pattern.isNotEmpty()
+}
+
+private class FakeNode(override val successors: MutableList<Node> = mutableListOf()) : Node

--- a/modules/pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/jimple/IncompleteInitPatternFilterRule.kt
+++ b/modules/pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/jimple/IncompleteInitPatternFilterRule.kt
@@ -1,7 +1,7 @@
 package org.cafejojo.schaapi.patternfilter.jimple
 
 import org.cafejojo.schaapi.common.Node
-import org.cafejojo.schaapi.common.PatternFilter
+import org.cafejojo.schaapi.common.PatternFilterRule
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import soot.jimple.InvokeStmt
 import soot.jimple.internal.JSpecialInvokeExpr
@@ -9,7 +9,7 @@ import soot.jimple.internal.JSpecialInvokeExpr
 /**
  * Filters out patterns that start with `<init>` invokes but do not have a new statement.
  */
-class IncompleteInitPatternFilter : PatternFilter {
+class IncompleteInitPatternFilterRule : PatternFilterRule {
     override fun retain(pattern: List<Node>): Boolean {
         if (pattern.isEmpty()) return true
 

--- a/modules/pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/jimple/LengthPatternFilterRule.kt
+++ b/modules/pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/patternfilter/jimple/LengthPatternFilterRule.kt
@@ -1,7 +1,7 @@
 package org.cafejojo.schaapi.patternfilter.jimple
 
 import org.cafejojo.schaapi.common.Node
-import org.cafejojo.schaapi.common.PatternFilter
+import org.cafejojo.schaapi.common.PatternFilterRule
 
 private const val DEFAULT_MINIMUM_PATTERN_LENGTH = 2
 
@@ -11,6 +11,7 @@ private const val DEFAULT_MINIMUM_PATTERN_LENGTH = 2
  * @property minimumLength the minimum length (inclusive) a pattern should have for it to be retained, which must at
  * least be 1. [DEFAULT_MINIMUM_PATTERN_LENGTH] by default
  */
-class LengthPatternFilter(private val minimumLength: Int = DEFAULT_MINIMUM_PATTERN_LENGTH) : PatternFilter {
+class LengthPatternFilterRule(private val minimumLength: Int = DEFAULT_MINIMUM_PATTERN_LENGTH) :
+    PatternFilterRule {
     override fun retain(pattern: List<Node>): Boolean = pattern.size >= minimumLength
 }

--- a/modules/pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/jimple/IncompleteInitPatternFilterRuleTest.kt
+++ b/modules/pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/jimple/IncompleteInitPatternFilterRuleTest.kt
@@ -13,7 +13,7 @@ import soot.jimple.InvokeStmt
 import soot.jimple.ReturnVoidStmt
 import soot.jimple.internal.JSpecialInvokeExpr
 
-internal class IncompleteInitPatternFilterTest : Spek({
+internal class IncompleteInitPatternFilterRuleTest : Spek({
     describe("filtering of init calls without new") {
         it("rejects patterns starting with init calls") {
             val initMethod = mock<SootMethod> {
@@ -30,7 +30,7 @@ internal class IncompleteInitPatternFilterTest : Spek({
                 mock<ReturnVoidStmt>()
             ).map { JimpleNode(it) }
 
-            assertThat(IncompleteInitPatternFilter().retain(pattern)).isFalse()
+            assertThat(IncompleteInitPatternFilterRule().retain(pattern)).isFalse()
         }
 
         it("retains patterns that start with a special invoke, but not an init call") {
@@ -48,7 +48,7 @@ internal class IncompleteInitPatternFilterTest : Spek({
                 mock<ReturnVoidStmt>()
             ).map { JimpleNode(it) }
 
-            assertThat(IncompleteInitPatternFilter().retain(pattern)).isTrue()
+            assertThat(IncompleteInitPatternFilterRule().retain(pattern)).isTrue()
         }
 
         it("retains patterns that start with a regular invoke") {
@@ -61,7 +61,7 @@ internal class IncompleteInitPatternFilterTest : Spek({
                 mock<ReturnVoidStmt>()
             ).map { JimpleNode(it) }
 
-            assertThat(IncompleteInitPatternFilter().retain(pattern)).isTrue()
+            assertThat(IncompleteInitPatternFilterRule().retain(pattern)).isTrue()
         }
 
         it("retains patterns that do not start with an invoke") {
@@ -69,19 +69,19 @@ internal class IncompleteInitPatternFilterTest : Spek({
                 mock<ReturnVoidStmt>()
             ).map { JimpleNode(it) }
 
-            assertThat(IncompleteInitPatternFilter().retain(pattern)).isTrue()
+            assertThat(IncompleteInitPatternFilterRule().retain(pattern)).isTrue()
         }
 
         it("retains empty patterns") {
             val pattern = emptyList<JimpleNode>()
 
-            assertThat(IncompleteInitPatternFilter().retain(pattern)).isTrue()
+            assertThat(IncompleteInitPatternFilterRule().retain(pattern)).isTrue()
         }
 
         it("retains lists of non-Jimple nodes") {
             val pattern = listOf(TestNode())
 
-            assertThat(IncompleteInitPatternFilter().retain(pattern)).isTrue()
+            assertThat(IncompleteInitPatternFilterRule().retain(pattern)).isTrue()
         }
     }
 })

--- a/modules/pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/jimple/LengthPatternFilterRuleTest.kt
+++ b/modules/pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/patternfilter/jimple/LengthPatternFilterRuleTest.kt
@@ -5,26 +5,26 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
-class LengthPatternFilterTest : Spek({
+class LengthPatternFilterRuleTest : Spek({
     describe("when filtering a pattern") {
         it("should return true for a pattern equal to the default length") {
-            assertThat(LengthPatternFilter().retain(listOf(TestNode(), TestNode()))).isTrue()
+            assertThat(LengthPatternFilterRule().retain(listOf(TestNode(), TestNode()))).isTrue()
         }
 
         it("should return false for a pattern shorter than the default length") {
-            assertThat(LengthPatternFilter().retain(listOf(TestNode()))).isFalse()
+            assertThat(LengthPatternFilterRule().retain(listOf(TestNode()))).isFalse()
         }
 
         it("should return false for a pattern shorter than the default length") {
-            assertThat(LengthPatternFilter().retain(listOf(TestNode()))).isFalse()
+            assertThat(LengthPatternFilterRule().retain(listOf(TestNode()))).isFalse()
         }
 
         it("should return true for a pattern longer than the passed length") {
-            assertThat(LengthPatternFilter(1).retain(listOf(TestNode(), TestNode()))).isTrue()
+            assertThat(LengthPatternFilterRule(1).retain(listOf(TestNode(), TestNode()))).isTrue()
         }
 
         it("should retain list if minimum length is negative") {
-            assertThat(LengthPatternFilter(-1).retain(listOf(TestNode()))).isTrue()
+            assertThat(LengthPatternFilterRule(-1).retain(listOf(TestNode()))).isTrue()
         }
     }
 })

--- a/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
+++ b/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
@@ -48,10 +48,9 @@ fun main(args: Array<String>) {
     val userGraphs = users.map { LibraryUsageGraphGenerator.generate(library, it) }.flatten().flatten()
 
     val patterns = PatternDetector(
-        userPaths,
         cmd.getOptionOrDefault("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt(),
         GeneralizedSootComparator()
-    ).findFrequentSequences()
+    ).findPatterns(userGraphs)
 
     val patternFilter = PatternFilter(
         IncompleteInitPatternFilterRule(),

--- a/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
+++ b/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
@@ -6,16 +6,19 @@ import org.apache.commons.cli.HelpFormatter
 import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
 import org.apache.commons.cli.ParseException
+import org.cafejojo.schaapi.common.PatternFilter
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.compare.GeneralizedSootComparator
 import org.cafejojo.schaapi.patterndetector.prefixspan.PatternDetector
-import org.cafejojo.schaapi.patternfilter.jimple.IncompleteInitPatternFilter
-import org.cafejojo.schaapi.patternfilter.jimple.LengthPatternFilter
+import org.cafejojo.schaapi.patternfilter.jimple.IncompleteInitPatternFilterRule
+import org.cafejojo.schaapi.patternfilter.jimple.LengthPatternFilterRule
 import org.cafejojo.schaapi.projectcompiler.javamaven.JavaMavenProject
 import org.cafejojo.schaapi.projectcompiler.javamaven.MavenInstaller
 import org.cafejojo.schaapi.testgenerator.jimpleevosuite.TestGenerator
+import org.cafejojo.schaapi.testgenerator.jimpleevosuite.TestableGenerator
 import org.cafejojo.schaapi.usagegraphgenerator.jimple.LibraryUsageGraphGenerator
 import java.io.File
 
+private const val DEFAULT_PATTERN_CLASS_NAME = "RegressionTest"
 private const val DEFAULT_TEST_GENERATOR_TIMEOUT = "60"
 private const val DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT = "3"
 
@@ -31,6 +34,7 @@ fun main(args: Array<String>) {
 
     val mavenDir = File(cmd.getOptionValue("maven_dir") ?: MavenInstaller.DEFAULT_MAVEN_HOME.absolutePath)
     val output = File(cmd.getOptionValue('o')).apply { mkdirs() }
+    val outputPatterns = output.resolve("patterns/").apply { mkdirs() }
     val library = JavaMavenProject(File(cmd.getOptionValue('l')), mavenDir)
     val users = cmd.getOptionValues('u').map { JavaMavenProject(File(it), mavenDir) }
 
@@ -44,13 +48,23 @@ fun main(args: Array<String>) {
     val userGraphs = users.map { LibraryUsageGraphGenerator.generate(library, it) }.flatten().flatten()
 
     val patterns = PatternDetector(
+        userPaths,
         cmd.getOptionOrDefault("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt(),
         GeneralizedSootComparator()
-    ).findPatterns(userGraphs)
+    ).findFrequentSequences()
 
-    val filteredPatterns = patterns
-        .filter { IncompleteInitPatternFilter().retain(it) }
-        .filter { LengthPatternFilter().retain(it) }
+    val patternFilter = PatternFilter(
+        IncompleteInitPatternFilterRule(),
+        LengthPatternFilterRule()
+    )
+    val filteredPatterns = patternFilter.filter(patterns)
+
+    val classGenerator = TestableGenerator(DEFAULT_PATTERN_CLASS_NAME)
+    filteredPatterns.forEachIndexed { index, pattern ->
+        classGenerator.generateMethod("pattern$index", pattern)
+    }
+
+    classGenerator.writeToFile(outputPatterns.absolutePath)
 
     val testGeneratorTimeout = cmd.getOptionOrDefault("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
     val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")


### PR DESCRIPTION
This PR restructures the pattern filters. The `jimple-pattern-filter` module now contains rules for filtering and the actual filtering is performed in a new `PatternFilter` class. The logic for filtering is (because of that) removed from the `Schaapi` class.