### PR TITLE
Remove inline infix in Pipeline

### DIFF
--- a/src/main/kotlin/org/cafejojo/schaapi/Pipeline.kt
+++ b/src/main/kotlin/org/cafejojo/schaapi/Pipeline.kt
@@ -34,4 +34,4 @@ class Pipeline(
 /**
  * Calls the specified function [map] with `this` value as its argument and returns its result.
  */
-inline infix fun <T, R> T.next(map: (T) -> R): R = map(this)
+fun <T, R> T.next(map: (T) -> R): R = map(this)


### PR DESCRIPTION
I removed these for the following reasons:
* `inline` is an optimization, but I don't think it matters much and the function is only called 4 times, so any type of optimization won't do much. I'd rather have one keyword less than pay a 0.0001ms penalty on a process that takes a minute anyway. (The compiler might just inline the function itself actually)
* `infix` is hip and all the cool kids use it, but the infix notation is not used here so there isn't really a reason to use it I believe.