### PR TITLE
Exclude transitive dependency on slf4j-simple

### DIFF
--- a/modules/models/jimple-library-usage-graph/build.gradle
+++ b/modules/models/jimple-library-usage-graph/build.gradle
@@ -5,7 +5,9 @@ repositories {
 dependencies {
     compile project(":models")
 
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion
+    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+        exclude group: "org.slf4j", module: "slf4j-simple"
+    }
 
     testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
 }

--- a/modules/pipeline/jimple-evosuite-test-generator/build.gradle
+++ b/modules/pipeline/jimple-evosuite-test-generator/build.gradle
@@ -9,5 +9,7 @@ dependencies {
     compile project(":models:jimple-library-usage-graph")
 
     compile group: "org.evosuite", name: "evosuite-master", version: evosuiteMasterVersion
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion
+    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+        exclude group: "org.slf4j", module: "slf4j-simple"
+    }
 }

--- a/modules/pipeline/jimple-library-usage-graph-generator/build.gradle
+++ b/modules/pipeline/jimple-library-usage-graph-generator/build.gradle
@@ -8,7 +8,9 @@ dependencies {
     compile project(":models:java-project")
     compile project(":models:jimple-library-usage-graph")
 
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion
+    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+        exclude group: "org.slf4j", module: "slf4j-simple"
+    }
 
     testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
 }

--- a/modules/pipeline/jimple-pattern-filter/build.gradle
+++ b/modules/pipeline/jimple-pattern-filter/build.gradle
@@ -7,7 +7,9 @@ dependencies {
 
     compile project(":models:jimple-library-usage-graph")
 
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion
+    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+        exclude group: "org.slf4j", module: "slf4j-simple"
+    }
 
     testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
 }

--- a/modules/pipeline/prefix-span-pattern-detector/build.gradle
+++ b/modules/pipeline/prefix-span-pattern-detector/build.gradle
@@ -10,5 +10,7 @@ dependencies {
     testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
 
     integrationTestCompile project(":models:jimple-library-usage-graph")
-    integrationTestCompile group: "ca.mcgill.sable", name: "soot", version: sootVersion
+    integrationTestCompile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+        exclude group: "org.slf4j", module: "slf4j-simple"
+    }
 }


### PR DESCRIPTION
Fixes #95.

By simply excluding `slf4j-simple` as a transitive dependency via Soot, there are no more errors when determining the binder. The transitive dependency has been removed from Soot a few minutes ago in https://github.com/Sable/soot/pull/949, but this fix is not the ~sable~ stable release yet.
