### PR TITLE
Refactor GeneralizedSootComparator to GeneralizedNodeComparator

### DIFF
--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/compare/GeneralizedNodeComparator.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/compare/GeneralizedNodeComparator.kt
@@ -5,24 +5,24 @@ import org.cafejojo.schaapi.common.Node
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import soot.Scene
 import soot.Type
-import soot.Unit
 import soot.Value
+import soot.jimple.Stmt
 
 /**
- * Comparator of [Unit]s by structure and generalized values.
+ * Comparator of [Stmt]s by structure and generalized values.
  *
  * This comparator is stateful and is sensitive to the order in which methods are called. Refer to the documentation of
  * [satisfies].
  */
-class GeneralizedSootComparator : GeneralizedNodeComparator {
+class GeneralizedNodeComparator : GeneralizedNodeComparator {
     /**
      * Maps [Value]s to tags.
      */
     private val valueTags = HashMap<Value, Int>()
     /**
-     * Denotes the [Unit] to which a tag was first assigned.
+     * Denotes the [Stmt] to which a tag was first assigned.
      */
-    private val tagOrigins = HashMap<Int, Unit>()
+    private val tagOrigins = HashMap<Int, Stmt>()
 
     override fun satisfies(template: Node, instance: Node) =
         structuresAreEqual(template, instance) && generalizedValuesAreEqual(template, instance)
@@ -42,7 +42,7 @@ class GeneralizedSootComparator : GeneralizedNodeComparator {
      */
     override fun structuresAreEqual(template: Node, instance: Node): Boolean {
         if (template !is JimpleNode || instance !is JimpleNode) {
-            throw IllegalArgumentException("GeneralizedSootComparator cannot handle non-JimpleNodes.")
+            throw IllegalArgumentException("Jimple GeneralizedNodeComparator cannot handle non-Jimple nodes.")
         }
 
         return template == instance
@@ -52,8 +52,8 @@ class GeneralizedSootComparator : GeneralizedNodeComparator {
      * Returns true iff [template] and [instance] have the same generalized values.
      *
      * An instance is said to satisfy the generalized values of the template if both [template] and [instance]
-     * use [Value]s that either this comparator has not seen before or has seen before in two [Unit]s such that those
-     * were equal according to this method. If the [Unit]s to be compared have more than one [Value], the above
+     * use [Value]s that either this comparator has not seen before or has seen before in two [Stmt]s such that those
+     * were equal according to this method. If the [Stmt]s to be compared have more than one [Value], the above
      * procedure is applied to the respective [Value]s.
      *
      * @param template the template [Node]
@@ -63,7 +63,7 @@ class GeneralizedSootComparator : GeneralizedNodeComparator {
     @SuppressWarnings("UnsafeCallOnNullableType") // The !! is implicitly avoided by checking `templateHasTag`
     override fun generalizedValuesAreEqual(template: Node, instance: Node): Boolean {
         if (template !is JimpleNode || instance !is JimpleNode) {
-            throw IllegalArgumentException("GeneralizedSootComparator cannot handle non-JimpleNodes.")
+            throw IllegalArgumentException("Jimple GeneralizedNodeComparator cannot handle non-Jimple nodes.")
         }
 
         val templateValues = template.getValues()
@@ -102,7 +102,7 @@ class GeneralizedSootComparator : GeneralizedNodeComparator {
 
     private fun hasTag(value: Value) = valueTags.contains(value)
 
-    private fun isDefinedIn(value: Value, unit: Unit) = tagOrigins[valueTags[value]] === unit
+    private fun isDefinedIn(value: Value, statement: Stmt) = tagOrigins[valueTags[value]] === statement
 }
 
 /**

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/compare/GeneralizedNodeComparatorStructureTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/compare/GeneralizedNodeComparatorStructureTest.kt
@@ -24,11 +24,11 @@ import soot.jimple.Stmt
 import soot.jimple.SwitchStmt
 import soot.jimple.ThrowStmt
 
-internal class GeneralizedSootComparatorStructureTest : Spek({
-    lateinit var comparator: GeneralizedSootComparator
+internal class GeneralizedNodeComparatorStructureTest : Spek({
+    lateinit var comparator: GeneralizedNodeComparator
 
     beforeEachTest {
-        comparator = GeneralizedSootComparator()
+        comparator = GeneralizedNodeComparator()
     }
 
     describe("bad weather cases") {
@@ -38,7 +38,7 @@ internal class GeneralizedSootComparatorStructureTest : Spek({
 
             assertThatThrownBy { comparator.structuresAreEqual(template, instance) }
                 .isExactlyInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("GeneralizedSootComparator cannot handle non-JimpleNodes.")
+                .hasMessage("Jimple GeneralizedNodeComparator cannot handle non-Jimple nodes.")
         }
 
         it("throws an exception if a non-JimpleNode instance is given") {
@@ -47,7 +47,7 @@ internal class GeneralizedSootComparatorStructureTest : Spek({
 
             assertThatThrownBy { comparator.structuresAreEqual(template, instance) }
                 .isExactlyInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("GeneralizedSootComparator cannot handle non-JimpleNodes.")
+                .hasMessage("Jimple GeneralizedNodeComparator cannot handle non-Jimple nodes.")
         }
     }
 

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/compare/GeneralizedSootComparatorValueTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/compare/GeneralizedSootComparatorValueTest.kt
@@ -18,10 +18,10 @@ import soot.jimple.SwitchStmt
 import soot.jimple.ThrowStmt
 
 internal class GeneralizedSootComparatorValueTest : Spek({
-    lateinit var comparator: GeneralizedSootComparator
+    lateinit var comparator: GeneralizedNodeComparator
 
     beforeEachTest {
-        comparator = GeneralizedSootComparator()
+        comparator = GeneralizedNodeComparator()
     }
 
     describe("generalized value comparison of statements") {
@@ -32,7 +32,7 @@ internal class GeneralizedSootComparatorValueTest : Spek({
 
                 assertThatThrownBy { comparator.generalizedValuesAreEqual(template, instance) }
                     .isExactlyInstanceOf(IllegalArgumentException::class.java)
-                    .hasMessage("GeneralizedSootComparator cannot handle non-JimpleNodes.")
+                    .hasMessage("Jimple GeneralizedNodeComparator cannot handle non-Jimple nodes.")
             }
 
             it("throws an exception if a non-JimpleNode instance is given") {
@@ -41,7 +41,7 @@ internal class GeneralizedSootComparatorValueTest : Spek({
 
                 assertThatThrownBy { comparator.generalizedValuesAreEqual(template, instance) }
                     .isExactlyInstanceOf(IllegalArgumentException::class.java)
-                    .hasMessage("GeneralizedSootComparator cannot handle non-JimpleNodes.")
+                    .hasMessage("Jimple GeneralizedNodeComparator cannot handle non-Jimple nodes.")
             }
         }
 

--- a/modules/pipeline/prefix-span-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/prefixspan/FrequentSequenceFinderAndSootComparatorTest.kt
+++ b/modules/pipeline/prefix-span-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/patterndetector/prefixspan/FrequentSequenceFinderAndSootComparatorTest.kt
@@ -2,7 +2,7 @@ package org.cafejojo.schaapi.patterndetector.prefixspan
 
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions
-import org.cafejojo.schaapi.models.libraryusagegraph.jimple.compare.GeneralizedSootComparator
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.compare.GeneralizedNodeComparator
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
@@ -14,7 +14,7 @@ class FrequentSequenceFinderAndSootComparatorTest : Spek({
             val node = mockJimpleNode()
             val path = listOf(node)
 
-            val detector = FrequentSequenceFinder(listOf(path), 1, GeneralizedSootComparator())
+            val detector = FrequentSequenceFinder(listOf(path), 1, GeneralizedNodeComparator())
             detector.findFrequentSequences()
 
             Assertions.assertThat(detector.pathContainsSequence(path, listOf(node))).isTrue()
@@ -40,7 +40,7 @@ class FrequentSequenceFinderAndSootComparatorTest : Spek({
             val path2 = listOf(node7, node8, node9, node10, node4, node5, node6)
 
             val paths = listOf(path1, path2)
-            val frequent = FrequentSequenceFinder(paths, 2, GeneralizedSootComparator()).findFrequentSequences()
+            val frequent = FrequentSequenceFinder(paths, 2, GeneralizedNodeComparator()).findFrequentSequences()
 
             Assertions.assertThat(frequent).contains(
                 listOf(
@@ -67,7 +67,7 @@ class FrequentSequenceFinderAndSootComparatorTest : Spek({
             val path2 = listOf(node7, node8, node9, node10, node4, node5, node6)
 
             val paths = listOf(path1, path2)
-            val frequent = FrequentSequenceFinder(paths, 2, GeneralizedSootComparator()).findFrequentSequences()
+            val frequent = FrequentSequenceFinder(paths, 2, GeneralizedNodeComparator()).findFrequentSequences()
 
             Assertions.assertThat(frequent).isEmpty()
         }

--- a/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
+++ b/src/main/kotlin/org/cafejojo/schaapi/Schaapi.kt
@@ -7,7 +7,7 @@ import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
 import org.apache.commons.cli.ParseException
 import org.cafejojo.schaapi.common.PatternFilter
-import org.cafejojo.schaapi.models.libraryusagegraph.jimple.compare.GeneralizedSootComparator
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.compare.GeneralizedNodeComparator
 import org.cafejojo.schaapi.patterndetector.prefixspan.PatternDetector
 import org.cafejojo.schaapi.patternfilter.jimple.IncompleteInitPatternFilterRule
 import org.cafejojo.schaapi.patternfilter.jimple.LengthPatternFilterRule
@@ -48,7 +48,7 @@ fun main(args: Array<String>) {
         libraryUsageGraphGenerator = LibraryUsageGraphGenerator,
         patternDetector = PatternDetector(
             cmd.getOptionOrDefault("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt(),
-            GeneralizedSootComparator()
+            GeneralizedNodeComparator()
         ),
         patternFilter = PatternFilter(
             IncompleteInitPatternFilterRule(),


### PR DESCRIPTION
Renames the class and converts its `Unit` usages with `Stmt` usages (as it is in the Jimple-specific package).