### PR TITLE
Refactor pathContainsSequence method

### DIFF
--- a/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/FrequentSequenceFinder.kt
+++ b/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/FrequentSequenceFinder.kt
@@ -116,10 +116,10 @@ class FrequentSequenceFinder(
      */
     internal fun pathContainsSequence(path: List<Node>, sequence: List<Node>) =
         path.indices.any { pathIndex ->
-            !sequence.filterIndexed { sequenceIndex, sequenceNode ->
+            !sequence.indices.any { sequenceIndex ->
                 pathIndex + sequenceIndex >= path.size ||
-                    !comparator.satisfies(path[pathIndex + sequenceIndex], sequenceNode)
-            }.any()
+                    !comparator.satisfies(path[pathIndex + sequenceIndex], sequence[sequenceIndex])
+            }
         }
 
     private fun generateFrequentItems(minimumCount: Int) {

--- a/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/FrequentSequenceFinder.kt
+++ b/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/FrequentSequenceFinder.kt
@@ -114,21 +114,13 @@ class FrequentSequenceFinder(
      * @param sequence the sequence which may be contained in path
      * @return true if path contains the given sequence
      */
-    internal fun pathContainsSequence(path: List<Node>, sequence: List<Node>): Boolean {
-        for (pathIndex in path.indices) {
-            for (sequenceIndex in sequence.indices) {
-                if (pathIndex + sequenceIndex >= path.size ||
-                    !comparator.satisfies(path[pathIndex + sequenceIndex], sequence[sequenceIndex])
-                ) {
-                    break
-                }
-
-                if (sequenceIndex == sequence.size - 1) return true
-            }
+    internal fun pathContainsSequence(path: List<Node>, sequence: List<Node>) =
+        path.indices.any { pathIndex ->
+            !sequence.filterIndexed { sequenceIndex, sequenceNode ->
+                pathIndex + sequenceIndex >= path.size ||
+                    !comparator.satisfies(path[pathIndex + sequenceIndex], sequenceNode)
+            }.any()
         }
-
-        return false
-    }
 
     private fun generateFrequentItems(minimumCount: Int) {
         val nodeCounts: MutableMap<Node, Int> = CustomEqualsHashMap(Node.Companion::equiv, Node::equivHashCode)


### PR DESCRIPTION
I was not a huge fan of the code of this method (because of the for loops and stuff), so I refactored it a bit to be more kotlin-y. In 'theory' it should act exactly the same as the old implementation.