### PR TITLE
Rename EvoSuiteTestGenerator to EvoSuiteRunner

### DIFF
--- a/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
@@ -18,7 +18,7 @@ import java.nio.charset.Charset
  * @property processStandardStream a stream to output EvoSuite's standard messages to
  * @property processErrorStream a stream to output EvoSuite's error messages to
  */
-class EvoSuiteTestGenerator(
+class EvoSuiteRunner(
     private val fullyQualifiedClassName: String,
     private val classpath: String,
     private val outputDirectory: String,

--- a/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/jimpleevosuite/TestGenerator.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/testgenerator/jimpleevosuite/TestGenerator.kt
@@ -29,7 +29,7 @@ class TestGenerator(
             writeToFile(outputPatterns.absolutePath)
         }
 
-        EvoSuiteTestGenerator(
+        EvoSuiteRunner(
             fullyQualifiedClassName = DEFAULT_PATTERN_CLASS_NAME,
             classpath = outputPatterns.absolutePath + File.pathSeparator + library.classpath,
             outputDirectory = outputTests.absolutePath,

--- a/modules/pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/jimpleevosuite/EvoSuiteRunnerTest.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/testgenerator/jimpleevosuite/EvoSuiteRunnerTest.kt
@@ -7,8 +7,8 @@ import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import java.io.File
 
-internal class TestGeneratorTest : Spek({
-    val classPath = TestGeneratorTest::class.java.getResource("../../../../../").toURI().path
+internal class EvoSuiteRunnerTest : Spek({
+    val classPath = EvoSuiteRunnerTest::class.java.getResource("../../../../../").toURI().path
     val evoSuiteTestOutput = File("$classPath/evosuite-tests/")
 
     fun deleteTestOutput() {
@@ -27,7 +27,7 @@ internal class TestGeneratorTest : Spek({
 
     describe("execution of the EvoSuite test generator") {
         it("generates tests for a test class") {
-            val evoSuiteRunner = EvoSuiteTestGenerator(
+            val evoSuiteRunner = EvoSuiteRunner(
                 "org.cafejojo.schaapi.test.EvoSuiteTestClass",
                 classPath,
                 classPath,
@@ -41,7 +41,7 @@ internal class TestGeneratorTest : Spek({
         }
 
         it("throws an exception when the class can't be found on the given class path") {
-            val evoSuiteRunner = EvoSuiteTestGenerator(
+            val evoSuiteRunner = EvoSuiteRunner(
                 "org.cafejojo.schaapi.test.EvoSuiteTestClass",
                 ".",
                 classPath,
@@ -54,7 +54,7 @@ internal class TestGeneratorTest : Spek({
         }
 
         it("throws an exception when the class doesn't exist") {
-            val evoSuiteRunner = EvoSuiteTestGenerator(
+            val evoSuiteRunner = EvoSuiteRunner(
                 "no.way.this.exists.SampleClass",
                 classPath,
                 classPath,


### PR DESCRIPTION
This rename aims to prevent confusing the functionality of this class with the TestGenerator interface (which this class does not implement).

Fixes #88