### PR TITLE
Move PathEnumerator to models module

### DIFF
--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathEnumerator.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathEnumerator.kt
@@ -1,7 +1,5 @@
-package org.cafejojo.schaapi.pipeline.patterndetector.prefixspan
+package org.cafejojo.schaapi.models
 
-import org.cafejojo.schaapi.models.Node
-import org.cafejojo.schaapi.models.SimpleNode
 import java.util.Stack
 
 /**

--- a/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/PathEnumeratorTest.kt
+++ b/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/PathEnumeratorTest.kt
@@ -1,7 +1,6 @@
-package org.cafejojo.schaapi.pipeline.patterndetector.prefixspan
+package org.cafejojo.schaapi.models
 
 import org.assertj.core.api.Assertions.assertThat
-import org.cafejojo.schaapi.models.SimpleNode
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it

--- a/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/PatternDetector.kt
+++ b/modules/pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/prefixspan/PatternDetector.kt
@@ -2,6 +2,7 @@ package org.cafejojo.schaapi.pipeline.patterndetector.prefixspan
 
 import org.cafejojo.schaapi.models.GeneralizedNodeComparator
 import org.cafejojo.schaapi.models.Node
+import org.cafejojo.schaapi.models.PathEnumerator
 import org.cafejojo.schaapi.pipeline.Pattern
 import org.cafejojo.schaapi.pipeline.PatternDetector
 


### PR DESCRIPTION
This move will allow us to reuse it in other algorithmic implementations, without copying it.