### PR TITLE
Disable parallel builds in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,9 @@ init:
 
 # Build
 build_script:
-- cmd: gradlew assemble
+- cmd: gradlew assemble --no-parallel
 test_script:
-- cmd: gradlew detektCheck --project-cache-dir=../schaapi-cache check
+- cmd: gradlew detektCheck --project-cache-dir=../schaapi-cache check --no-parallel
 
 
 # Caching


### PR DESCRIPTION
@gandreadis and I suspected that the flakiness of AppVeyor was the result of the parallel builds. To verify this, I forked the Schaapi repo and [ran the `master` build 20 times on AppVeyor](https://ci.appveyor.com/project/FWDekker/schaapi/history): 10 times with parallel builds and 10 times without. With parallel builds enabled, 3 builds failed. Without parallel builds, 0 builds failed. Therefore, it is likely that the parallellism caused AppVeyor to fail.

This PR disables the parallel builds for AppVeyor.
