### PR TITLE
Filter empty LUGs

### DIFF
--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
@@ -15,7 +15,7 @@ object ControlFlowGraphGenerator {
      * Creates the control flow graph of a method body.
      *
      * @param body a Soot method [Body]
-     * @return the [Body]'s root [Unit] wrapped in a [JimpleNode]
+     * @return the [Body]'s root [Stmt] wrapped in a [JimpleNode]
      */
     fun create(body: Body): JimpleNode? = BriefUnitGraph(body).let { transform(it, HashMap(), it.rootUnitIfExists()) }
 

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
@@ -1,6 +1,5 @@
 package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple
 
-import org.cafejojo.schaapi.models.Node
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import soot.Body
 import soot.Unit
@@ -16,25 +15,25 @@ object ControlFlowGraphGenerator {
      * Creates the control flow graph of a method body.
      *
      * @param body a Soot method [Body]
-     * @return the [Body]'s root [Unit] wrapped in a [Node]
+     * @return the [Body]'s root [Unit] wrapped in a [JimpleNode]
      */
-    fun create(body: Body): Node? = BriefUnitGraph(body).let { transform(it, HashMap(), it.rootUnitIfExists()) }
+    fun create(body: Body): JimpleNode? = BriefUnitGraph(body).let { transform(it, HashMap(), it.rootUnitIfExists()) }
 
     /**
-     * Wraps the control flow graph recursively within [Node] objects.
+     * Wraps the control flow graph recursively within [JimpleNode] objects.
      *
      * @param cfg the Soot control flow graph
      * @param mappedUnits visited units
      * @param unit the unit to wrap
-     * @param predecessor the predecessor of the [Node] to be created
-     * @return [unit] wrapped within a [Node]
+     * @param predecessor the predecessor of the [JimpleNode] to be created
+     * @return [unit] wrapped within a [JimpleNode]
      */
     private fun transform(
         cfg: UnitGraph,
-        mappedUnits: HashMap<Unit, Node>,
+        mappedUnits: HashMap<Unit, JimpleNode>,
         unit: Unit,
-        predecessor: Node? = null
-    ): Node? {
+        predecessor: JimpleNode? = null
+    ): JimpleNode? {
         if (mappedUnits.containsKey(unit)) {
             mappedUnits[unit]?.let { predecessor?.successors?.add(it) }
             return mappedUnits[unit]

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
@@ -2,6 +2,7 @@ package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple
 
 import org.cafejojo.schaapi.models.Node
 import org.cafejojo.schaapi.models.Project
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import org.cafejojo.schaapi.models.project.java.JavaProject
 import org.cafejojo.schaapi.pipeline.LibraryUsageGraphGenerator
 import org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.filters.BranchStatementFilter
@@ -10,6 +11,8 @@ import soot.Scene
 import soot.SootClass
 import soot.SootMethod
 import soot.jimple.Jimple
+import soot.jimple.ReturnStmt
+import soot.jimple.ReturnVoidStmt
 import soot.options.Options
 import java.io.File
 
@@ -27,6 +30,7 @@ object LibraryUsageGraphGenerator : LibraryUsageGraphGenerator {
             sootClass.methods
                 .filter { it.isConcrete }
                 .map { generateMethodGraph(libraryProject, it) }
+                .filter { it.statement !is ReturnStmt && it.statement !is ReturnVoidStmt }
         }
     }
 
@@ -57,7 +61,7 @@ object LibraryUsageGraphGenerator : LibraryUsageGraphGenerator {
      * @param method method for which to generate the graph
      * @return library usage graph
      */
-    private fun generateMethodGraph(libraryProject: JavaProject, method: SootMethod): Node {
+    private fun generateMethodGraph(libraryProject: JavaProject, method: SootMethod): JimpleNode {
         val methodBody = method.retrieveActiveBody()
         val filters = listOf(StatementFilter(libraryProject), BranchStatementFilter(libraryProject))
         filters.forEach { it.apply(methodBody) }

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/EmptyPatternTest.java
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/EmptyPatternTest.java
@@ -1,0 +1,11 @@
+package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.testclasses.users;
+
+public class EmptyPatternTest {
+    public void returnVoid() {
+    }
+
+    public String returnNonVoid() {
+        String a = "abc";
+        return a;
+    }
+}

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -22,8 +22,8 @@ private val testClassesClassPath = IntegrationTest::class.java.getResource("../.
 
 internal class IntegrationTest : Spek({
     describe("the integration of different components of the package for simple classes") {
-        it("converts a simple class to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a simple class to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.SimpleTest"))
             )[0]
@@ -38,14 +38,14 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
     }
 
     describe("the integration of different components of the package for classes containing if statements") {
-        it("converts a class containing an if with a library usage in the false-branch to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing an if with a library usage in the false-branch to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfFalseUseTest"))
             )[0]
@@ -65,12 +65,12 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
-        it("converts a class containing an if with a library usage in the true-branch to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing an if with a library usage in the true-branch to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfTrueUseTest"))
             )[0]
@@ -90,12 +90,12 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
-        it("converts a class containing an if with a library usage in both branches to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing an if with a library usage in both branches to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfBothUseTest"))
             )[0]
@@ -117,12 +117,12 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
-        it("converts a class containing an if with a library usage in both branches to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing an if with a library usage in both branches to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfNoUseTest"))
             )[0]
@@ -135,12 +135,12 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
         it("converts a class containing an if with no successors of the true/false branch") {
-            val lug = LibraryUsageGraphGenerator.generate(
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfNoEndTest"))
             )[0]
@@ -156,14 +156,14 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
     }
 
     describe("the integration of different components of the package for classes containing switch statements") {
-        it("converts a class containing a switch with a library usage in a branch to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a switch with a library usage in a branch to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.switchconditional.SwitchOneUseTest"
@@ -188,12 +188,12 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
-        it("converts a class containing a switch with a library usage in the default branch to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a switch with a library usage in the default branch to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.switchconditional.SwitchDefaultUseTest"
@@ -218,12 +218,12 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
-        it("converts a class containing a switch with no library usage in its branches to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a switch with no library usage in its branches to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.switchconditional.SwitchNoUseTest"
@@ -238,14 +238,14 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
     }
 
     describe("the integration of different components of the package for classes containing complex statements") {
         it("converts a class containing an arraylist and a lambda") {
-            val lug = LibraryUsageGraphGenerator.generate(
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ArrayListAndLambdaTest"))
             )[0]
@@ -256,12 +256,12 @@ internal class IntegrationTest : Spek({
                         node<JReturnStmt>()
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
         it("converts a class containing annotations") {
-            val lug = LibraryUsageGraphGenerator.generate(
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.AnnotationTest"))
             )[0]
@@ -274,12 +274,12 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
-        it("converts a class containing a throw statement with library usage to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a throw statement with library usage to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ThrowTest"))
             )[0]
@@ -290,31 +290,31 @@ internal class IntegrationTest : Spek({
                         node<JAssignStmt>()
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
-        it("does not convert a class containing a checked throw statement without library usage to a filtered lug") {
-            val lugs = LibraryUsageGraphGenerator.generate(
+        it("does not convert a class containing a checked throw statement without library usage") {
+            val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath,
                     listOf("$TEST_CLASSES_PACKAGE.users.ThrowOtherUncheckedExceptionTest"))
             )
 
-            assertThat(lugs).isEmpty()
+            assertThat(libraryUsageGraphs).isEmpty()
         }
 
-        it("does not convert a class containing an unchecked throw statement without library usage to a filtered lug") {
-            val lugs = LibraryUsageGraphGenerator.generate(
+        it("does not convert a class containing an unchecked throw statement without library usage") {
+            val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ThrowOtherCheckedExceptionTest"))
             )
 
-            assertThat(lugs).isEmpty()
+            assertThat(libraryUsageGraphs).isEmpty()
         }
 
-        it("converts a class containing a try-catch statement with library usage in the try block to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class with a try-catch with library usage in the try block to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.TryCatchTest"))
             )[0]
@@ -329,12 +329,12 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
-        it("converts a class containing a static class call to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a static class call to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.StaticTest"))
             )[0]
@@ -343,12 +343,12 @@ internal class IntegrationTest : Spek({
                 node<JInvokeStmt>(
                     node<JReturnVoidStmt>()
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
-        it("converts a class containing a nested loop to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a nested loop to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.LoopTest"))
             )[0]
@@ -381,12 +381,12 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
 
-        it("converts a class containing a loop with a continue statement to a filtered lug") {
-            val lug = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a loop with a continue statement to a library usage graph") {
+            val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.LoopContinueTest"))
             )[0]
@@ -419,36 +419,36 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                lug
+                libraryUsageGraph
             )
         }
     }
 
     describe("the integration of different components for types containing non-concrete method declarations") {
         it("ignores a non-concrete interface method declaration") {
-            val lugs = LibraryUsageGraphGenerator.generate(
+            val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.InterfaceTest"
                 ))
             )
 
-            assertThat(lugs).hasSize(0)
+            assertThat(libraryUsageGraphs).hasSize(0)
         }
 
         it("ignores a non-concrete abstract class method declaration") {
-            val lugs = LibraryUsageGraphGenerator.generate(
+            val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.AbstractClassTest"
                 ))
             )
 
-            assertThat(lugs).hasSize(0)
+            assertThat(libraryUsageGraphs).hasSize(0)
         }
 
         it("ignores a non-concrete abstract class method declaration") {
-            val lugs = LibraryUsageGraphGenerator.generate(
+            val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.PartiallyAbstractClassTest"
@@ -456,35 +456,35 @@ internal class IntegrationTest : Spek({
             )
 
             // Should contain the fully specified method (not the declared method)
-            assertThat(lugs).hasSize(1)
+            assertThat(libraryUsageGraphs).hasSize(1)
         }
     }
 
     describe("it filters non-'empty' patterns") {
         it("filters out patterns with only return statements") {
-            val lugs = LibraryUsageGraphGenerator.generate(
+            val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.EmptyPatternTest"
                 ))
             )
 
-            assertThat(lugs).isEmpty()
+            assertThat(libraryUsageGraphs).isEmpty()
         }
     }
 })
 
-private fun assertThatStructureMatches(structure: Node, lug: Node) {
-    assertThat(lug::class).isEqualTo(structure::class)
-    assertThat(lug.successors).hasSameSizeAs(structure.successors)
+private fun assertThatStructureMatches(structure: Node, libraryUsageGraph: Node) {
+    assertThat(libraryUsageGraph::class).isEqualTo(structure::class)
+    assertThat(libraryUsageGraph.successors).hasSameSizeAs(structure.successors)
 
-    if (lug is JimpleNode && structure is JimpleNode) {
-        assertThat(structure.statement).isInstanceOf(lug.statement::class.java)
+    if (libraryUsageGraph is JimpleNode && structure is JimpleNode) {
+        assertThat(structure.statement).isInstanceOf(libraryUsageGraph.statement::class.java)
     }
 
     structure.successors.forEachIndexed { index, structureSuccessor ->
         if (structureSuccessor !is PreviousBranchNode)
-            assertThatStructureMatches(structureSuccessor, lug.successors[index])
+            assertThatStructureMatches(structureSuccessor, libraryUsageGraph.successors[index])
     }
 }
 

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -22,11 +22,11 @@ private val testClassesClassPath = IntegrationTest::class.java.getResource("../.
 
 internal class IntegrationTest : Spek({
     describe("the integration of different components of the package for simple classes") {
-        it("converts a simple class to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a simple class to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.SimpleTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -38,17 +38,17 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
     }
 
     describe("the integration of different components of the package for classes containing if statements") {
-        it("converts a class containing an if with a library usage in the false-branch to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing an if with a library usage in the false-branch to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfFalseUseTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -65,15 +65,15 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
 
-        it("converts a class containing an if with a library usage in the true-branch to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing an if with a library usage in the true-branch to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfTrueUseTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -90,15 +90,15 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
 
-        it("converts a class containing an if with a library usage in both branches to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing an if with a library usage in both branches to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfBothUseTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -117,15 +117,15 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
 
-        it("converts a class containing an if with a library usage in both branches to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing an if with a library usage in both branches to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfNoUseTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -135,15 +135,15 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
 
         it("converts a class containing an if with no successors of the true/false branch") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfNoEndTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -156,19 +156,19 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
     }
 
     describe("the integration of different components of the package for classes containing switch statements") {
-        it("converts a class containing a switch with a library usage in a branch to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a switch with a library usage in a branch to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.switchconditional.SwitchOneUseTest"
                 ))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -188,17 +188,17 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
 
-        it("converts a class containing a switch with a library usage in the default branch to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a switch with a library usage in the default branch to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.switchconditional.SwitchDefaultUseTest"
                 ))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -218,17 +218,17 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
 
-        it("converts a class containing a switch with no library usage in its branches to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a switch with no library usage in its branches to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.switchconditional.SwitchNoUseTest"
                 ))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -238,17 +238,17 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
     }
 
     describe("the integration of different components of the package for classes containing complex statements") {
         it("converts a class containing an arraylist and a lambda") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ArrayListAndLambdaTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -256,15 +256,15 @@ internal class IntegrationTest : Spek({
                         node<JReturnStmt>()
                     )
                 ),
-                cfg
+                lug
             )
         }
 
         it("converts a class containing annotations") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.AnnotationTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -274,15 +274,15 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
 
-        it("converts a class containing a throw statement with library usage to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a throw statement with library usage to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ThrowTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -290,40 +290,34 @@ internal class IntegrationTest : Spek({
                         node<JAssignStmt>()
                     )
                 ),
-                cfg
+                lug
             )
         }
 
-        it("converts a class containing a checked throw statement without library usage to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("does not convert a class containing a checked throw statement without library usage to a filtered lug") {
+            val lugs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath,
                     listOf("$TEST_CLASSES_PACKAGE.users.ThrowOtherUncheckedExceptionTest"))
-            )[1]
-
-            assertThatStructureMatches(
-                node<JReturnVoidStmt>(),
-                cfg
             )
+
+            assertThat(lugs).isEmpty()
         }
 
-        it("converts a class containing an unchecked throw statement without library usage to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("does not convert a class containing an unchecked throw statement without library usage to a filtered lug") {
+            val lugs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ThrowOtherCheckedExceptionTest"))
-            )[1]
-
-            assertThatStructureMatches(
-                node<JReturnVoidStmt>(),
-                cfg
             )
+
+            assertThat(lugs).isEmpty()
         }
 
-        it("converts a class containing a try-catch statement with library usage in the try block to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a try-catch statement with library usage in the try block to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.TryCatchTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -335,29 +329,29 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
 
-        it("converts a class containing a static class call to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a static class call to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.StaticTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JInvokeStmt>(
                     node<JReturnVoidStmt>()
                 ),
-                cfg
+                lug
             )
         }
 
-        it("converts a class containing a nested loop to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a nested loop to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.LoopTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -387,15 +381,15 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
 
-        it("converts a class containing a loop with a continue statement to a filtered cfg") {
-            val cfg = LibraryUsageGraphGenerator.generate(
+        it("converts a class containing a loop with a continue statement to a filtered lug") {
+            val lug = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.LoopContinueTest"))
-            )[1]
+            )[0]
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
@@ -425,60 +419,72 @@ internal class IntegrationTest : Spek({
                         )
                     )
                 ),
-                cfg
+                lug
             )
         }
     }
 
     describe("the integration of different components for types containing non-concrete method declarations") {
         it("ignores a non-concrete interface method declaration") {
-            val methods = LibraryUsageGraphGenerator.generate(
+            val lugs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.InterfaceTest"
                 ))
             )
 
-            assertThat(methods.size).isEqualTo(0)
+            assertThat(lugs).hasSize(0)
         }
 
         it("ignores a non-concrete abstract class method declaration") {
-            val methods = LibraryUsageGraphGenerator.generate(
+            val lugs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.AbstractClassTest"
                 ))
             )
 
-            // Should only contain the implicit constructor
-            assertThat(methods.size).isEqualTo(1)
+            assertThat(lugs).hasSize(0)
         }
 
         it("ignores a non-concrete abstract class method declaration") {
-            val methods = LibraryUsageGraphGenerator.generate(
+            val lugs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath, listOf(
                     "$TEST_CLASSES_PACKAGE.users.PartiallyAbstractClassTest"
                 ))
             )
 
-            // Should contain the implicit constructor and the fully specified method (not the declared method)
-            assertThat(methods.size).isEqualTo(2)
+            // Should contain the fully specified method (not the declared method)
+            assertThat(lugs).hasSize(1)
+        }
+    }
+
+    describe("it filters non-'empty' patterns") {
+        it("filters out patterns with only return statements") {
+            val lugs = LibraryUsageGraphGenerator.generate(
+                libraryProject,
+                TestProject(testClassesClassPath, listOf(
+                    "$TEST_CLASSES_PACKAGE.users.EmptyPatternTest"
+                ))
+            )
+
+            assertThat(lugs).isEmpty()
         }
     }
 })
 
-private fun assertThatStructureMatches(structure: Node, cfg: Node) {
-    assertThat(cfg::class).isEqualTo(structure::class)
-    assertThat(cfg.successors).hasSameSizeAs(structure.successors)
+private fun assertThatStructureMatches(structure: Node, lug: Node) {
+    assertThat(lug::class).isEqualTo(structure::class)
+    assertThat(lug.successors).hasSameSizeAs(structure.successors)
 
-    if (cfg is JimpleNode && structure is JimpleNode) {
-        assertThat(structure.statement).isInstanceOf(cfg.statement::class.java)
+    if (lug is JimpleNode && structure is JimpleNode) {
+        assertThat(structure.statement).isInstanceOf(lug.statement::class.java)
     }
 
     structure.successors.forEachIndexed { index, structureSuccessor ->
         if (structureSuccessor !is PreviousBranchNode)
-            assertThatStructureMatches(structureSuccessor, cfg.successors[index])
+            assertThatStructureMatches(structureSuccessor, lug.successors[index])
     }
 }
 


### PR DESCRIPTION
This PR:
* Filters LUGs with only returns
* Fixes assertions in the LUG integration test
* Changes `cfg` to `lug` in the integration test