### PR TITLE
Unescape escaped characters in paths in smoke test

### DIFF
--- a/src/test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
+++ b/src/test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
 import java.io.File
+import java.net.URLDecoder
 import java.nio.file.Files
 
 /**
@@ -38,4 +39,5 @@ internal class SchaapiSmokeTest : Spek({
     }
 })
 
-private fun getResourcePath(path: String) = SchaapiSmokeTest::class.java.getResource(path).path
+private fun getResourcePath(path: String) =
+    URLDecoder.decode(SchaapiSmokeTest::class.java.getResource(path).path, "UTF-8")


### PR DESCRIPTION
Fixes #66.

The issue was that the `Class::getResource` method returns a `URL`, which automatically escapes certain characters. Therefore, this was only really an issue in the smoke test itself. I have changed the helper method `getResourcePath` to decode the characters that were encoded by `URL`.
