### PR TITLE
Uncapitalise "contributors" in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,10 @@ Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 If you discover any security-related issues, please email cafejojo@fwdekker.com instead of using the issue tracker.
 
 ## Credits
-- [Joël Abrahams](https://github.com/jsabrahams)
+- [Joël Abrahams](https://github.com/JSAbrahams)
 - [Georgios Andreadis](https://github.com/gandreadis)
 - [Casper Boone](https://github.com/casperboone)
-- [Felix Dekker](https://github.com/fwdekker)
+- [Felix Dekker](https://github.com/FWDekker)
 - [All contributors](../../contributors)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you discover any security-related issues, please email cafejojo@fwdekker.com 
 - [Georgios Andreadis](https://github.com/gandreadis)
 - [Casper Boone](https://github.com/casperboone)
 - [Felix Dekker](https://github.com/fwdekker)
-- [All Contributors](../../contributors)
+- [All contributors](../../contributors)
 
 ## License
 The MIT License (MIT). Please see the [license file](LICENSE) for more information.


### PR DESCRIPTION
Because "contributors" is not a name.

Yay, 100th PR!