### PR TITLE
Include module-integration test coverage in report

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,7 @@ allprojects {
     test {
         jacoco {
             append = true
-            destinationFile = file("$rootProject.buildDir/jacoco/test.exec")
+            destinationFile = file("$buildDir/jacoco/test.exec")
         }
     }
 
@@ -80,6 +80,7 @@ allprojects {
         additionalSourceDirs = files(sourceSets.main.allSource.srcDirs)
         sourceDirectories = files(sourceSets.main.allSource.srcDirs)
         classDirectories = files(sourceSets.main.output)
+        executionData = files("$buildDir/jacoco/test.exec")
 
         reports {
             csv.enabled = false

--- a/gradle/tests/test-configuration-generator.gradle
+++ b/gradle/tests/test-configuration-generator.gradle
@@ -23,18 +23,17 @@ ext.generateTestConfiguration = { String taskName, String directoryName ->
         testClassesDirs = sourceSets[taskName].output.classesDirs
         classpath = sourceSets[taskName].runtimeClasspath
 
-        jacoco {
-            append = false
-        }
-
         useJUnitPlatform() {
             includeEngines "spek"
         }
 
-        jacocoTestReport {
-            executionData file("$buildDir/jacoco/${directoryName}.exec")
+        jacoco {
+            append = true
+            destinationFile = file("$buildDir/jacoco/test.exec")
         }
     }
+
+    jacocoTestReport.dependsOn customTestTask
 
     customTestTask.mustRunAfter test
     check.dependsOn customTestTask


### PR DESCRIPTION
This PR fixes the missing coverage through the following two changes:

1. Instead of putting all the execution data in one file, there is now a separate file for each module.
2. `jacocoTestReport` now depends on `moduleIntegrationTest`

Strictly speaking, I think only the second change was necessary, but the first one is also nice.