### PR TITLE
Ignore build folder in `modules` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ hs_err_pid*
 ## Gradle
 .gradle
 /build/
-/subprojects/*/build/
+/modules/*/build/
 
 # Ignore Gradle GUI config
 gradle-app.setting


### PR DESCRIPTION
Now that everything has been moved to `modules`, the `.gitignore` should also be updated to ignore the `build` folder in `modules` rather than `subprojects`. That is exactly what this PR does.