### PR TITLE
Use OS path separator to separate user projects

### DIFF
--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -85,7 +85,7 @@ private fun buildOptions(): Options =
             .longOpt("user_dirs")
             .desc("The user directories, separated by semi-colons.")
             .hasArgs()
-            .valueSeparator(';')
+            .valueSeparator(File.pathSeparatorChar)
             .required()
             .build())
         .addOption(Option

--- a/modules/application/src/test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
+++ b/modules/application/src/test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
@@ -28,7 +28,7 @@ internal class SchaapiSmokeTest : Spek({
         main(arrayOf(
             "-o", target.absolutePath,
             "-l", getResourcePath("/library/"),
-            "-u", "${getResourcePath("/user/a/")};${getResourcePath("/user/b/")}",
+            "-u", getResourcePath("/user/a/") + File.pathSeparatorChar + getResourcePath("/user/b/"),
             "--maven_dir", mavenDir.absolutePath,
             "--pattern_detector_minimum_count", "1",
             "--test_generator_timeout", "3"


### PR DESCRIPTION
Rather than always using `;` to separate the paths to the user projects, the CLI will now use the OS's default path separator character.
