### PR TITLE
Seach options typo fix

### DIFF
--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/GithubProjectDownloader.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/GithubProjectDownloader.kt
@@ -19,7 +19,7 @@ import kotlin.streams.toList
  * @property projectPacker packer which determines what type of [Project] to wrap the project directory in
  */
 @Suppress("PrintStackTrace") // TODO use searchContent logger
-class GithubProjectDownloader(
+class GitHubProjectDownloader(
     private val projectNames: Collection<String>,
     private val outputDirectory: File,
     private val projectPacker: (File) -> Project

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/ProjectMiner.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/ProjectMiner.kt
@@ -15,7 +15,6 @@ import java.io.File
  *
  * @property username username of GitHub user
  * @property password password of GitHub user
- * @property searchOptions options to use during searching
  * @property outputDirectory directory to store all the project directories. If directory doesn't exit new directory
  * is created
  * @property projectPacker packer which determines what type of [Project] to wrap the project directory in
@@ -25,7 +24,7 @@ class ProjectMiner(
     private val username: String, private val password: String,
     private val outputDirectory: File,
     private val projectPacker: (File) -> Project
-) : ProjectMiner<GithubSearchOptions> {
+) : ProjectMiner<GitHubSearchOptions> {
     init {
         if (!outputDirectory.isDirectory) outputDirectory.mkdirs()
     }
@@ -34,17 +33,17 @@ class ProjectMiner(
      * Mine GitHub for projects with `pom.xml` files which contain searchContent dependency on searchContent library
      * with searchContent given group id, artifact id and version (number).
      *
-     * @param searchOptions search options, which must be of type [GithubSearchOptions]
+     * @param searchOptions search options, which must be of type [GitHubSearchOptions]
      * @return list of [Project]s which likely depend on said library
-     * @see GithubProjectDownloader.download
+     * @see GitHubProjectDownloader.download
      */
-    override fun mine(searchOptions: GithubSearchOptions): List<Project> {
+    override fun mine(searchOptions: GitHubSearchOptions): List<Project> {
         val gitHub = GitHub.connectUsingPassword(username, password)
 
         require(!gitHub.isOffline) { "Unable to connect to GitHub." }
         require(gitHub.isCredentialValid) { "Valid credentials are required to connect to GitHub." }
 
         val projectNames = searchOptions.searchContent(gitHub)
-        return GithubProjectDownloader(projectNames, outputDirectory, projectPacker).download()
+        return GitHubProjectDownloader(projectNames, outputDirectory, projectPacker).download()
     }
 }

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/SearchOptions.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/SearchOptions.kt
@@ -21,7 +21,7 @@ interface GithubSearchOptions : SearchOptions {
  * @property artifactId artifact id of library maven project should depend on
  * @property version version of library maven project should depend on
  */
-class MavenProjectSeachOptions(
+class MavenProjectSearchOptions(
     private val groupId: String,
     private val artifactId: String,
     private val version: String

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/SearchOptions.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/SearchOptions.kt
@@ -6,9 +6,10 @@ import org.kohsuke.github.GitHub
 /**
  * Represents options used to mine [GitHub].
  */
-interface GithubSearchOptions : SearchOptions {
+interface GitHubSearchOptions : SearchOptions {
     /**
-     * Search content on github with the given options and return a list of the full names of the found repositories.
+     * Search content on GitHub with the given options and return a list of the full names of the found repositories.
+     *
      * @return list of full names of found repositories on [GitHub] based on the passed options
      */
     fun searchContent(gitHub: GitHub): List<String>
@@ -25,7 +26,7 @@ class MavenProjectSearchOptions(
     private val groupId: String,
     private val artifactId: String,
     private val version: String
-) : GithubSearchOptions {
+) : GitHubSearchOptions {
     override fun searchContent(gitHub: GitHub): List<String> =
         gitHub.searchContent()
             .apply {

--- a/modules/pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/pipeline/miner/github/GithubProjectDownloaderTest.kt
+++ b/modules/pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/pipeline/miner/github/GithubProjectDownloaderTest.kt
@@ -14,7 +14,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.file.Files
 
-class GithubProjectDownloaderTest : Spek({
+class GitHubProjectDownloaderTest : Spek({
     var output = Files.createTempDirectory("project-downloader").toFile()
 
     // Create zip file with given dir name (+ zip extension) in output with searchContent single text file with given
@@ -51,7 +51,7 @@ class GithubProjectDownloaderTest : Spek({
             val zipStreamContent = "testZip"
             val repoZipStream = zipStreamContent.byteInputStream()
 
-            GithubProjectDownloader(repoNames, output, ::testProjectPacker)
+            GitHubProjectDownloader(repoNames, output, ::testProjectPacker)
                 .saveToFile(repoZipStream, repoName)
 
             assertThat(File(output, "${repoName}0-project.zip")).exists()
@@ -64,7 +64,7 @@ class GithubProjectDownloaderTest : Spek({
             val zipStreamContent = "testZip"
             val repoZipStream = zipStreamContent.byteInputStream()
 
-            GithubProjectDownloader(repoNames, output, ::testProjectPacker)
+            GitHubProjectDownloader(repoNames, output, ::testProjectPacker)
                 .saveToFile(repoZipStream, repoName)
 
             assertThat(File(output, "0-project.zip")).exists()
@@ -79,7 +79,7 @@ class GithubProjectDownloaderTest : Spek({
             val repo2ZipStream = zip2StreamContent.byteInputStream()
 
             val repoNames = listOf(repoName1, repoName2)
-            GithubProjectDownloader(repoNames, output, ::testProjectPacker)
+            GitHubProjectDownloader(repoNames, output, ::testProjectPacker)
                 .apply { saveToFile(repo1ZipStream, repoName1) }
                 .apply { saveToFile(repo2ZipStream, repoName2) }
 
@@ -99,7 +99,7 @@ class GithubProjectDownloaderTest : Spek({
 
             assertThat(output.listFiles().size).isEqualTo(1)
 
-            GithubProjectDownloader(repoNames, output, ::testProjectPacker)
+            GitHubProjectDownloader(repoNames, output, ::testProjectPacker)
                 .saveToFile(repoZipStream, repoName)
 
             assertThat(output.listFiles().size).isEqualTo(1)
@@ -109,7 +109,7 @@ class GithubProjectDownloaderTest : Spek({
     describe("when unzipping searchContent file") {
         it("should create searchContent new directory and remove the old") {
             val zipFile = addZipFile("testZipDirectory", "")
-            val unzippedFile = GithubProjectDownloader(emptyList(), output, ::testProjectPacker)
+            val unzippedFile = GitHubProjectDownloader(emptyList(), output, ::testProjectPacker)
                 .unzip(zipFile)
 
             assertThat(output.listFiles()).doesNotContain(zipFile)
@@ -118,7 +118,7 @@ class GithubProjectDownloaderTest : Spek({
 
         it("should create searchContent new directory which has searchContent file with the expected content") {
             val zipFile = addZipFile("testZipDirectory", "test text")
-            val unzippedFile = GithubProjectDownloader(emptyList(), output, ::testProjectPacker)
+            val unzippedFile = GitHubProjectDownloader(emptyList(), output, ::testProjectPacker)
                 .unzip(zipFile)
 
             assertThat(unzippedFile?.listFiles()?.first()?.readText()).isEqualTo("test text")
@@ -129,7 +129,7 @@ class GithubProjectDownloaderTest : Spek({
 
             assertThat(output.listFiles()).containsExactly(zipFile)
 
-            val unzippedFile = GithubProjectDownloader(
+            val unzippedFile = GitHubProjectDownloader(
                 emptyList(),
                 output,
                 ::testProjectPacker
@@ -144,7 +144,7 @@ class GithubProjectDownloaderTest : Spek({
 
             assertThat(output.listFiles().size).isEqualTo(2)
 
-            GithubProjectDownloader(emptyList(), output, ::testProjectPacker).unzip(zipFile)
+            GitHubProjectDownloader(emptyList(), output, ::testProjectPacker).unzip(zipFile)
 
             assertThat(output.listFiles().size).isEqualTo(1)
         }
@@ -152,7 +152,7 @@ class GithubProjectDownloaderTest : Spek({
         it("should return null if the zip file does not exist") {
             val invisibleFile = File(output, "invisibleFile")
 
-            assertThat(GithubProjectDownloader(emptyList(), output, ::testProjectPacker).unzip(invisibleFile)).isNull()
+            assertThat(GitHubProjectDownloader(emptyList(), output, ::testProjectPacker).unzip(invisibleFile)).isNull()
             assertThat(output.listFiles()).isEmpty()
         }
 
@@ -160,21 +160,21 @@ class GithubProjectDownloaderTest : Spek({
             val notAZipFile = File(output, "notAZipFile")
             notAZipFile.createNewFile()
 
-            assertThat(GithubProjectDownloader(emptyList(), output, ::testProjectPacker).unzip(notAZipFile)).isNull()
+            assertThat(GitHubProjectDownloader(emptyList(), output, ::testProjectPacker).unzip(notAZipFile)).isNull()
             assertThat(output.listFiles()).isEmpty()
         }
     }
 
     describe("when downloading searchContent project") {
         it("should create searchContent connection request with the correct url") {
-            val connection = GithubProjectDownloader(emptyList(), output, ::testProjectPacker)
+            val connection = GitHubProjectDownloader(emptyList(), output, ::testProjectPacker)
                 .getConnection("cafejojo/schaapi")
 
             assertThat(connection?.url).isEqualTo(URL("https://github.com/cafejojo/schaapi/archive/master.zip"))
         }
 
         it("should create searchContent connection request with searchContent get request method") {
-            val connection = GithubProjectDownloader(emptyList(), output, ::testProjectPacker)
+            val connection = GitHubProjectDownloader(emptyList(), output, ::testProjectPacker)
                 .getConnection("cafejojo/schaapi")
 
             assertThat(connection?.requestMethod).isEqualTo("GET")
@@ -183,7 +183,7 @@ class GithubProjectDownloaderTest : Spek({
         it("should save the unzipped file") {
             val zipFile = addZipFile("testProject", "content", Files.createTempDirectory("project-downloader").toFile())
 
-            val downloader = spy(GithubProjectDownloader(listOf("testProject"), output, ::testProjectPacker))
+            val downloader = spy(GitHubProjectDownloader(listOf("testProject"), output, ::testProjectPacker))
             val mockHttpURLConnection = mock<HttpURLConnection> {
                 on(it.inputStream) doReturn FileInputStream(zipFile)
             }


### PR DESCRIPTION
Two fixes:
1. Fixes the capitalisation of "GitHub" (from "Github" to "GitHub")
2. Renames `*SeachOptions` to `*SearchOptions`