### PR TITLE
Change behavior of connectLeavesToExitNode

### DIFF
--- a/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/PathEnumerator.kt
+++ b/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/PathEnumerator.kt
@@ -65,7 +65,7 @@ internal fun Node.connectLeavesToExitNode() = ExitNode().also { exitNode ->
     iterator().asSequence().toList().let { allNodes ->
         allNodes.filter { it.successors.isEmpty() }
             .let { if (it.isEmpty()) allNodes.takeLast(1) else it }
-        .forEach { it.successors.add(exitNode) }
+            .forEach { it.successors.add(exitNode) }
     }
 }
 

--- a/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/PathEnumerator.kt
+++ b/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/PathEnumerator.kt
@@ -61,13 +61,14 @@ class ExitNode(successors: MutableList<Node> = mutableListOf()) : SimpleNode(suc
 /**
  * Connects all nodes with no successors (connected to this node) with a single [ExitNode].
  */
-internal fun Node.connectLeavesToExitNode() = ExitNode().also { exitNode ->
-    iterator().asSequence().toList().let { allNodes ->
-        allNodes.filter { it.successors.isEmpty() }
-            .let { if (it.isEmpty()) allNodes.takeLast(1) else it }
-            .forEach { it.successors.add(exitNode) }
+internal fun Node.connectLeavesToExitNode() =
+    ExitNode().also { exitNode ->
+        iterator().asSequence().toList().let { allNodes ->
+            allNodes.filter { it.successors.isEmpty() }
+                .let { if (it.isEmpty()) allNodes.takeLast(1) else it }
+                .forEach { it.successors.add(exitNode) }
+        }
     }
-}
 
 /**
  * Removes all [ExitNode]s from the graph of nodes connected to this node.

--- a/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/PathEnumerator.kt
+++ b/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/PathEnumerator.kt
@@ -62,14 +62,11 @@ class ExitNode(successors: MutableList<Node> = mutableListOf()) : SimpleNode(suc
  * Connects all nodes with no successors (connected to this node) with a single [ExitNode].
  */
 internal fun Node.connectLeavesToExitNode() = ExitNode().also { exitNode ->
-    iterator().asSequence().toList()
-        .filter { it.successors.isEmpty() }
-        .also {
-            if (it.count() == 0) {
-                throw IllegalStateException("No sink nodes could be identified in the control flow graph.")
-            }
-        }
+    iterator().asSequence().toList().let { allNodes ->
+        allNodes.filter { it.successors.isEmpty() }
+            .let { if (it.isEmpty()) allNodes.takeLast(1) else it }
         .forEach { it.successors.add(exitNode) }
+    }
 }
 
 /**

--- a/modules/pipeline/prefix-span-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/PathEnumeratorTest.kt
+++ b/modules/pipeline/prefix-span-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/PathEnumeratorTest.kt
@@ -1,7 +1,6 @@
 package org.cafejojo.schaapi.pipeline.patterndetector.prefixspan
 
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.cafejojo.schaapi.models.SimpleNode
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
@@ -154,9 +153,8 @@ internal class PathEnumeratorTest : Spek({
             node2.successors.add(node3)
             node3.successors.add(node2)
 
-            assertThatThrownBy {
-                node1.connectLeavesToExitNode()
-            }.isInstanceOf(IllegalStateException::class.java)
+            val exitNode = node1.connectLeavesToExitNode()
+            assertThat(node3.successors).contains(exitNode)
         }
     }
 


### PR DESCRIPTION
Previously, this code failed when no sink nodes could be found. This PR changes this behavior to instead select the last node of the iterated list of nodes, to accommodate scenarios found in real projects.