### PR TITLE
Move integration test config to separate file

### DIFF
--- a/gradle/integration-tests.gradle
+++ b/gradle/integration-tests.gradle
@@ -1,0 +1,36 @@
+configurations {
+    integrationTestCompile.extendsFrom testCompile
+    integrationTestRuntime.extendsFrom integrationTestCompile, testRuntime
+}
+
+sourceSets {
+    integrationTest {
+        kotlin.srcDirs file("src/integration-test/kotlin")
+        resources.srcDirs file("src/integration-test/resources")
+
+        compileClasspath += sourceSets.main.output
+        compileClasspath += configurations.compileOnly
+        compileClasspath += configurations.testCompileOnly
+        runtimeClasspath += compileClasspath
+    }
+}
+
+task integrationTest(type: Test, description: "Runs the integration tests.", group: "Verification") {
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+
+    jacoco {
+        append = false
+    }
+
+    useJUnitPlatform() {
+        includeEngines "spek"
+    }
+
+    jacocoTestReport {
+        executionData file("$buildDir/jacoco/integration-test.exec")
+    }
+}
+
+integrationTest.mustRunAfter test
+check.dependsOn integrationTest

--- a/modules/pipeline/prefix-span-pattern-detector/build.gradle
+++ b/modules/pipeline/prefix-span-pattern-detector/build.gradle
@@ -1,10 +1,7 @@
+apply from: "$rootDir/gradle/integration-tests.gradle"
+
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
-}
-
-configurations {
-    integrationTestCompile.extendsFrom testCompile
-    integrationTestRuntime.extendsFrom integrationTestCompile, testRuntime
 }
 
 dependencies {
@@ -15,36 +12,3 @@ dependencies {
     integrationTestCompile project(":models:jimple-library-usage-graph")
     integrationTestCompile group: "ca.mcgill.sable", name: "soot", version: sootVersion
 }
-
-// Integration test src
-sourceSets {
-    integrationTest {
-        kotlin.srcDirs file("src/integration-test/kotlin")
-        resources.srcDirs file("src/integration-test/resources")
-
-        compileClasspath += sourceSets.main.output
-        compileClasspath += configurations.compileOnly
-        compileClasspath += configurations.testCompileOnly
-        runtimeClasspath += compileClasspath
-    }
-}
-
-task integrationTest(type: Test, description: "Runs the integration tests.", group: "Verification") {
-    testClassesDirs = sourceSets.integrationTest.output.classesDirs
-    classpath = sourceSets.integrationTest.runtimeClasspath
-
-    jacoco {
-        append = false
-    }
-
-    useJUnitPlatform() {
-        includeEngines "spek"
-    }
-
-    jacocoTestReport {
-        executionData file("$buildDir/jacoco/integration-test.exec")
-    }
-}
-
-integrationTest.mustRunAfter test
-check.dependsOn integrationTest


### PR DESCRIPTION
An extension on the work added in #106, this PR extracts the integration-test specific Gradle configuration to a separate file. Simply write the following in your `build.gradle` to enable integration tests for that module:

```groovy
apply from: "$rootDir/gradle/integration-tests.gradle"
```
