### PR TITLE
Add Project Miner to Pipeline

### DIFF
--- a/modules/application/build.gradle
+++ b/modules/application/build.gradle
@@ -10,6 +10,8 @@ repositories {
 dependencies {
     compile project(":models:java-project")
     compile project(":models:jimple-library-usage-graph")
+
+    compile project(":pipeline:directory-project-miner")
     compile project(":pipeline:java-jar-project-compiler")
     compile project(":pipeline:java-maven-project-compiler")
     compile project(":pipeline:jimple-evosuite-test-generator")

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -89,7 +89,7 @@ private fun buildOptions(): Options =
         .addOption(Option
             .builder("u")
             .longOpt("user_dirs")
-            .desc("The directory containing user directories.")
+            .desc("The directory containing user project directories.")
             .hasArg()
             .required()
             .build())

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -10,6 +10,8 @@ import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeCompa
 import org.cafejojo.schaapi.models.project.JavaJarProject
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import org.cafejojo.schaapi.pipeline.PatternFilter
+import org.cafejojo.schaapi.pipeline.miner.directory.DirectorySearchOptions
+import org.cafejojo.schaapi.pipeline.miner.directory.ProjectMiner
 import org.cafejojo.schaapi.pipeline.patterndetector.prefixspan.PatternDetector
 import org.cafejojo.schaapi.pipeline.patternfilter.jimple.IncompleteInitPatternFilterRule
 import org.cafejojo.schaapi.pipeline.patternfilter.jimple.LengthPatternFilterRule
@@ -35,7 +37,7 @@ fun main(args: Array<String>) {
     val mavenDir = File(cmd.getOptionValue("maven_dir") ?: JavaMavenProject.DEFAULT_MAVEN_HOME.absolutePath)
     val output = File(cmd.getOptionValue('o')).apply { mkdirs() }
     val library = JavaMavenProject(File(cmd.getOptionValue('l')), mavenDir)
-    val users = cmd.getOptionValues('u').map { JavaJarProject(File(it)) }
+    val userDirs = File(cmd.getOptionValue('u'))
 
     if (!mavenDir.resolve("bin/mvn").exists() || cmd.hasOption("repair_maven")) {
         MavenInstaller().installMaven(mavenDir)
@@ -45,6 +47,8 @@ fun main(args: Array<String>) {
     val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")
 
     Pipeline(
+        projectMiner = ProjectMiner(::JavaJarProject),
+        searchOptions = DirectorySearchOptions(userDirs),
         libraryProjectCompiler = JavaMavenCompiler(),
         userProjectCompiler = JavaJarCompiler(),
         libraryUsageGraphGenerator = LibraryUsageGraphGenerator,
@@ -63,7 +67,7 @@ fun main(args: Array<String>) {
             processStandardStream = if (testGeneratorEnableOutput) System.out else null,
             processErrorStream = if (testGeneratorEnableOutput) System.out else null
         )
-    ).run(users, library)
+    ).run(library)
 }
 
 private fun buildOptions(): Options =
@@ -85,9 +89,8 @@ private fun buildOptions(): Options =
         .addOption(Option
             .builder("u")
             .longOpt("user_dirs")
-            .desc("The user directories, separated by semi-colons.")
-            .hasArgs()
-            .valueSeparator(File.pathSeparatorChar)
+            .desc("The directory containing user directories.")
+            .hasArg()
             .required()
             .build())
         .addOption(Option

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -37,7 +37,7 @@ fun main(args: Array<String>) {
     val mavenDir = File(cmd.getOptionValue("maven_dir") ?: JavaMavenProject.DEFAULT_MAVEN_HOME.absolutePath)
     val output = File(cmd.getOptionValue('o')).apply { mkdirs() }
     val library = JavaMavenProject(File(cmd.getOptionValue('l')), mavenDir)
-    val userDirs = File(cmd.getOptionValue('u'))
+    val userBaseDir = File(cmd.getOptionValue('u'))
 
     if (!mavenDir.resolve("bin/mvn").exists() || cmd.hasOption("repair_maven")) {
         MavenInstaller().installMaven(mavenDir)
@@ -48,7 +48,7 @@ fun main(args: Array<String>) {
 
     Pipeline(
         projectMiner = ProjectMiner(::JavaJarProject),
-        searchOptions = DirectorySearchOptions(userDirs),
+        searchOptions = DirectorySearchOptions(userBaseDir),
         libraryProjectCompiler = JavaMavenCompiler(),
         userProjectCompiler = JavaJarCompiler(),
         libraryUsageGraphGenerator = LibraryUsageGraphGenerator,

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/Pipeline.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/Pipeline.kt
@@ -6,12 +6,16 @@ import org.cafejojo.schaapi.pipeline.LibraryUsageGraphGenerator
 import org.cafejojo.schaapi.pipeline.PatternDetector
 import org.cafejojo.schaapi.pipeline.PatternFilter
 import org.cafejojo.schaapi.pipeline.ProjectCompiler
+import org.cafejojo.schaapi.pipeline.ProjectMiner
+import org.cafejojo.schaapi.pipeline.SearchOptions
 import org.cafejojo.schaapi.pipeline.TestGenerator
 
 /**
  * Represents the complete Schaapi pipeline.
  */
-class Pipeline<LP : Project, UP : Project, N : Node>(
+class Pipeline<SO : SearchOptions, LP : Project, UP : Project, N : Node>(
+    private val projectMiner: ProjectMiner<SO, UP>,
+    private val searchOptions: SO,
     private val libraryProjectCompiler: ProjectCompiler<LP>,
     private val userProjectCompiler: ProjectCompiler<UP>,
     private val libraryUsageGraphGenerator: LibraryUsageGraphGenerator<LP, UP, N>,
@@ -22,10 +26,11 @@ class Pipeline<LP : Project, UP : Project, N : Node>(
     /**
      * Executes all steps in the pipeline.
      */
-    fun run(projects: List<UP>, libraryProject: LP) {
+    fun run(libraryProject: LP) {
         libraryProjectCompiler.compile(libraryProject)
 
-        projects.map { userProjectCompiler.compile(it) }
+        projectMiner.mine(searchOptions)
+            .map { userProjectCompiler.compile(it) }
             .flatMap { libraryUsageGraphGenerator.generate(libraryProject, it) }
             .next(patternDetector::findPatterns)
             .next(patternFilter::filter)

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/Pipeline.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/Pipeline.kt
@@ -13,7 +13,7 @@ import org.cafejojo.schaapi.pipeline.TestGenerator
 /**
  * Represents the complete Schaapi pipeline.
  */
-class Pipeline<SO : SearchOptions, LP : Project, UP : Project, N : Node>(
+class Pipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
     private val projectMiner: ProjectMiner<SO, UP>,
     private val searchOptions: SO,
     private val libraryProjectCompiler: ProjectCompiler<LP>,

--- a/modules/application/src/module-integration-test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
+++ b/modules/application/src/module-integration-test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
@@ -28,8 +28,7 @@ internal class SchaapiSmokeTest : Spek({
         main(arrayOf(
             "-o", target.absolutePath,
             "-l", getResourcePath("/library/"),
-            "-u", getResourcePath("/user/a/target/a-1.0.0.jar") + File.pathSeparatorChar +
-                getResourcePath("/user/b/target/b-1.0.0.jar"),
+            "-u", getResourcePath("/user/a/target"),
             "--maven_dir", mavenDir.absolutePath,
             "--pattern_detector_minimum_count", "1",
             "--test_generator_timeout", "3"

--- a/modules/pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/DirectorySearchOptions.kt
+++ b/modules/pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/DirectorySearchOptions.kt
@@ -1,6 +1,5 @@
 package org.cafejojo.schaapi.pipeline.miner.directory
 
-import org.cafejojo.schaapi.models.Project
 import org.cafejojo.schaapi.pipeline.SearchOptions
 import java.io.File
 
@@ -9,4 +8,4 @@ import java.io.File
  *
  * @property directory the directory containing the projects to be mined
  */
-class SearchOptions<P : Project>(val directory: File) : SearchOptions<P>
+class DirectorySearchOptions(val directory: File) : SearchOptions

--- a/modules/pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/ProjectMiner.kt
+++ b/modules/pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/ProjectMiner.kt
@@ -10,7 +10,7 @@ import java.io.File
  * @property projectPacker the packer that transforms [File]s into projects. It may be invoked on both directories and
  * files.
  */
-class ProjectMiner<P : Project>(private val projectPacker: (File) -> P) : ProjectMiner<SearchOptions<P>, P> {
-    override fun mine(searchOptions: SearchOptions<P>) =
+class ProjectMiner<P : Project>(private val projectPacker: (File) -> P) : ProjectMiner<DirectorySearchOptions, P> {
+    override fun mine(searchOptions: DirectorySearchOptions) =
         searchOptions.directory.listFiles()?.map { projectPacker(it) } ?: emptyList()
 }

--- a/modules/pipeline/directory-project-miner/src/test/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/ProjectMinerTest.kt
+++ b/modules/pipeline/directory-project-miner/src/test/kotlin/org/cafejojo/schaapi/pipeline/miner/directory/ProjectMinerTest.kt
@@ -28,37 +28,37 @@ internal class ProjectMinerTest : Spek({
         }
 
         it("finds no projects if the directory is invalid") {
-            miner.mine(SearchOptions(File("does_not_exist")))
+            miner.mine(DirectorySearchOptions(File("does_not_exist")))
 
             verifyNoMoreInteractions(packer)
         }
 
         it("finds a single file-based project") {
-            miner.mine(SearchOptions(getResourceAsFile("/one-file-project")))
+            miner.mine(DirectorySearchOptions(getResourceAsFile("/one-file-project")))
 
             verify(packer).invoke(any())
         }
 
         it("finds multiple file-based projects") {
-            miner.mine(SearchOptions(getResourceAsFile("/multiple-file-projects")))
+            miner.mine(DirectorySearchOptions(getResourceAsFile("/multiple-file-projects")))
 
             verify(packer, times(3)).invoke(any())
         }
 
         it("finds a single directory-based project") {
-            miner.mine(SearchOptions(getResourceAsFile("/one-directory-project")))
+            miner.mine(DirectorySearchOptions(getResourceAsFile("/one-directory-project")))
 
             verify(packer).invoke(any())
         }
 
         it("finds multiple directory-based projects") {
-            miner.mine(SearchOptions(getResourceAsFile("/multiple-directory-projects")))
+            miner.mine(DirectorySearchOptions(getResourceAsFile("/multiple-directory-projects")))
 
             verify(packer, times(3)).invoke(any())
         }
 
         it("finds both file- and directory-based projects") {
-            miner.mine(SearchOptions(getResourceAsFile("/mixed-projects")))
+            miner.mine(DirectorySearchOptions(getResourceAsFile("/mixed-projects")))
 
             verify(packer, times(4)).invoke(any())
         }

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/ProjectMiner.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/ProjectMiner.kt
@@ -24,7 +24,7 @@ class ProjectMiner<P : Project>(
     private val username: String, private val password: String,
     private val outputDirectory: File,
     private val projectPacker: (File) -> P
-) : ProjectMiner<GitHubSearchOptions<P>, P> {
+) : ProjectMiner<GitHubSearchOptions, P> {
     init {
         if (!outputDirectory.isDirectory) outputDirectory.mkdirs()
     }
@@ -37,7 +37,7 @@ class ProjectMiner<P : Project>(
      * @return list of [Project]s which likely depend on said library
      * @see GitHubProjectDownloader.download
      */
-    override fun mine(searchOptions: GitHubSearchOptions<P>): List<P> {
+    override fun mine(searchOptions: GitHubSearchOptions): List<P> {
         val gitHub = GitHub.connectUsingPassword(username, password)
 
         require(!gitHub.isOffline) { "Unable to connect to GitHub." }

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/SearchOptions.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/SearchOptions.kt
@@ -1,14 +1,12 @@
 package org.cafejojo.schaapi.pipeline.miner.github
 
-import org.cafejojo.schaapi.models.Project
-import org.cafejojo.schaapi.models.project.MavenProject
 import org.cafejojo.schaapi.pipeline.SearchOptions
 import org.kohsuke.github.GitHub
 
 /**
  * Represents options used to mine [GitHub].
  */
-interface GitHubSearchOptions<P : Project> : SearchOptions<P> {
+interface GitHubSearchOptions : SearchOptions {
     /**
      * Search content on GitHub with the given options and return a list of the full names of the found repositories.
      *
@@ -28,7 +26,7 @@ class MavenProjectSearchOptions(
     private val groupId: String,
     private val artifactId: String,
     private val version: String
-) : GitHubSearchOptions<MavenProject> {
+) : GitHubSearchOptions {
     override fun searchContent(gitHub: GitHub): List<String> =
         gitHub.searchContent()
             .apply {

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/ProjectMiner.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/ProjectMiner.kt
@@ -5,7 +5,7 @@ import org.cafejojo.schaapi.models.Project
 /**
  * Project miner.
  */
-interface ProjectMiner<in S : SearchOptions<out P>, out P : Project> {
+interface ProjectMiner<in S : SearchOptions, out P : Project> {
     /**
      * Mines projects.
      */

--- a/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/SearchOptions.kt
+++ b/modules/pipeline/src/main/kotlin/org/cafejojo/schaapi/pipeline/SearchOptions.kt
@@ -1,8 +1,6 @@
 package org.cafejojo.schaapi.pipeline
 
-import org.cafejojo.schaapi.models.Project
-
 /**
  * Search options to be used by the [ProjectMiner].
  */
-interface SearchOptions<P : Project>
+interface SearchOptions


### PR DESCRIPTION
Builds upon #161. See [here](https://github.com/cafejojo/schaapi/pull/167/files/af9d31ad68f021c49e0f5a92f90122915fd6c9ef..4eae4b64bfb0164d812dbf903e35e4576af5754c) for easy review.

* Use the directory project miner in the `CommandLineInterface`
* Remove unecessary generic type parameter from `SearchOptions`
* Use generics to ensure `SearchOptions` type is compatible with the `ProjectMiner`