### PR TITLE
Decrease visibility of GitHub project miner package

### DIFF
--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/GitHubProjectDownloader.kt
@@ -19,7 +19,7 @@ import kotlin.streams.toList
  * @property outputDirectory the directory to store all the project directories
  * @property projectPacker packer which determines what type of [Project] to wrap the project directory in
  */
-class GitHubProjectDownloader<P : Project>(
+internal class GitHubProjectDownloader<P : Project>(
     private val projectNames: Collection<String>,
     private val outputDirectory: File,
     private val projectPacker: (File) -> P

--- a/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/pipeline/miner/github/GitHubProjectDownloader.kt
@@ -24,7 +24,7 @@ internal class GitHubProjectDownloader<P : Project>(
     private val outputDirectory: File,
     private val projectPacker: (File) -> P
 ) {
-    companion object : KLogging()
+    private companion object : KLogging()
 
     /**
      * Starts downloading repositories.

--- a/modules/pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javajar/ProjectCompiler.kt
+++ b/modules/pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javajar/ProjectCompiler.kt
@@ -10,7 +10,7 @@ import java.util.jar.JarInputStream
  * Finds all classes in a Java project consisting of a single JAR.
  */
 class ProjectCompiler : ProjectCompiler<JavaJarProject> {
-    companion object : KLogging()
+    private companion object : KLogging()
 
     override fun compile(project: JavaJarProject): JavaJarProject {
         val classNames = mutableListOf<String>()

--- a/modules/pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javamaven/ProjectCompiler.kt
+++ b/modules/pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/pipeline/projectcompiler/javamaven/ProjectCompiler.kt
@@ -11,7 +11,7 @@ import java.io.File
  * Compiles a Java project using Maven.
  */
 class ProjectCompiler : ProjectCompiler<JavaMavenProject> {
-    companion object : KLogging()
+    private companion object : KLogging()
 
     override fun compile(project: JavaMavenProject): JavaMavenProject {
         runMaven(project)


### PR DESCRIPTION
`GithubProjectDownloader` is not part of the interface, and should therefore not be public. It is now internal.