### PR TITLE
Use correct POM file in project compiler

### DIFF
--- a/modules/pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javamaven/ProjectCompiler.kt
+++ b/modules/pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javamaven/ProjectCompiler.kt
@@ -38,7 +38,7 @@ class ProjectCompiler : ProjectCompiler {
             goals = listOf("clean", "install", "dependency:copy-dependencies")
             isBatchMode = true
             javaHome = File(System.getProperty("java.home"))
-            pomFile = pomFile
+            pomFile = project.pomFile
         }
 
         val invoker = DefaultInvoker().apply {


### PR DESCRIPTION
Instead of doing `setPomFile(getPomFile())` I thought it would be nice to use the actual POM file of the project :wink:. (bug introduced after moving the compilation process out of `JavaMavenProject`)