### PR TITLE
Gradle failure messages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,10 @@ allprojects {
 
     // JUnit / Spek
     test {
+        testLogging {
+            exceptionFormat = "full"
+        }
+
         useJUnitPlatform() {
             includeEngines "spek"
         }

--- a/modules/application/src/test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
+++ b/modules/application/src/test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
@@ -26,7 +26,7 @@ internal class SchaapiSmokeTest : Spek({
 
     it("generates a test class from the patterns in a project using a library") {
         main(arrayOf(
-            "-o", target.absolutePath,
+            "-a", target.absolutePath,
             "-l", getResourcePath("/library/"),
             "-u", "${getResourcePath("/user/a/")};${getResourcePath("/user/b/")}",
             "--maven_dir", mavenDir.absolutePath,

--- a/modules/application/src/test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
+++ b/modules/application/src/test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
@@ -26,7 +26,7 @@ internal class SchaapiSmokeTest : Spek({
 
     it("generates a test class from the patterns in a project using a library") {
         main(arrayOf(
-            "-a", target.absolutePath,
+            "-o", target.absolutePath,
             "-l", getResourcePath("/library/"),
             "-u", "${getResourcePath("/user/a/")};${getResourcePath("/user/b/")}",
             "--maven_dir", mavenDir.absolutePath,


### PR DESCRIPTION
Enables Gradle exception logging.

Before | After
:---:|:---:
![before](https://user-images.githubusercontent.com/13442533/40547477-47702826-6032-11e8-9448-a6a338a60430.png)  |  ![after](https://user-images.githubusercontent.com/13442533/40547486-4da66426-6032-11e8-81d8-5cac16f6a859.png)
