### PR TITLE
Add Project Generics to Pipeline

### DIFF
--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/Pipeline.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/Pipeline.kt
@@ -11,10 +11,10 @@ import org.cafejojo.schaapi.pipeline.TestGenerator
 /**
  * Represents the complete Schaapi pipeline.
  */
-class Pipeline<N : Node>(
-    private val libraryProjectCompiler: ProjectCompiler,
-    private val userProjectCompiler: ProjectCompiler,
-    private val libraryUsageGraphGenerator: LibraryUsageGraphGenerator<N>,
+class Pipeline<N : Node, LP : Project, UP : Project>(
+    private val libraryProjectCompiler: ProjectCompiler<LP>,
+    private val userProjectCompiler: ProjectCompiler<UP>,
+    private val libraryUsageGraphGenerator: LibraryUsageGraphGenerator<LP, UP, N>,
     private val patternDetector: PatternDetector<N>,
     private val patternFilter: PatternFilter<N>,
     private val testGenerator: TestGenerator<N>
@@ -22,7 +22,7 @@ class Pipeline<N : Node>(
     /**
      * Executes all steps in the pipeline.
      */
-    fun run(projects: List<Project>, libraryProject: Project) {
+    fun run(projects: List<UP>, libraryProject: LP) {
         libraryProjectCompiler.compile(libraryProject)
 
         projects.map { userProjectCompiler.compile(it) }

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/Pipeline.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/Pipeline.kt
@@ -11,7 +11,7 @@ import org.cafejojo.schaapi.pipeline.TestGenerator
 /**
  * Represents the complete Schaapi pipeline.
  */
-class Pipeline<N : Node, LP : Project, UP : Project>(
+class Pipeline<LP : Project, UP : Project, N : Node>(
     private val libraryProjectCompiler: ProjectCompiler<LP>,
     private val userProjectCompiler: ProjectCompiler<UP>,
     private val libraryUsageGraphGenerator: LibraryUsageGraphGenerator<LP, UP, N>,

--- a/modules/pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/ProjectMiner.kt
+++ b/modules/pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/ProjectMiner.kt
@@ -10,7 +10,7 @@ import java.io.File
  * @property projectPacker the packer that transforms [File]s into projects. It may be invoked on both directories and
  * files.
  */
-class ProjectMiner(private val projectPacker: (File) -> Project) : ProjectMiner<SearchOptions> {
-    override fun mine(searchOptions: SearchOptions) =
+class ProjectMiner<P : Project>(private val projectPacker: (File) -> P) : ProjectMiner<P, SearchOptions<P>> {
+    override fun mine(searchOptions: SearchOptions<P>) =
         searchOptions.directory.listFiles()?.map { projectPacker(it) } ?: emptyList()
 }

--- a/modules/pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/ProjectMiner.kt
+++ b/modules/pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/ProjectMiner.kt
@@ -10,7 +10,7 @@ import java.io.File
  * @property projectPacker the packer that transforms [File]s into projects. It may be invoked on both directories and
  * files.
  */
-class ProjectMiner<P : Project>(private val projectPacker: (File) -> P) : ProjectMiner<P, SearchOptions<P>> {
+class ProjectMiner<P : Project>(private val projectPacker: (File) -> P) : ProjectMiner<SearchOptions<P>, P> {
     override fun mine(searchOptions: SearchOptions<P>) =
         searchOptions.directory.listFiles()?.map { projectPacker(it) } ?: emptyList()
 }

--- a/modules/pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/SearchOptions.kt
+++ b/modules/pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/SearchOptions.kt
@@ -1,5 +1,6 @@
 package org.cafejojo.schaapi.pipeline.miner.directory
 
+import org.cafejojo.schaapi.models.Project
 import org.cafejojo.schaapi.pipeline.SearchOptions
 import java.io.File
 
@@ -8,6 +9,4 @@ import java.io.File
  *
  * @property directory the directory containing the projects to be mined
  */
-class SearchOptions(
-    val directory: File
-) : SearchOptions
+class SearchOptions<P : Project>(val directory: File) : SearchOptions<P>

--- a/modules/pipeline/directory-project-miner/src/test/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/ProjectMinerTest.kt
+++ b/modules/pipeline/directory-project-miner/src/test/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/ProjectMinerTest.kt
@@ -17,7 +17,7 @@ internal class ProjectMinerTest : Spek({
         File(URLDecoder.decode(ProjectMinerTest::class.java.getResource(path).path, "UTF-8"))
 
     describe("directory project miner") {
-        lateinit var miner: ProjectMiner
+        lateinit var miner: ProjectMiner<Project>
         lateinit var packer: (File) -> Project
 
         beforeEachTest {
@@ -36,7 +36,7 @@ internal class ProjectMinerTest : Spek({
         it("finds a single file-based project") {
             miner.mine(SearchOptions(getResourceAsFile("/one-file-project")))
 
-            verify(packer, times(1)).invoke(any())
+            verify(packer).invoke(any())
         }
 
         it("finds multiple file-based projects") {
@@ -48,7 +48,7 @@ internal class ProjectMinerTest : Spek({
         it("finds a single directory-based project") {
             miner.mine(SearchOptions(getResourceAsFile("/one-directory-project")))
 
-            verify(packer, times(1)).invoke(any())
+            verify(packer).invoke(any())
         }
 
         it("finds multiple directory-based projects") {

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/GitHubProjectDownloader.kt
@@ -19,10 +19,10 @@ import kotlin.streams.toList
  * @property projectPacker packer which determines what type of [Project] to wrap the project directory in
  */
 @Suppress("PrintStackTrace") // TODO use searchContent logger
-class GitHubProjectDownloader(
+class GitHubProjectDownloader<P : Project>(
     private val projectNames: Collection<String>,
     private val outputDirectory: File,
-    private val projectPacker: (File) -> Project
+    private val projectPacker: (File) -> P
 ) {
     /**
      * Starts downloading repositories.
@@ -35,14 +35,14 @@ class GitHubProjectDownloader(
      *
      * @return list of [Project]s which reference the downloaded projects from GitHub
      */
-    fun download(): List<Project> =
+    fun download(): List<P> =
         projectNames
             .parallelStream()
             .map { downloadAndSaveProject(it) }
             .toList()
             .filterNotNull()
 
-    private fun downloadAndSaveProject(projectName: String): Project? {
+    private fun downloadAndSaveProject(projectName: String): P? {
         val connection = getConnection(projectName) ?: return null
 
         try {

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/ProjectMiner.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/ProjectMiner.kt
@@ -24,7 +24,7 @@ class ProjectMiner<P : Project>(
     private val username: String, private val password: String,
     private val outputDirectory: File,
     private val projectPacker: (File) -> P
-) : ProjectMiner<P, GitHubSearchOptions<P>> {
+) : ProjectMiner<GitHubSearchOptions<P>, P> {
     init {
         if (!outputDirectory.isDirectory) outputDirectory.mkdirs()
     }

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/ProjectMiner.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/ProjectMiner.kt
@@ -24,7 +24,7 @@ class ProjectMiner<P : Project>(
     private val username: String, private val password: String,
     private val outputDirectory: File,
     private val projectPacker: (File) -> P
-) : ProjectMiner<GitHubSearchOptions<P>, P> {
+) : ProjectMiner<P, GitHubSearchOptions<P>> {
     init {
         if (!outputDirectory.isDirectory) outputDirectory.mkdirs()
     }

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/ProjectMiner.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/ProjectMiner.kt
@@ -20,11 +20,11 @@ import java.io.File
  * @property projectPacker packer which determines what type of [Project] to wrap the project directory in
  */
 @Suppress("PrintStackTrace") // TODO use searchContent logger
-class ProjectMiner(
+class ProjectMiner<P : Project>(
     private val username: String, private val password: String,
     private val outputDirectory: File,
-    private val projectPacker: (File) -> Project
-) : ProjectMiner<GitHubSearchOptions> {
+    private val projectPacker: (File) -> P
+) : ProjectMiner<GitHubSearchOptions<P>, P> {
     init {
         if (!outputDirectory.isDirectory) outputDirectory.mkdirs()
     }
@@ -37,7 +37,7 @@ class ProjectMiner(
      * @return list of [Project]s which likely depend on said library
      * @see GitHubProjectDownloader.download
      */
-    override fun mine(searchOptions: GitHubSearchOptions): List<Project> {
+    override fun mine(searchOptions: GitHubSearchOptions<P>): List<P> {
         val gitHub = GitHub.connectUsingPassword(username, password)
 
         require(!gitHub.isOffline) { "Unable to connect to GitHub." }

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/SearchOptions.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/SearchOptions.kt
@@ -28,7 +28,7 @@ class MavenProjectSearchOptions(
     private val groupId: String,
     private val artifactId: String,
     private val version: String
-) : GithubSearchOptions<MavenProject> {
+) : GitHubSearchOptions<MavenProject> {
     override fun searchContent(gitHub: GitHub): List<String> =
         gitHub.searchContent()
             .apply {

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/SearchOptions.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/SearchOptions.kt
@@ -1,12 +1,14 @@
 package org.cafejojo.schaapi.pipeline.miner.github
 
+import org.cafejojo.schaapi.models.Project
+import org.cafejojo.schaapi.models.project.MavenProject
 import org.cafejojo.schaapi.pipeline.SearchOptions
 import org.kohsuke.github.GitHub
 
 /**
  * Represents options used to mine [GitHub].
  */
-interface GitHubSearchOptions : SearchOptions {
+interface GitHubSearchOptions<P : Project> : SearchOptions<P> {
     /**
      * Search content on GitHub with the given options and return a list of the full names of the found repositories.
      *
@@ -26,7 +28,7 @@ class MavenProjectSearchOptions(
     private val groupId: String,
     private val artifactId: String,
     private val version: String
-) : GitHubSearchOptions {
+) : GithubSearchOptions<MavenProject> {
     override fun searchContent(gitHub: GitHub): List<String> =
         gitHub.searchContent()
             .apply {

--- a/modules/pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javajar/ProjectCompiler.kt
+++ b/modules/pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javajar/ProjectCompiler.kt
@@ -1,6 +1,5 @@
 package org.cafejojo.schaapi.pipeline.projectcompiler.javajar
 
-import org.cafejojo.schaapi.models.Project
 import org.cafejojo.schaapi.models.project.JavaJarProject
 import org.cafejojo.schaapi.pipeline.ProjectCompiler
 import java.io.FileInputStream
@@ -9,10 +8,8 @@ import java.util.jar.JarInputStream
 /**
  * Finds all classes in a Java project consisting of a single JAR.
  */
-class ProjectCompiler : ProjectCompiler {
-    override fun compile(project: Project): Project {
-        if (project !is JavaJarProject) throw IllegalArgumentException("Project must be JavaJarProject.")
-
+class ProjectCompiler : ProjectCompiler<JavaJarProject> {
+    override fun compile(project: JavaJarProject): JavaJarProject {
         val classNames = mutableListOf<String>()
         val jarInputStream = JarInputStream(FileInputStream(project.classDir))
         var jarEntry = jarInputStream.nextJarEntry

--- a/modules/pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javamaven/ProjectCompiler.kt
+++ b/modules/pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javamaven/ProjectCompiler.kt
@@ -2,7 +2,6 @@ package org.cafejojo.schaapi.pipeline.projectcompiler.javamaven
 
 import org.apache.maven.shared.invoker.DefaultInvocationRequest
 import org.apache.maven.shared.invoker.DefaultInvoker
-import org.cafejojo.schaapi.models.Project
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import org.cafejojo.schaapi.pipeline.ProjectCompiler
 import java.io.File
@@ -10,10 +9,8 @@ import java.io.File
 /**
  * Compiles a Java project using Maven.
  */
-class ProjectCompiler : ProjectCompiler {
-    override fun compile(project: Project): Project {
-        if (project !is JavaMavenProject) throw IllegalArgumentException("Project must be JavaMavenProject.")
-
+class ProjectCompiler : ProjectCompiler<JavaMavenProject> {
+    override fun compile(project: JavaMavenProject): JavaMavenProject {
         runMaven(project)
 
         project.classes = project.classDir.walk().filter { it.isFile && it.extension == "class" }.toList()

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
@@ -1,7 +1,6 @@
 package org.cafejojo.schaapi.pipeline.usagegraphgenerator.jimple
 
 import org.cafejojo.schaapi.models.DfsIterator
-import org.cafejojo.schaapi.models.Project
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import org.cafejojo.schaapi.models.project.JavaProject
 import org.cafejojo.schaapi.pipeline.LibraryUsageGraphGenerator
@@ -23,11 +22,8 @@ import java.io.File
 /**
  * Library usage graph generator based on Soot.
  */
-object LibraryUsageGraphGenerator : LibraryUsageGraphGenerator<JimpleNode> {
-    override fun generate(libraryProject: Project, userProject: Project): List<JimpleNode> {
-        if (libraryProject !is JavaProject) throw IllegalArgumentException("Library project must be JavaProject.")
-        if (userProject !is JavaProject) throw IllegalArgumentException("User project must be JavaProject.")
-
+object LibraryUsageGraphGenerator : LibraryUsageGraphGenerator<JavaProject, JavaProject, JimpleNode> {
+    override fun generate(libraryProject: JavaProject, userProject: JavaProject): List<JimpleNode> {
         Scene.v().sootClassPath = arrayOf(
             System.getProperty("java.home") + "${File.separator}lib${File.separator}rt.jar",
             System.getProperty("java.home") + "${File.separator}lib${File.separator}jce.jar",

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/LibraryUsageGraphGenerator.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/LibraryUsageGraphGenerator.kt
@@ -6,7 +6,7 @@ import org.cafejojo.schaapi.models.Project
 /**
  * Library usage graph generator.
  */
-interface LibraryUsageGraphGenerator<in LP : Project, in UP : Project, N : Node> {
+interface LibraryUsageGraphGenerator<in LP : Project, in UP : Project, out N : Node> {
     /**
      * Generates all usage graphs for the user project with respect to the library project.
      *

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/LibraryUsageGraphGenerator.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/LibraryUsageGraphGenerator.kt
@@ -6,7 +6,7 @@ import org.cafejojo.schaapi.models.Project
 /**
  * Library usage graph generator.
  */
-interface LibraryUsageGraphGenerator<N : Node> {
+interface LibraryUsageGraphGenerator<N : Node, P : Project> {
     /**
      * Generates all usage graphs for the user project with respect to the library project.
      *
@@ -14,5 +14,5 @@ interface LibraryUsageGraphGenerator<N : Node> {
      * @param userProject library user project
      * @return list of graphs
      */
-    fun generate(libraryProject: Project, userProject: Project): List<N>
+    fun generate(libraryProject: P, userProject: P): List<N>
 }

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/LibraryUsageGraphGenerator.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/LibraryUsageGraphGenerator.kt
@@ -6,7 +6,7 @@ import org.cafejojo.schaapi.models.Project
 /**
  * Library usage graph generator.
  */
-interface LibraryUsageGraphGenerator<N : Node, P : Project> {
+interface LibraryUsageGraphGenerator<in LP : Project, in UP : Project, N : Node> {
     /**
      * Generates all usage graphs for the user project with respect to the library project.
      *
@@ -14,5 +14,5 @@ interface LibraryUsageGraphGenerator<N : Node, P : Project> {
      * @param userProject library user project
      * @return list of graphs
      */
-    fun generate(libraryProject: P, userProject: P): List<N>
+    fun generate(libraryProject: LP, userProject: UP): List<N>
 }

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/PatternFilterRule.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/PatternFilterRule.kt
@@ -5,7 +5,7 @@ import org.cafejojo.schaapi.models.Node
 /**
  * Decides whether a [Pattern] should be retained.
  */
-interface PatternFilterRule<N : Node> {
+interface PatternFilterRule<in N : Node> {
     /**
      * Determines if [pattern] should be retained.
      *

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/ProjectCompiler.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/ProjectCompiler.kt
@@ -5,7 +5,7 @@ import org.cafejojo.schaapi.models.Project
 /**
  * Compiles [Project]s.
  */
-interface ProjectCompiler {
+interface ProjectCompiler<P : Project> {
     /**
      * Compiles a [Project].
      *
@@ -14,5 +14,5 @@ interface ProjectCompiler {
      * @param project an uncompiled project
      * @return a compiled project
      */
-    fun compile(project: Project): Project
+    fun compile(project: P): P
 }

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/ProjectMiner.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/ProjectMiner.kt
@@ -5,7 +5,7 @@ import org.cafejojo.schaapi.models.Project
 /**
  * Project miner.
  */
-interface ProjectMiner<S : SearchOptions, P : Project> {
+interface ProjectMiner<P : Project, S : SearchOptions<P>> {
     /**
      * Mines projects.
      */

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/ProjectMiner.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/ProjectMiner.kt
@@ -5,9 +5,9 @@ import org.cafejojo.schaapi.models.Project
 /**
  * Project miner.
  */
-interface ProjectMiner<S : SearchOptions> {
+interface ProjectMiner<S : SearchOptions, P : Project> {
     /**
      * Mines projects.
      */
-    fun mine(searchOptions: S): List<Project>
+    fun mine(searchOptions: S): List<P>
 }

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/ProjectMiner.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/ProjectMiner.kt
@@ -5,7 +5,7 @@ import org.cafejojo.schaapi.models.Project
 /**
  * Project miner.
  */
-interface ProjectMiner<P : Project, S : SearchOptions<P>> {
+interface ProjectMiner<in S : SearchOptions<out P>, out P : Project> {
     /**
      * Mines projects.
      */

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/SearchOptions.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/SearchOptions.kt
@@ -1,6 +1,8 @@
 package org.cafejojo.schaapi.pipeline
 
+import org.cafejojo.schaapi.models.Project
+
 /**
  * Search options to be used by the [ProjectMiner].
  */
-interface SearchOptions
+interface SearchOptions<P : Project>

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/TestGenerator.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/TestGenerator.kt
@@ -6,7 +6,7 @@ import java.io.File
 /**
  * Generates test files based on [Pattern]s.
  */
-interface TestGenerator<N : Node> {
+interface TestGenerator<in N : Node> {
     /**
      * Generates a test file based on the given [patterns].
      *


### PR DESCRIPTION
Now Project generics are also passed to the pipeline. One for the library project type and one for the user library type.

`in` and `out` keywords are used where necessary:
* `in` means that it may take as input a subtype of the generic that it has inferred. For instance, if the inferred generic is `JavaProject`, it may also take as input `JavaMavenProject`.
* `out` means that it may give as output any supertype of the inferred generic. For instance, if the inferred generic is `JavaMavenProject`, it may also give as output a `JavaProject`.

For instance, in the pipeline:
1. `JavaMavenCompiler` compiles the library project and outputs a `JavaMavenProject`
2. `JavaJarCompiler` compiles the user projects and outputs a `JavaJarProject`

Now, The `LibraryUsageGraphGenerator` would normally, through type inference, require the internal method signatures to use `LibraryMavenProject` for the library and `JavaJarProject` for the user project. However this makes its use case rather specific, and doesn't make sense. To generate a usage library it is only relevant that they are both `JavaProject`s.

Note: Below, input and output refers to the generics themselves and not the values.

To this end we use the `in` keyword in the interface. Even though the inferred generic for the library project is `JavaMavenProject` in the pipeline due to `libraryProjectCompiler`'s generic being `JavaMavenProject`. the `libraryUsageGraphGenerator` uses the same generic however, so the compiler will complain that `libraryUsageGraphGenerator` has `JavaProject` as generic for the library and not `JavaMavenProject`. The `in` keyword however in `LibraryUsageGraphGenerator`s interface means that it can insert any subtype of `JavaProject`, including `JavaProject` itself, as the class's generic even if it was inferred to be a subtype of `JavaProject`. Therefore, even though the inferred type of the library project is `JavaMavenProject`, `libraryUsageGraphGenerator` still accepts this as it takes as input any generic that is a subtype of `JavaProject`.

In other words, were the `in` keyword not used, the compiler would complain that it cannot infer that `JavaMavenCompiler` and `libraryUsageGraphGenerator` use *exactly* the same generic type. They may both be a subtype of `JavaProject`, but the point is that they must be *exactly* the same subtype.

In other other words, `in` allows as input any generic that is a subtype of `JavaProject`, even if it was inferred to be a completely different subtype of `JavaProject` before.