### PR TITLE
Check for references instead for equality

### DIFF
--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/DfsIterator.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/DfsIterator.kt
@@ -37,7 +37,7 @@ class DfsIterator(entryNode: Node) : Iterator<Node> {
             }
 
             nextNode = neighbors?.next()
-        } while (visited.contains(nextNode))
+        } while (visited.any { it === nextNode })
 
         successorStack.push(nextNode?.successors?.iterator())
     }


### PR DESCRIPTION
The `DFSIterator` previously checked for equality defined by the `equals` method implementation. In implementations such as the `JimpleNode`, however, this leads to structurally equal nodes being seen as 'visited', even though they are in fact other instances. This led to statement sequences being cut short in iteration, such as the one below (with line 1 and 2 being structurally equal):

```
int x = new LibraryClass().libraryFoo();
int y = new LibraryClass().libraryFoo();
return x;
```