### PR TITLE
Rename FrequentSequenceFinder class in spam module to Spam

### DIFF
--- a/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/PatternDetector.kt
+++ b/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/PatternDetector.kt
@@ -14,8 +14,7 @@ class PatternDetector<N : Node>(
     private val comparator: GeneralizedNodeComparator<N>
 ) : PatternDetector<N> {
     override fun findPatterns(graphs: List<N>): List<Pattern<N>> {
-        val userPaths = graphs.flatMap { PathEnumerator(it).enumerate() }
-
-        return FrequentSequenceFinder(userPaths, minimumCount, comparator).findFrequentSequences()
+        val sequences = graphs.flatMap { PathEnumerator(it).enumerate() }
+        return SPAM(sequences, minimumCount, comparator).findFrequentSequences()
     }
 }

--- a/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/PatternDetector.kt
+++ b/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/PatternDetector.kt
@@ -15,6 +15,6 @@ class PatternDetector<N : Node>(
 ) : PatternDetector<N> {
     override fun findPatterns(graphs: List<N>): List<Pattern<N>> {
         val sequences = graphs.flatMap { PathEnumerator(it).enumerate() }
-        return SPAM(sequences, minimumCount, comparator).findFrequentSequences()
+        return Spam(sequences, minimumCount, comparator).findFrequentPatterns()
     }
 }

--- a/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SPAM.kt
+++ b/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SPAM.kt
@@ -53,7 +53,9 @@ internal class SPAM<N : Node>(
 
         val frequentExtensions = extensions.mapNotNull { extension ->
             val extendedPattern: List<N> = (pattern + extension) as List<N>
-            val support = sequences.count { path -> pathUtil.pathContainsSequence(path, extendedPattern, nodeComparator) }
+            val support = sequences.count { path ->
+                pathUtil.pathContainsSequence(path, extendedPattern, nodeComparator)
+            }
 
             if (support >= minimumSupport) extension
             else null

--- a/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SPAM.kt
+++ b/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SPAM.kt
@@ -7,44 +7,44 @@ import org.cafejojo.schaapi.models.PathUtil
 import org.cafejojo.schaapi.pipeline.Pattern
 
 /**
- * Finds frequent sequences of [Node]s in the given collection of paths, using the SPAM algorithm.
+ * Finds frequent sequences of [Node]s in the given collection of paths, using the SPAM algorithm by Ayres et al.
  *
- * @property allPaths all paths in which patterns should be detected. Each path is a list of [Node]s.
- * @property minimumCount the minimum amount of times a node must appear in [allPaths] for it to be considered a
+ * @property sequences all paths in which patterns should be detected. Each path is a list of [Node]s.
+ * @property minimumSupport the minimum amount of times a node must appear in [sequences] for it to be considered a
  * frequent node.
- * @property comparator the comparator used to determine whether two [Node]s are equal
+ * @property nodeComparator the nodeComparator used to determine whether two [Node]s are equal
  */
-class FrequentSequenceFinder<N : Node>(
-    private val allPaths: Collection<List<N>>,
-    private val minimumCount: Int,
-    private val comparator: GeneralizedNodeComparator<N>
+internal class SPAM<N : Node>(
+    private val sequences: Collection<List<N>>,
+    private val minimumSupport: Int,
+    private val nodeComparator: GeneralizedNodeComparator<N>
 ) {
     private val pathUtil = PathUtil<N>()
     private val frequentSequences = mutableListOf<List<N>>()
     private val frequentItems = CustomEqualsHashSet<N>(Node.Companion::equiv, Node::equivHashCode)
 
     /**
-     * Finds frequent sequences in [allPaths], using the SPAM algorithm by Ayres et al. (2002).
+     * Finds frequent sequences in [sequences], using the SPAM algorithm by Ayres et al. (2002).
      *
-     * @return frequent sequences in [allPaths]
+     * @return frequent sequences in [sequences]
      */
-    fun findFrequentSequences(): List<Pattern<N>> {
-        frequentItems.addAll(pathUtil.findFrequentNodesInPaths(allPaths, minimumCount))
+    internal fun findFrequentSequences(): List<Pattern<N>> {
+        frequentItems.addAll(pathUtil.findFrequentNodesInPaths(sequences, minimumSupport))
         frequentItems.forEach { runAlgorithm(listOf(it), frequentItems) }
 
         return frequentSequences
     }
 
     /**
-     * Creates a mapping from the found frequent patterns to [allPaths] which contain said sequence.
+     * Creates a mapping from the found frequent [Pattern]s to [sequences] which contain said sequence.
      *
      * If [findFrequentSequences] has not been run before, the resulting map will not contain any keys.
      *
      * @return a mapping from the frequent patterns to sequences which contain said sequence
      */
-    fun mapFrequentSequencesToPaths(): Map<List<N>, List<List<N>>> =
+    internal fun mapFrequentPatternsToSequences(): Map<Pattern<N>, List<List<N>>> =
         frequentSequences.map { sequence ->
-            Pair(sequence, allPaths.filter { pathUtil.pathContainsSequence(it, sequence, comparator) })
+            Pair(sequence, sequences.filter { pathUtil.pathContainsSequence(it, sequence, nodeComparator) })
         }.toMap()
 
     @Suppress("UnsafeCast") // pattern: List<N> + extension: N is always a List<N>
@@ -53,9 +53,9 @@ class FrequentSequenceFinder<N : Node>(
 
         val frequentExtensions = extensions.mapNotNull { extension ->
             val extendedPattern: List<N> = (pattern + extension) as List<N>
-            val support = allPaths.count { path -> pathUtil.pathContainsSequence(path, extendedPattern, comparator) }
+            val support = sequences.count { path -> pathUtil.pathContainsSequence(path, extendedPattern, nodeComparator) }
 
-            if (support >= minimumCount) extension
+            if (support >= minimumSupport) extension
             else null
         }.toSet()
 

--- a/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SPAM.kt
+++ b/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SPAM.kt
@@ -7,9 +7,9 @@ import org.cafejojo.schaapi.models.PathUtil
 import org.cafejojo.schaapi.pipeline.Pattern
 
 /**
- * Finds frequent sequences of [Node]s in the given collection of paths, using the SPAM algorithm by Ayres et al.
+ * Finds frequent sequences of [Node]s in the given collection of sequences, using the SPAM algorithm by Ayres et al.
  *
- * @property sequences all paths in which patterns should be detected. Each path is a list of [Node]s.
+ * @property sequences all sequences in which patterns should be detected. Each sequence is a list of [Node]s.
  * @property minimumSupport the minimum amount of times a node must appear in [sequences] for it to be considered a
  * frequent node.
  * @property nodeComparator the nodeComparator used to determine whether two [Node]s are equal
@@ -53,8 +53,8 @@ internal class SPAM<N : Node>(
 
         val frequentExtensions = extensions.mapNotNull { extension ->
             val extendedPattern: List<N> = (pattern + extension) as List<N>
-            val support = sequences.count { path ->
-                pathUtil.pathContainsSequence(path, extendedPattern, nodeComparator)
+            val support = sequences.count { sequence ->
+                pathUtil.pathContainsSequence(sequence, extendedPattern, nodeComparator)
             }
 
             if (support >= minimumSupport) extension

--- a/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/Spam.kt
+++ b/modules/pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/Spam.kt
@@ -14,13 +14,13 @@ import org.cafejojo.schaapi.pipeline.Pattern
  * frequent node.
  * @property nodeComparator the nodeComparator used to determine whether two [Node]s are equal
  */
-internal class SPAM<N : Node>(
+internal class Spam<N : Node>(
     private val sequences: Collection<List<N>>,
     private val minimumSupport: Int,
     private val nodeComparator: GeneralizedNodeComparator<N>
 ) {
     private val pathUtil = PathUtil<N>()
-    private val frequentSequences = mutableListOf<List<N>>()
+    private val frequentPatterns = mutableListOf<Pattern<N>>()
     private val frequentItems = CustomEqualsHashSet<N>(Node.Companion::equiv, Node::equivHashCode)
 
     /**
@@ -28,28 +28,28 @@ internal class SPAM<N : Node>(
      *
      * @return frequent sequences in [sequences]
      */
-    internal fun findFrequentSequences(): List<Pattern<N>> {
+    internal fun findFrequentPatterns(): List<Pattern<N>> {
         frequentItems.addAll(pathUtil.findFrequentNodesInPaths(sequences, minimumSupport))
         frequentItems.forEach { runAlgorithm(listOf(it), frequentItems) }
 
-        return frequentSequences
+        return frequentPatterns
     }
 
     /**
      * Creates a mapping from the found frequent [Pattern]s to [sequences] which contain said sequence.
      *
-     * If [findFrequentSequences] has not been run before, the resulting map will not contain any keys.
+     * If [findFrequentPatterns] has not been run before, the resulting map will not contain any keys.
      *
      * @return a mapping from the frequent patterns to sequences which contain said sequence
      */
     internal fun mapFrequentPatternsToSequences(): Map<Pattern<N>, List<List<N>>> =
-        frequentSequences.map { sequence ->
+        frequentPatterns.map { sequence ->
             Pair(sequence, sequences.filter { pathUtil.pathContainsSequence(it, sequence, nodeComparator) })
         }.toMap()
 
     @Suppress("UnsafeCast") // pattern: List<N> + extension: N is always a List<N>
     private fun runAlgorithm(pattern: List<N>, extensions: Set<N>) {
-        frequentSequences.add(pattern)
+        frequentPatterns.add(pattern)
 
         val frequentExtensions = extensions.mapNotNull { extension ->
             val extendedPattern: List<N> = (pattern + extension) as List<N>

--- a/modules/pipeline/spam-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SPAMTest.kt
+++ b/modules/pipeline/spam-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SPAMTest.kt
@@ -7,7 +7,7 @@ import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
 internal class SPAMTest : Spek({
-    describe("detecting patterns in a set of paths") {
+    describe("detecting patterns in a set of sequences") {
         it("should not find a pattern in a set of random nodes with support 2") {
             val node1 = SimpleNode()
             val node2 = SimpleNode()
@@ -20,17 +20,17 @@ internal class SPAMTest : Spek({
             val node9 = SimpleNode()
             val node10 = SimpleNode()
 
-            val path1 = listOf(node1, node2, node3)
-            val path2 = listOf(node4, node5, node6)
-            val path3 = listOf(node7, node8, node9, node10)
+            val sequence1 = listOf(node1, node2, node3)
+            val sequence2 = listOf(node4, node5, node6)
+            val sequence3 = listOf(node7, node8, node9, node10)
 
-            val paths = listOf(path1, path2, path3)
-            val frequent = SPAM(paths, 2, TestNodeComparator()).findFrequentSequences()
+            val sequences = listOf(sequence1, sequence2, sequence3)
+            val frequent = SPAM(sequences, 2, TestNodeComparator()).findFrequentSequences()
 
             assertThat(frequent).isEmpty()
         }
 
-        it("should find a pattern that occurs in two different paths") {
+        it("should find a pattern that occurs in two different sequences") {
             val node1 = SimpleNode()
             val node2 = SimpleNode()
             val node3 = SimpleNode()
@@ -41,34 +41,34 @@ internal class SPAMTest : Spek({
             val node8 = SimpleNode()
             val node9 = SimpleNode()
 
-            val path1 = listOf(node1, node2, node2)
-            val path2 = listOf(node3, node4, node5)
-            val path3 = listOf(node6, node7, node8, node9, node1, node2, node2)
+            val sequence1 = listOf(node1, node2, node2)
+            val sequence2 = listOf(node3, node4, node5)
+            val sequence3 = listOf(node6, node7, node8, node9, node1, node2, node2)
 
-            val paths = listOf(path1, path2, path3)
-            val frequent = SPAM(paths, 2, TestNodeComparator()).findFrequentSequences()
+            val sequences = listOf(sequence1, sequence2, sequence3)
+            val frequent = SPAM(sequences, 2, TestNodeComparator()).findFrequentSequences()
 
-            assertThat(frequent).contains(path1)
+            assertThat(frequent).contains(sequence1)
         }
     }
 
     describe("When mapping between sequences and patterns") {
-        it("should find a mapping from sequences to paths") {
+        it("should find a mapping from patterns to sequences") {
             val node1 = SimpleNode()
             val node2 = SimpleNode()
             val node3 = SimpleNode()
             val node4 = SimpleNode()
 
-            val path1 = listOf(node1, node2, node3, node4)
-            val path2 = listOf(node2, node1, node2)
+            val sequence1 = listOf(node1, node2, node3, node4)
+            val sequence2 = listOf(node2, node1, node2)
 
-            val paths = listOf(path1, path2)
-            val patternDetector = SPAM(paths, 2, TestNodeComparator())
+            val sequences = listOf(sequence1, sequence2)
+            val patternDetector = SPAM(sequences, 2, TestNodeComparator())
 
             patternDetector.findFrequentSequences()
             val patterns = patternDetector.mapFrequentPatternsToSequences()
 
-            assertThat(patterns[listOf(node1, node2)]).isEqualTo(listOf(path1, path2))
+            assertThat(patterns[listOf(node1, node2)]).isEqualTo(listOf(sequence1, sequence2))
         }
     }
 })

--- a/modules/pipeline/spam-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SPAMTest.kt
+++ b/modules/pipeline/spam-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SPAMTest.kt
@@ -6,7 +6,7 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
-internal class FrequentSequenceFinderTest : Spek({
+internal class SPAMTest : Spek({
     describe("detecting patterns in a set of paths") {
         it("should not find a pattern in a set of random nodes with support 2") {
             val node1 = SimpleNode()
@@ -25,7 +25,7 @@ internal class FrequentSequenceFinderTest : Spek({
             val path3 = listOf(node7, node8, node9, node10)
 
             val paths = listOf(path1, path2, path3)
-            val frequent = FrequentSequenceFinder(paths, 2, TestNodeComparator()).findFrequentSequences()
+            val frequent = SPAM(paths, 2, TestNodeComparator()).findFrequentSequences()
 
             assertThat(frequent).isEmpty()
         }
@@ -46,7 +46,7 @@ internal class FrequentSequenceFinderTest : Spek({
             val path3 = listOf(node6, node7, node8, node9, node1, node2, node2)
 
             val paths = listOf(path1, path2, path3)
-            val frequent = FrequentSequenceFinder(paths, 2, TestNodeComparator()).findFrequentSequences()
+            val frequent = SPAM(paths, 2, TestNodeComparator()).findFrequentSequences()
 
             assertThat(frequent).contains(path1)
         }
@@ -63,10 +63,10 @@ internal class FrequentSequenceFinderTest : Spek({
             val path2 = listOf(node2, node1, node2)
 
             val paths = listOf(path1, path2)
-            val patternDetector = FrequentSequenceFinder(paths, 2, TestNodeComparator())
+            val patternDetector = SPAM(paths, 2, TestNodeComparator())
 
             patternDetector.findFrequentSequences()
-            val patterns = patternDetector.mapFrequentSequencesToPaths()
+            val patterns = patternDetector.mapFrequentPatternsToSequences()
 
             assertThat(patterns[listOf(node1, node2)]).isEqualTo(listOf(path1, path2))
         }

--- a/modules/pipeline/spam-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SpamTest.kt
+++ b/modules/pipeline/spam-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/pipeline/patterndetector/spam/SpamTest.kt
@@ -6,7 +6,7 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
-internal class SPAMTest : Spek({
+internal class SpamTest : Spek({
     describe("detecting patterns in a set of sequences") {
         it("should not find a pattern in a set of random nodes with support 2") {
             val node1 = SimpleNode()
@@ -25,7 +25,7 @@ internal class SPAMTest : Spek({
             val sequence3 = listOf(node7, node8, node9, node10)
 
             val sequences = listOf(sequence1, sequence2, sequence3)
-            val frequent = SPAM(sequences, 2, TestNodeComparator()).findFrequentSequences()
+            val frequent = Spam(sequences, 2, TestNodeComparator()).findFrequentPatterns()
 
             assertThat(frequent).isEmpty()
         }
@@ -46,7 +46,7 @@ internal class SPAMTest : Spek({
             val sequence3 = listOf(node6, node7, node8, node9, node1, node2, node2)
 
             val sequences = listOf(sequence1, sequence2, sequence3)
-            val frequent = SPAM(sequences, 2, TestNodeComparator()).findFrequentSequences()
+            val frequent = Spam(sequences, 2, TestNodeComparator()).findFrequentPatterns()
 
             assertThat(frequent).contains(sequence1)
         }
@@ -63,9 +63,9 @@ internal class SPAMTest : Spek({
             val sequence2 = listOf(node2, node1, node2)
 
             val sequences = listOf(sequence1, sequence2)
-            val patternDetector = SPAM(sequences, 2, TestNodeComparator())
+            val patternDetector = Spam(sequences, 2, TestNodeComparator())
 
-            patternDetector.findFrequentSequences()
+            patternDetector.findFrequentPatterns()
             val patterns = patternDetector.mapFrequentPatternsToSequences()
 
             assertThat(patterns[listOf(node1, node2)]).isEqualTo(listOf(sequence1, sequence2))


### PR DESCRIPTION
Rename the confusing `allPath` variable and its derivatives to `sequence` and its derivates:
* `sequence` and its derivatives are used to denote sequences, which more closely coincides with literature
* `patterns` and its derivates are used to denote the output of the algorithm, to more closely coincide with the name of the pipeline

Also rename `FrequentSequenceFinder` to `PrefixSpan` to make clear it uses the PrefixSpan algorithm.
* Make the class internal as it is not used elsewhere.