### PR TITLE
Fix issue where no common end statement could be found

### DIFF
--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/IfNoEndTest.java
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/IfNoEndTest.java
@@ -1,0 +1,15 @@
+package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.testclasses.users;
+
+import org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.testclasses.library.Object1;
+
+public class IfNoEndTest {
+    public int test() {
+        Object1 o1 = new Object1();
+
+        if (Math.random() > 123) {
+            return 456;
+        }
+
+        return 123;
+    }
+}

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -138,6 +138,27 @@ internal class IntegrationTest : Spek({
                 cfg
             )
         }
+
+        it("converts a class containing an if with no successors of the true/false branch") {
+            val cfg = LibraryUsageGraphGenerator.generate(
+                libraryProject,
+                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.IfNoEndTest"))
+            )[1]
+
+            assertThatStructureMatches(
+                node<JAssignStmt>(
+                    node<JInvokeStmt>(
+                        node<JAssignStmt>(
+                            node<JIfStmt>(
+                                node<JReturnStmt>(),
+                                node<JReturnStmt>()
+                            )
+                        )
+                    )
+                ),
+                cfg
+            )
+        }
     }
 
     describe("the integration of different components of the package for classes containing switch statements") {


### PR DESCRIPTION
This PR fixes an issue where no common end statement can be found.

We now just ignore this case, because this can only occur when a true/false branch has no successors. In this case it must contain a return or throw statement, and these cases we want to keep the branches.