### PR TITLE
Rename 'user_dirs' argument to 'user_base_dir'

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ usage: schaapi -o <arg> -l <arg> -u <arg> [--maven_dir <arg>]
        [--test_generator_enable_output] [--test_generator_timeout <arg>]
  -o,--output_dir <arg>                       The output directory.
  -l,--library_dir <arg>                      The library directory.
- -u,--user_dirs <arg>                        The user directories,
-                                             separated by semi-colons.
+ -u,--user_base_dir <arg>                    The directory containing user
+                                             project directories.
     --maven_dir <arg>                        The directory to run Maven
                                              from.
     --repair_maven                           Repairs the Maven

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -88,7 +88,7 @@ private fun buildOptions(): Options =
             .build())
         .addOption(Option
             .builder("u")
-            .longOpt("user_dirs")
+            .longOpt("user_base_dir")
             .desc("The directory containing user project directories.")
             .hasArg()
             .required()


### PR DESCRIPTION
The semantics of the user projects argument was changed in an earlier PR without changing the corresponding CLI command name.