### PR TITLE
Add tests for abstract methods in UGG module

### DIFF
--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
@@ -23,7 +23,9 @@ object LibraryUsageGraphGenerator : LibraryUsageGraphGenerator {
         return userProject.classNames.flatMap {
             val sootClass = createSootClass(userProject.classpath, it)
 
-            sootClass.methods.map { generateMethodGraph(libraryProject, it) }
+            sootClass.methods
+                .filter { it.isConcrete }
+                .map { generateMethodGraph(libraryProject, it) }
         }
     }
 

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/AbstractClassTest.java
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/AbstractClassTest.java
@@ -1,0 +1,5 @@
+package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.testclasses.users;
+
+public abstract class AbstractClassTest {
+    public abstract void test();
+}

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/InterfaceTest.java
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/InterfaceTest.java
@@ -1,0 +1,5 @@
+package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.testclasses.users;
+
+public interface InterfaceTest {
+    public void test();
+}

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/PartiallyAbstractClassTest.java
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/PartiallyAbstractClassTest.java
@@ -1,0 +1,9 @@
+package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.testclasses.users;
+
+public abstract class PartiallyAbstractClassTest {
+    public abstract void foo();
+
+    public void bar() {
+
+    }
+}

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -328,6 +328,30 @@ internal class IntegrationTest : Spek({
             )
         }
     }
+
+    describe("the integration of different components for types containing non-concrete method declarations") {
+        it("ignores a non-concrete interface method declaration") {
+            val methods = LibraryUsageGraphGenerator.generate(
+                libraryProject,
+                TestProject(testClassesClassPath, listOf(
+                    "$TEST_CLASSES_PACKAGE.users.InterfaceTest"
+                ))
+            )
+
+            assertThat(methods.size).isEqualTo(0)
+        }
+
+        it("ignores a non-concrete abstract class method declaration") {
+            val methods = LibraryUsageGraphGenerator.generate(
+                libraryProject,
+                TestProject(testClassesClassPath, listOf(
+                    "$TEST_CLASSES_PACKAGE.users.AbstractClassTest"
+                ))
+            )
+
+            assertThat(methods.size).isEqualTo(1)
+        }
+    }
 })
 
 private fun assertThatStructureMatches(structure: Node, cfg: Node) {

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -349,7 +349,20 @@ internal class IntegrationTest : Spek({
                 ))
             )
 
+            // Should only contain the implicit constructor
             assertThat(methods.size).isEqualTo(1)
+        }
+
+        it("ignores a non-concrete abstract class method declaration") {
+            val methods = LibraryUsageGraphGenerator.generate(
+                libraryProject,
+                TestProject(testClassesClassPath, listOf(
+                    "$TEST_CLASSES_PACKAGE.users.PartiallyAbstractClassTest"
+                ))
+            )
+
+            // Should contain the implicit constructor and the fully specified method (not the declared method)
+            assertThat(methods.size).isEqualTo(2)
         }
     }
 })


### PR DESCRIPTION
The current UGG implementation crashes on non-concrete methods (abstract or interface declarations) with a `RuntimeException`. This PR fixes this and adds two test cases to the module integration test suite to demonstrate this.