### PR TITLE
Enable creation of phantom refs for JARs without dependencies

### DIFF
--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
@@ -44,6 +44,7 @@ object LibraryUsageGraphGenerator : LibraryUsageGraphGenerator {
             classpath
         ).joinToString(File.pathSeparator)
         Options.v().set_whole_program(true)
+        Options.v().set_allow_phantom_refs(true)
 
         Scene.v().loadNecessaryClasses()
 


### PR DESCRIPTION
This PR enables the creation of phantom refs for JARs without dependencies.