### PR TITLE
Filter out non-library returns in branches

### DIFF
--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/BranchStatementFilter.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/BranchStatementFilter.kt
@@ -98,7 +98,7 @@ class BranchStatementFilter(project: JavaProject) : Filter {
         }
 
         private fun branchesContainOnlyReturnOrThrowStatements(branchTargets: List<Unit>) = branchTargets.all {
-            cfg.getSuccsOf(it).size == 0 && when (it) {
+            cfg.getSuccsOf(it).isEmpty() && when (it) {
                 is ReturnStmt -> !valueFilter.retain(it.op)
                 is ReturnVoidStmt -> true
                 is ThrowStmt -> !valueFilter.retain(it.op)

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/ifconditional/IfReturnsTest.java
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/testclasses/users/ifconditional/IfReturnsTest.java
@@ -1,0 +1,14 @@
+package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.testclasses.users.ifconditional;
+
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class IfReturnsTest {
+    public Object test() {
+        boolean a = true;
+        if (a) {
+            return new LinkedBlockingQueue();
+        } else {
+            return new LinkedBlockingQueue();
+        }
+    }
+}

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -149,16 +149,20 @@ internal class IntegrationTest : Spek({
             assertThatStructureMatches(
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
-                        node<JAssignStmt>(
-                            node<JIfStmt>(
-                                node<JReturnStmt>(),
-                                node<JReturnStmt>()
-                            )
-                        )
+                        node<JAssignStmt>()
                     )
                 ),
                 libraryUsageGraph
             )
+        }
+
+        it("filters out a class containing an if with method exitting return statements") {
+            val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
+                libraryProject,
+                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfReturnsTest"))
+            )
+
+            assertThat(libraryUsageGraphs).isEmpty()
         }
     }
 


### PR DESCRIPTION
This PR filters out non library return/throw statements that were retained by the value filter.