### PR TITLE
Set up Web module using Spring

### DIFF
--- a/modules/web/build.gradle
+++ b/modules/web/build.gradle
@@ -1,0 +1,20 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+	dependencies {
+		classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+	}
+}
+
+apply plugin: "org.springframework.boot"
+apply plugin: "io.spring.dependency-management"
+
+dependencies {
+    compile("com.fasterxml.jackson.module:jackson-module-kotlin")
+    compile("org.jetbrains.kotlin:kotlin-reflect")
+    compile("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+    compile("org.springframework.boot:spring-boot-starter-web")
+
+    testCompile("org.springframework.boot:spring-boot-starter-test")
+}

--- a/modules/web/gradle.properties
+++ b/modules/web/gradle.properties
@@ -1,0 +1,1 @@
+springBootVersion=2.0.2.RELEASE

--- a/modules/web/gradle.properties
+++ b/modules/web/gradle.properties
@@ -1,1 +1,1 @@
-springBootVersion=2.0.2.RELEASE
+springBootVersion = 2.0.2.RELEASE

--- a/modules/web/src/main/kotlin/org/cafejojo/schaapi/web/HomeController.kt
+++ b/modules/web/src/main/kotlin/org/cafejojo/schaapi/web/HomeController.kt
@@ -1,0 +1,21 @@
+package org.cafejojo.schaapi.web
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+
+/**
+ * Controller for the home page.
+ */
+@Controller
+@EnableAutoConfiguration
+class HomeController {
+    /**
+     * Returns the contents of the home page.
+     */
+    @RequestMapping("/")
+    @ResponseBody
+    @Suppress("FunctionOnlyReturningConstant")
+    fun home() = "Welcome to Schaapi"
+}

--- a/modules/web/src/main/kotlin/org/cafejojo/schaapi/web/WebApplication.kt
+++ b/modules/web/src/main/kotlin/org/cafejojo/schaapi/web/WebApplication.kt
@@ -1,0 +1,18 @@
+package org.cafejojo.schaapi.web
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+/**
+ * The web application.
+ */
+@SpringBootApplication
+class WebApplication
+
+/**
+ * Starts the web application.
+ */
+@Suppress("SpreadOperator")
+fun main(args: Array<String>) {
+    runApplication<WebApplication>(*args)
+}

--- a/modules/web/src/test/kotlin/org/cafejojo/schaapi/web/HomeTest.kt
+++ b/modules/web/src/test/kotlin/org/cafejojo/schaapi/web/HomeTest.kt
@@ -1,0 +1,25 @@
+package org.cafejojo.schaapi.web
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment
+import org.springframework.boot.test.web.client.TestRestTemplate
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class HomeTest {
+    @Autowired
+    private lateinit var restTemplate: TestRestTemplate
+
+    @Test
+    fun `it can retrieve the contents of the homepage`() {
+        val body = restTemplate.getForObject("/", String::class.java)
+
+        assertThat(body).isEqualTo("Welcome to Schaapi")
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -26,3 +26,5 @@ includeModule "pipeline", "jimple-library-usage-graph-generator"
 includeModule "pipeline", "jimple-pattern-filter"
 includeModule "pipeline", "prefix-span-pattern-detector"
 includeModule "pipeline", "spam-pattern-detector"
+
+includeModule "web"


### PR DESCRIPTION
This PR adds Spring in a separate web module.

The controllers for the web application will be part of relevant modules (e.g. a module for reporting to developers can define its own endpoints).

For testing I had to switch back to JUnit, since there's no nice and stable to way to test Spring apps with Spek, see issue 50 on https://github.com/spekframework/spek.