### PR TITLE
Dokka default

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,11 @@ Please see [releases](../../releases) for more information on what has changed r
 $ ./gradlew check
 ```
 
+## Documentation
+``` bash
+$ ./gradlew dokka
+```
+
 ## Contributing
 Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
 

--- a/build.gradle
+++ b/build.gradle
@@ -65,11 +65,6 @@ allprojects {
         }
     }
 
-    // Dokka
-    dokka {
-        outputFormat = "javadoc"
-    }
-
     // Spotless
     spotless {
         kotlin {


### PR DESCRIPTION
Generating Javadoc-style documentation with Dokka is troublesome and gives many, many, many unnecessary warnings that cannot be disabled. Therefore, I have decided to revert to the default style, which does not have such issues.

Additionally, I have added instructions on how to generate the documentation to the README.
