### PR TITLE
Move Java projects out of `java` package

### DIFF
--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -7,8 +7,8 @@ import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
 import org.apache.commons.cli.ParseException
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
-import org.cafejojo.schaapi.models.project.java.JavaJarProject
-import org.cafejojo.schaapi.models.project.java.JavaMavenProject
+import org.cafejojo.schaapi.models.project.JavaJarProject
+import org.cafejojo.schaapi.models.project.JavaMavenProject
 import org.cafejojo.schaapi.pipeline.PatternFilter
 import org.cafejojo.schaapi.pipeline.patterndetector.prefixspan.PatternDetector
 import org.cafejojo.schaapi.pipeline.patternfilter.jimple.IncompleteInitPatternFilterRule

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaJarProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaJarProject.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.models.project.java
+package org.cafejojo.schaapi.models.project
 
 import java.io.File
 

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaMavenProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaMavenProject.kt
@@ -1,6 +1,5 @@
-package org.cafejojo.schaapi.models.project.java
+package org.cafejojo.schaapi.models.project
 
-import org.cafejojo.schaapi.models.project.MavenProject
 import java.io.File
 
 /**

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaProject.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.models.project.java
+package org.cafejojo.schaapi.models.project
 
 import org.cafejojo.schaapi.models.Project
 import java.io.File

--- a/modules/pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javajar/ProjectCompiler.kt
+++ b/modules/pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javajar/ProjectCompiler.kt
@@ -1,7 +1,7 @@
 package org.cafejojo.schaapi.pipeline.projectcompiler.javajar
 
 import org.cafejojo.schaapi.models.Project
-import org.cafejojo.schaapi.models.project.java.JavaJarProject
+import org.cafejojo.schaapi.models.project.JavaJarProject
 import org.cafejojo.schaapi.pipeline.ProjectCompiler
 import java.io.FileInputStream
 import java.util.jar.JarInputStream

--- a/modules/pipeline/java-jar-project-compiler/src/test/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javajar/ProjectCompilerTest.kt
+++ b/modules/pipeline/java-jar-project-compiler/src/test/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javajar/ProjectCompilerTest.kt
@@ -1,7 +1,7 @@
 package org.cafejojo.schaapi.pipeline.projectcompiler.javajar
 
 import org.assertj.core.api.Assertions.assertThat
-import org.cafejojo.schaapi.models.project.java.JavaJarProject
+import org.cafejojo.schaapi.models.project.JavaJarProject
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it

--- a/modules/pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javamaven/ProjectCompiler.kt
+++ b/modules/pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javamaven/ProjectCompiler.kt
@@ -3,7 +3,7 @@ package org.cafejojo.schaapi.pipeline.projectcompiler.javamaven
 import org.apache.maven.shared.invoker.DefaultInvocationRequest
 import org.apache.maven.shared.invoker.DefaultInvoker
 import org.cafejojo.schaapi.models.Project
-import org.cafejojo.schaapi.models.project.java.JavaMavenProject
+import org.cafejojo.schaapi.models.project.JavaMavenProject
 import org.cafejojo.schaapi.pipeline.ProjectCompiler
 import java.io.File
 

--- a/modules/pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javamaven/ProjectCompilerTest.kt
+++ b/modules/pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javamaven/ProjectCompilerTest.kt
@@ -1,7 +1,7 @@
 package org.cafejojo.schaapi.pipeline.projectcompiler.javamaven
 
 import org.assertj.core.api.Assertions.assertThat
-import org.cafejojo.schaapi.models.project.java.JavaMavenProject
+import org.cafejojo.schaapi.models.project.JavaMavenProject
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it

--- a/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/TestGenerator.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/TestGenerator.kt
@@ -1,6 +1,6 @@
 package org.cafejojo.schaapi.pipeline.testgenerator.jimpleevosuite
 
-import org.cafejojo.schaapi.models.project.java.JavaProject
+import org.cafejojo.schaapi.models.project.JavaProject
 import org.cafejojo.schaapi.pipeline.Pattern
 import org.cafejojo.schaapi.pipeline.TestGenerator
 import java.io.File

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
@@ -4,7 +4,7 @@ import org.cafejojo.schaapi.models.DfsIterator
 import org.cafejojo.schaapi.models.Node
 import org.cafejojo.schaapi.models.Project
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
-import org.cafejojo.schaapi.models.project.java.JavaProject
+import org.cafejojo.schaapi.models.project.JavaProject
 import org.cafejojo.schaapi.pipeline.LibraryUsageGraphGenerator
 import org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.filters.BranchStatementFilter
 import org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.filters.StatementFilter

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/BranchStatementFilter.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/BranchStatementFilter.kt
@@ -1,6 +1,6 @@
 package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.filters
 
-import org.cafejojo.schaapi.models.project.java.JavaProject
+import org.cafejojo.schaapi.models.project.JavaProject
 import soot.Body
 import soot.Unit
 import soot.Value

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
@@ -1,6 +1,6 @@
 package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.filters
 
-import org.cafejojo.schaapi.models.project.java.JavaProject
+import org.cafejojo.schaapi.models.project.JavaProject
 import soot.Body
 import soot.Unit
 import soot.jimple.DefinitionStmt

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -1,6 +1,6 @@
 package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple.filters
 
-import org.cafejojo.schaapi.models.project.java.JavaProject
+import org.cafejojo.schaapi.models.project.JavaProject
 import soot.EquivalentValue
 import soot.Immediate
 import soot.Local

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/Helpers.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/Helpers.kt
@@ -1,6 +1,6 @@
 package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple
 
-import org.cafejojo.schaapi.models.project.java.JavaProject
+import org.cafejojo.schaapi.models.project.JavaProject
 import java.io.File
 
 internal data class TestProject(


### PR DESCRIPTION
The `java` package inside the `java-maven-project` module is redundant because the name of the module already specifies that no other languages will be supported. Therefore, the classes in the `java` package have been moved up one level.