### PR TITLE
Categorise modules into submodules in Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 
 // Shared config
-allprojects {
+subprojects {
     /// Plugins
     // Compilation
     apply plugin: "java"
@@ -91,11 +91,11 @@ apply from: "gradle/detekt.gradle"
 
 // Jacoco report combining all reports
 task jacocoRootReport(type: JacocoReport) {
-    dependsOn = allprojects.test
-    additionalSourceDirs = files(allprojects.sourceSets.main.allSource.srcDirs)
-    sourceDirectories = files(allprojects.sourceSets.main.allSource.srcDirs)
-    classDirectories = files(allprojects.sourceSets.main.output)
-    executionData = files(allprojects.jacocoTestReport.executionData)
+    dependsOn = subprojects.test
+    additionalSourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs)
+    sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
+    classDirectories = files(subprojects.sourceSets.main.output)
+    executionData = files(subprojects.jacocoTestReport.executionData)
 
     reports {
         html.enabled = true

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ buildscript {
 
 
 // Shared config
-subprojects {
+allprojects {
     /// Plugins
     // Compilation
     apply plugin: "java"
@@ -91,11 +91,11 @@ apply from: "gradle/detekt.gradle"
 
 // Jacoco report combining all reports
 task jacocoRootReport(type: JacocoReport) {
-    dependsOn = subprojects.test
-    additionalSourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs)
-    sourceDirectories = files(subprojects.sourceSets.main.allSource.srcDirs)
-    classDirectories = files(subprojects.sourceSets.main.output)
-    executionData = files(subprojects.jacocoTestReport.executionData)
+    dependsOn = allprojects.test
+    additionalSourceDirs = files(allprojects.sourceSets.main.allSource.srcDirs)
+    sourceDirectories = files(allprojects.sourceSets.main.allSource.srcDirs)
+    classDirectories = files(allprojects.sourceSets.main.output)
+    executionData = files(allprojects.jacocoTestReport.executionData)
 
     reports {
         html.enabled = true

--- a/modules/application/build.gradle
+++ b/modules/application/build.gradle
@@ -7,13 +7,13 @@ repositories {
 }
 
 dependencies {
-    compile project(":java-maven-project")
-    compile project(":java-maven-project-compiler")
-    compile project(":jimple-evosuite-test-generator")
-    compile project(":jimple-library-usage-graph")
-    compile project(":jimple-library-usage-graph-generator")
-    compile project(":jimple-pattern-filter")
-    compile project(":prefix-span-pattern-detector")
+    compile project(":models:java-maven-project")
+    compile project(":models:jimple-library-usage-graph")
+    compile project(":pipeline:java-maven-project-compiler")
+    compile project(":pipeline:jimple-evosuite-test-generator")
+    compile project(":pipeline:jimple-library-usage-graph-generator")
+    compile project(":pipeline:jimple-pattern-filter")
+    compile project(":pipeline:prefix-span-pattern-detector")
 
     compile group: "commons-cli", name: "commons-cli", version: commonsCliVersion
 }

--- a/modules/pipeline/java-maven-project-compiler/build.gradle
+++ b/modules/pipeline/java-maven-project-compiler/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(":pipeline")
 
-    compile project(":java-maven-project")
+    compile project(":models:java-maven-project")
 
     compile group: "org.apache.maven.shared", name: "maven-invoker", version: mavenInvokerVersion
     compile group: "org.zeroturnaround", name: "zt-zip", version: ztZipVersion

--- a/modules/pipeline/jimple-evosuite-test-generator/build.gradle
+++ b/modules/pipeline/jimple-evosuite-test-generator/build.gradle
@@ -5,8 +5,8 @@ repositories {
 dependencies {
     compile project(":pipeline")
 
-    compile project(":java-maven-project")
-    compile project(":jimple-library-usage-graph")
+    compile project(":models:java-maven-project")
+    compile project(":models:jimple-library-usage-graph")
 
     compile group: "org.evosuite", name: "evosuite-master", version: evosuiteMasterVersion
     compile group: "ca.mcgill.sable", name: "soot", version: sootVersion

--- a/modules/pipeline/jimple-library-usage-graph-generator/build.gradle
+++ b/modules/pipeline/jimple-library-usage-graph-generator/build.gradle
@@ -5,8 +5,8 @@ repositories {
 dependencies {
     compile project(":pipeline")
 
-    compile project(":java-maven-project")
-    compile project(":jimple-library-usage-graph")
+    compile project(":models:java-maven-project")
+    compile project(":models:jimple-library-usage-graph")
 
     compile group: "ca.mcgill.sable", name: "soot", version: sootVersion
 

--- a/modules/pipeline/jimple-pattern-filter/build.gradle
+++ b/modules/pipeline/jimple-pattern-filter/build.gradle
@@ -5,7 +5,7 @@ repositories {
 dependencies {
     compile project(":pipeline")
 
-    compile project(":jimple-library-usage-graph")
+    compile project(":models:jimple-library-usage-graph")
 
     compile group: "ca.mcgill.sable", name: "soot", version: sootVersion
 

--- a/modules/pipeline/prefix-span-pattern-detector/build.gradle
+++ b/modules/pipeline/prefix-span-pattern-detector/build.gradle
@@ -5,7 +5,7 @@ repositories {
 dependencies {
     compile project(":pipeline")
 
-    testCompile project(":jimple-library-usage-graph")
+    testCompile project(":models:jimple-library-usage-graph")
 
     testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,23 +1,24 @@
 // Based on `https://github.com/griffon/griffon/blob/ed86035/settings.gradle`
-def includeModule = { String directory, String projectName  ->
+def includeModule(String directory = "", String projectName) {
     File baseDir = new File((File) rootDir, "modules/" + directory)
     File moduleDir = new File(baseDir, projectName)
+    String projectPath = (directory == "" ? "" : ":${directory}") + ":${projectName}"
 
     assert moduleDir.isDirectory()
 
-    include projectName
-    project(":${projectName}").projectDir = moduleDir
+    include projectPath
+    project(projectPath).projectDir = moduleDir
 }
 
 rootProject.name = "schaapi"
 
-includeModule "", "application"
+includeModule "application"
 
-includeModule "", "models"
+includeModule "models"
 includeModule "models", "jimple-library-usage-graph"
 includeModule "models", "java-maven-project"
 
-includeModule "", "pipeline"
+includeModule "pipeline"
 includeModule "pipeline", "java-maven-project-compiler"
 includeModule "pipeline", "jimple-evosuite-test-generator"
 includeModule "pipeline", "jimple-library-usage-graph-generator"


### PR DESCRIPTION
The module names now correspond to the directory structure. For example, `:jimple-pattern-filter` has now been moved to `:pipeline:jimple-pattern-filter`.