### PR TITLE
Fix handling of method with only one throw stmt

### DIFF
--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
@@ -9,6 +9,7 @@ import org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.filters.Statemen
 import soot.Scene
 import soot.SootClass
 import soot.SootMethod
+import soot.jimple.Jimple
 import soot.options.Options
 import java.io.File
 
@@ -60,6 +61,8 @@ object LibraryUsageGraphGenerator : LibraryUsageGraphGenerator {
         val methodBody = method.retrieveActiveBody()
         val filters = listOf(StatementFilter(libraryProject), BranchStatementFilter(libraryProject))
         filters.forEach { it.apply(methodBody) }
+
+        if (methodBody.units.isEmpty()) methodBody.units.add(Jimple.v().newReturnVoidStmt())
 
         return ControlFlowGraphGenerator.create(methodBody)
             ?: throw IllegalStateException("Control flow graph could not be generated")

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/ThrowOtherExceptionTest.java
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/ThrowOtherExceptionTest.java
@@ -1,0 +1,7 @@
+package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.testclasses.users;
+
+public class ThrowOtherExceptionTest {
+    public void foo() {
+        throw new RuntimeException();
+    }
+}

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -294,6 +294,18 @@ internal class IntegrationTest : Spek({
             )
         }
 
+        it("converts a class containing a throw statement without library usage to a filtered cfg") {
+            val cfg = LibraryUsageGraphGenerator.generate(
+                libraryProject,
+                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ThrowOtherExceptionTest"))
+            )[1]
+
+            assertThatStructureMatches(
+                node<JReturnVoidStmt>(),
+                cfg
+            )
+        }
+
         it("converts a class containing a try-catch statement with library usage in the try block to a filtered cfg") {
             val cfg = LibraryUsageGraphGenerator.generate(
                 libraryProject,


### PR DESCRIPTION
At the moment, the implementation fails on methods with only one throw-statement in them, if the exception class is not part of the library. Fixes this and also adds a test case for it.