### PR TITLE
Recursive type checking

### DIFF
--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparator.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparator.kt
@@ -63,8 +63,8 @@ class GeneralizedNodeComparator : GeneralizedNodeComparator {
             throw IllegalArgumentException("Jimple GeneralizedNodeComparator cannot handle non-Jimple nodes.")
         }
 
-        val templateValues = template.getTopLevelValues()
-        val instanceValues = instance.getTopLevelValues()
+        val templateValues = template.getValues()
+        val instanceValues = instance.getValues()
 
         templateValues.forEachIndexed { index, templateValue ->
             val instanceValue = instanceValues[index]

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNode.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNode.kt
@@ -20,9 +20,9 @@ class JimpleNode(val statement: Stmt, override val successors: MutableList<Node>
     override fun toString() = statement.toString()
 
     /**
-     * Extract the values from the contained [Stmt] based on its type.
+     * Returns all [soot.Value]s used as fields in [statement].
      *
-     * @return all values of the contained [Stmt] based on the type of the [Stmt]
+     * @return all [soot.Value]s used as fields in [statement]
      */
     fun getTopLevelValues() =
         when (statement) {
@@ -36,6 +36,13 @@ class JimpleNode(val statement: Stmt, override val successors: MutableList<Node>
             is ReturnVoidStmt -> emptyList()
             else -> emptyList()
         }
+
+    /**
+     * Returns all [soot.Value]s recursively contained in [statement].
+     *
+     * @return all [soot.Value]s recursively contained in [statement]
+     */
+    fun getValues() = getTopLevelValues().union(getTopLevelValues().flatMap { it.useBoxes.map { it.value } }).toList()
 
     /**
      * A [JimpleNode] equals another [JimpleNode] if the [statement] is of the same type, they have the same amount of

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparatorValueTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparatorValueTest.kt
@@ -189,6 +189,23 @@ internal class GeneralizedNodeComparatorValueTest : Spek({
                 assertThat(comparator.generalizedValuesAreEqual(templateB, instanceB)).isTrue()
             }
 
+            it("rejects wrongly used nested values") {
+                val templateLeft = mockValue("left")
+                val templateRight = mockValue("right")
+                val templateExpr = SimpleBinopExpr(templateLeft, templateRight)
+                val instanceLeft = mockValue("left")
+                val instanceRight = mockValue("right")
+                val instanceExpr = SimpleBinopExpr(instanceLeft, instanceRight)
+
+                val templateA = JimpleNode(mockIfStmt(templateExpr))
+                val instanceA = JimpleNode(mockIfStmt(instanceExpr))
+                comparator.generalizedValuesAreEqual(templateA, instanceA)
+
+                val templateB = JimpleNode(mockDefinitionStmt(templateExpr, templateLeft))
+                val instanceB = JimpleNode(mockDefinitionStmt(instanceExpr, instanceRight))
+                assertThat(comparator.generalizedValuesAreEqual(templateB, instanceB)).isFalse()
+            }
+
             it("allows method instances to be reused across statements") {
                 val method = SimpleSootMethod("base", listOf("arg1", "arg2"), "output")
 

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
@@ -14,7 +14,7 @@ internal class JimpleNodeTest : Spek({
         context("non-recursive statements") {
             it("returns the operator of a throw statement") {
                 val value = mockValue("value")
-                val node = JimpleNode(mockIfStmt(value))
+                val node = JimpleNode(mockThrowStmt(value))
 
                 assertThat(node.getTopLevelValues()).containsExactly(value)
                 assertThat(node.getValues()).containsExactly(value)
@@ -45,7 +45,7 @@ internal class JimpleNodeTest : Spek({
                 assertThat(node.getValues()).containsExactly(value)
             }
 
-            it("returns the key of a switch statement") {
+            it("returns the invocation expression of an invoke statement") {
                 val invokeExpr = mockInvokeExpr("value")
                 val node = JimpleNode(mockInvokeStmt(invokeExpr))
 

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
@@ -4,71 +4,210 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import soot.jimple.DefinitionStmt
 
 internal class JimpleNodeTest : Spek({
-    describe("top-level values") {
-        it("returns the operator of a throw statement") {
-            val value = mockValue("value")
-            val node = JimpleNode(mockIfStmt(value))
+    describe("contained values") {
+        context("non-recursive statements") {
+            it("returns the operator of a throw statement") {
+                val value = mockValue("value")
+                val node = JimpleNode(mockIfStmt(value))
 
-            assertThat(node.getTopLevelValues()).containsExactly(value)
+                assertThat(node.getTopLevelValues()).containsExactly(value)
+                assertThat(node.getValues()).containsExactly(value)
+            }
+
+            it("returns both operators of a definition statement") {
+                val leftValue = mockValue("left")
+                val rightValue = mockValue("right")
+                val node = JimpleNode(mockDefinitionStmt(leftValue, rightValue))
+
+                assertThat(node.getTopLevelValues()).containsExactly(leftValue, rightValue)
+                assertThat(node.getValues()).containsExactly(leftValue, rightValue)
+            }
+
+            it("returns the condition of an if statement") {
+                val value = mockValue("value")
+                val node = JimpleNode(mockIfStmt(value))
+
+                assertThat(node.getTopLevelValues()).containsExactly(value)
+                assertThat(node.getValues()).containsExactly(value)
+            }
+
+            it("returns the key of a switch statement") {
+                val value = mockValue("value")
+                val node = JimpleNode(mockSwitchStmt(value))
+
+                assertThat(node.getTopLevelValues()).containsExactly(value)
+                assertThat(node.getValues()).containsExactly(value)
+            }
+
+            it("returns the key of a switch statement") {
+                val invokeExpr = mockInvokeExpr("value")
+                val node = JimpleNode(mockInvokeStmt(invokeExpr))
+
+                assertThat(node.getTopLevelValues()).containsExactly(invokeExpr)
+                assertThat(node.getValues()).containsExactly(invokeExpr)
+            }
+
+            it("returns the operator of a return statement") {
+                val value = mockValue("value")
+                val node = JimpleNode(mockReturnStmt(value))
+
+                assertThat(node.getTopLevelValues()).containsExactly(value)
+                assertThat(node.getValues()).containsExactly(value)
+            }
+
+            it("returns nothing for a goto statement") {
+                val node = JimpleNode(mockGotoStmt())
+
+                assertThat(node.getTopLevelValues()).isEmpty()
+                assertThat(node.getValues()).isEmpty()
+            }
+
+            it("returns nothing for a return void statement") {
+                val node = JimpleNode(mockReturnVoidStmt())
+
+                assertThat(node.getTopLevelValues()).isEmpty()
+                assertThat(node.getValues()).isEmpty()
+            }
+
+            it("returns nothing for an unrecognised statement") {
+                val node = JimpleNode(mockStmt())
+
+                assertThat(node.getTopLevelValues()).isEmpty()
+                assertThat(node.getValues()).isEmpty()
+            }
         }
 
-        it("returns both operators of a definition statement") {
-            val leftValue = mockValue("left")
-            val rightValue = mockValue("right")
-            val node = JimpleNode(mockDefinitionStmt(leftValue, rightValue))
+        context("recursive statements") {
+            context("unop/binop") {
+                it("finds the value in an expression") {
+                    val value = mockValue("value")
+                    val expr = SimpleUnopExpr(value)
+                    val node = JimpleNode(mockIfStmt(expr))
 
-            assertThat(node.getTopLevelValues()).containsExactly(leftValue, rightValue)
-        }
+                    assertThat(node.getTopLevelValues()).containsExactly(expr)
+                    assertThat(node.getValues()).containsExactly(expr, value)
+                }
 
-        it("returns the condition of an if statement") {
-            val value = mockValue("value")
-            val node = JimpleNode(mockIfStmt(value))
+                it("finds the value in an expression in an expression") {
+                    val value = mockValue("value")
+                    val innerExpr = SimpleUnopExpr(value)
+                    val outerExpr = SimpleUnopExpr(innerExpr)
+                    val node = JimpleNode(mockIfStmt(outerExpr))
 
-            assertThat(node.getTopLevelValues()).containsExactly(value)
-        }
+                    assertThat(node.getTopLevelValues()).containsExactly(outerExpr)
+                    assertThat(node.getValues()).containsExactly(outerExpr, value, innerExpr)
+                }
 
-        it("returns the key of a switch statement") {
-            val value = mockValue("value")
-            val node = JimpleNode(mockSwitchStmt(value))
+                it("finds the values in an expression") {
+                    val leftValue = mockValue("left")
+                    val rightValue = mockValue("right")
+                    val expr = SimpleBinopExpr(leftValue, rightValue)
+                    val node = JimpleNode(mockIfStmt(expr))
 
-            assertThat(node.getTopLevelValues()).containsExactly(value)
-        }
+                    assertThat(node.getTopLevelValues()).containsExactly(expr)
+                    assertThat(node.getValues()).containsExactly(expr, leftValue, rightValue)
+                }
 
-        it("returns the key of a switch statement") {
-            val invokeExpr = mockInvokeExpr("value")
-            val node = JimpleNode(mockInvokeStmt(invokeExpr))
+                it("finds the values in an expression") {
+                    val leftValue = mockValue("left")
+                    val rightValue = mockValue("right")
+                    val expr = SimpleBinopExpr(leftValue, rightValue)
+                    val node = JimpleNode(mockIfStmt(expr))
 
-            assertThat(node.getTopLevelValues()).containsExactly(invokeExpr)
-        }
+                    assertThat(node.getTopLevelValues()).containsExactly(expr)
+                    assertThat(node.getValues()).containsExactly(expr, leftValue, rightValue)
+                }
 
-        it("returns the operator of a return statement") {
-            val value = mockValue("value")
-            val node = JimpleNode(mockReturnStmt(value))
+                it("finds the values in two expressions") {
+                    val leftValue = mockValue("left")
+                    val leftExpr = SimpleUnopExpr(leftValue)
 
-            assertThat(node.getTopLevelValues()).containsExactly(value)
-        }
+                    val rightValue = mockValue("right")
+                    val rightExpr = SimpleUnopExpr(rightValue)
 
-        it("returns nothing for a goto statement") {
-            val node = JimpleNode(mockGotoStmt())
+                    val node = JimpleNode(mockDefinitionStmt(leftExpr, rightExpr))
 
-            assertThat(node.getTopLevelValues()).isEmpty()
-        }
+                    assertThat(node.getTopLevelValues()).containsExactly(leftExpr, rightExpr)
+                    assertThat(node.getValues()).containsExactly(leftExpr, rightExpr, leftValue, rightValue)
+                }
 
-        it("returns nothing for a return void statement") {
-            val node = JimpleNode(mockReturnVoidStmt())
+                it("finds the values in the expressions in two expressions") {
+                    val leftLeftValue = mockValue("left-left")
+                    val leftRightValue = mockValue("left-right")
+                    val leftExpr = SimpleBinopExpr(leftLeftValue, leftRightValue)
 
-            assertThat(node.getTopLevelValues()).isEmpty()
-        }
+                    val rightLeftValue = mockValue("right-left")
+                    val rightRightValue = mockValue("right-right")
+                    val rightExpr = SimpleBinopExpr(rightLeftValue, rightRightValue)
 
-        it("returns nothing for an unrecognised statement") {
-            val node = JimpleNode(mockStmt())
+                    val node = JimpleNode(mockDefinitionStmt(leftExpr, rightExpr))
 
-            assertThat(node.getTopLevelValues()).isEmpty()
+                    assertThat(node.getTopLevelValues()).containsExactly(leftExpr, rightExpr)
+                    assertThat(node.getValues()).containsExactly(
+                        leftExpr, rightExpr,
+                        leftLeftValue, leftRightValue,
+                        rightLeftValue, rightRightValue
+                    )
+                }
+
+                it("finds the values in an invocation without arguments") {
+                    val method = SimpleSootMethod("method", emptyList(), "output")
+                    val base = mockValue("base")
+                    @SuppressWarnings("SpreadOperator") // Cannot be avoided because of generic
+                    val expr = SimpleInvokeExpr(base, method, *emptyArray<String>())
+                    val node = JimpleNode(mockIfStmt(expr))
+
+                    assertThat(node.getTopLevelValues()).containsExactly(expr)
+                    assertThat(node.getValues()).containsExactly(expr, base)
+                }
+            }
+
+            context("invocation") {
+                it("finds the values in an invocation") {
+                    val method = SimpleSootMethod("method", listOf("arg1", "arg2", "arg3"), "output")
+                    val base = mockValue("base")
+                    val arg1 = mockValue("arg1")
+                    val arg2 = mockValue("arg2")
+                    val arg3 = mockValue("arg3")
+                    val expr = SimpleInvokeExpr(base, method, arg1, arg2, arg3)
+                    val node = JimpleNode(mockIfStmt(expr))
+
+                    assertThat(node.getTopLevelValues()).containsExactly(expr)
+                    assertThat(node.getValues()).containsExactly(expr, arg1, arg2, arg3, base)
+                }
+
+                it("finds the values in the base of an invocation") {
+                    val method = SimpleSootMethod("method", listOf("arg1", "arg2"), "output")
+                    val baseValue = mockValue("base-value")
+                    val baseExpr = SimpleUnopExpr(baseValue)
+                    val arg1 = mockValue("arg1")
+                    val arg2 = mockValue("arg2")
+                    val expr = SimpleInvokeExpr(baseExpr, method, arg1, arg2)
+                    val node = JimpleNode(mockIfStmt(expr))
+
+                    assertThat(node.getTopLevelValues()).containsExactly(expr)
+                    assertThat(node.getValues()).containsExactly(expr, arg1, arg2, baseValue, baseExpr)
+                }
+
+                it("finds the values in the argument of an invocation") {
+                    val method = SimpleSootMethod("method", listOf("arg1", "arg2"), "output")
+                    val base = mockValue("base")
+                    val arg1 = mockValue("arg1")
+                    val arg2Value = mockValue("arg2-value")
+                    val arg2Expr = SimpleUnopExpr(arg2Value)
+                    val expr = SimpleInvokeExpr(base, method, arg1, arg2Expr)
+                    val node = JimpleNode(mockIfStmt(expr))
+
+                    assertThat(node.getTopLevelValues()).containsExactly(expr)
+                    assertThat(node.getValues()).containsExactly(expr, arg1, arg2Expr, arg2Value, base)
+                }
+            }
         }
     }
 

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
@@ -9,6 +9,69 @@ import org.jetbrains.spek.api.dsl.it
 import soot.jimple.DefinitionStmt
 
 internal class JimpleNodeTest : Spek({
+    describe("top-level values") {
+        it("returns the operator of a throw statement") {
+            val value = mockValue("value")
+            val node = JimpleNode(mockIfStmt(value))
+
+            assertThat(node.getTopLevelValues()).containsExactly(value)
+        }
+
+        it("returns both operators of a definition statement") {
+            val leftValue = mockValue("left")
+            val rightValue = mockValue("right")
+            val node = JimpleNode(mockDefinitionStmt(leftValue, rightValue))
+
+            assertThat(node.getTopLevelValues()).containsExactly(leftValue, rightValue)
+        }
+
+        it("returns the condition of an if statement") {
+            val value = mockValue("value")
+            val node = JimpleNode(mockIfStmt(value))
+
+            assertThat(node.getTopLevelValues()).containsExactly(value)
+        }
+
+        it("returns the key of a switch statement") {
+            val value = mockValue("value")
+            val node = JimpleNode(mockSwitchStmt(value))
+
+            assertThat(node.getTopLevelValues()).containsExactly(value)
+        }
+
+        it("returns the key of a switch statement") {
+            val invokeExpr = mockInvokeExpr("value")
+            val node = JimpleNode(mockInvokeStmt(invokeExpr))
+
+            assertThat(node.getTopLevelValues()).containsExactly(invokeExpr)
+        }
+
+        it("returns the operator of a return statement") {
+            val value = mockValue("value")
+            val node = JimpleNode(mockReturnStmt(value))
+
+            assertThat(node.getTopLevelValues()).containsExactly(value)
+        }
+
+        it("returns nothing for a goto statement") {
+            val node = JimpleNode(mockGotoStmt())
+
+            assertThat(node.getTopLevelValues()).isEmpty()
+        }
+
+        it("returns nothing for a return void statement") {
+            val node = JimpleNode(mockReturnVoidStmt())
+
+            assertThat(node.getTopLevelValues()).isEmpty()
+        }
+
+        it("returns nothing for an unrecognised statement") {
+            val node = JimpleNode(mockStmt())
+
+            assertThat(node.getTopLevelValues()).isEmpty()
+        }
+    }
+
     describe("when checking whether two Jimple nodes are equal") {
         fun mockDefinitionStmt(leftType: String, rightType: String): JimpleNode {
             val leftOp = mockValue(leftType)

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/SimpleSoot.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/SimpleSoot.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockito_kotlin.mock
 import soot.RefType
 import soot.SootMethod
 import soot.Value
+import soot.ValueBox
 import soot.jimple.InvokeExpr
 import soot.jimple.internal.AbstractBinopExpr
 import soot.jimple.internal.AbstractNegExpr
@@ -18,6 +19,7 @@ import soot.util.Switch
  */
 fun mockValue(type: String): Value = mock {
     on { it.type } doReturn RefType.v(type)
+    on { it.useBoxes } doReturn emptyList<ValueBox>()
     on { it.equivTo(any()) } doAnswer { answer ->
         val other = answer.arguments[0]
 
@@ -31,6 +33,7 @@ fun mockValue(type: String): Value = mock {
  */
 fun mockInvokeExpr(type: String): InvokeExpr = mock {
     on { it.type } doReturn RefType.v(type)
+    on { it.useBoxes } doReturn emptyList<ValueBox>()
     on { it.equivTo(any()) } doAnswer { answer ->
         val other = answer.arguments[0]
 


### PR DESCRIPTION
* Adds a `getValues` function in `JimpleNode` that recursively finds _all_ `Value`s in the node.
* Changes the `generalizedValuesAreEqual` function to use `getValues` rather than `getTopLevelValues`.
* Adds tests for both functions.
