### PR TITLE
Decrease visibility of classes in Jimple EvoSuite package

### DIFF
--- a/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -49,7 +49,7 @@ internal class ClassGenerator(className: String) {
      * @param methodName the name the method should have
      * @param nodes a list of [Node]s which should be converted into a method
      */
-    internal fun generateMethod(methodName: String, nodes: List<JimpleNode>) {
+    fun generateMethod(methodName: String, nodes: List<JimpleNode>) {
         val statements = nodes.map { it.statement }
         val methodParams = findUnboundVariables(statements)
         val sootMethod = SootMethod(methodName, methodParams.map { it.type }, VoidType.v())
@@ -69,7 +69,7 @@ internal class ClassGenerator(className: String) {
      *
      * @param targetDirectory the path to the base directory in which to place the class file structure
      */
-    internal fun writeToFile(targetDirectory: String) = ClassWriter.writeToFile(sootClass, targetDirectory)
+    fun writeToFile(targetDirectory: String) = ClassWriter.writeToFile(sootClass, targetDirectory)
 
     private fun addParameterAssignmentsToBody(jimpleBody: Body, methodParams: Set<Value>) {
         methodParams.forEachIndexed { paramIndex, param ->

--- a/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -24,7 +24,7 @@ import soot.jimple.internal.JReturnVoidStmt
  *
  * @param className name of [SootClass] to be generated
  */
-class ClassGenerator(className: String) {
+internal class ClassGenerator(className: String) {
     init {
         Scene.v().addBasicClass("java.lang.Object")
     }
@@ -49,7 +49,7 @@ class ClassGenerator(className: String) {
      * @param methodName the name the method should have
      * @param nodes a list of [Node]s which should be converted into a method
      */
-    fun generateMethod(methodName: String, nodes: List<JimpleNode>) {
+    internal fun generateMethod(methodName: String, nodes: List<JimpleNode>) {
         val statements = nodes.map { it.statement }
         val methodParams = findUnboundVariables(statements)
         val sootMethod = SootMethod(methodName, methodParams.map { it.type }, VoidType.v())
@@ -69,7 +69,7 @@ class ClassGenerator(className: String) {
      *
      * @param targetDirectory the path to the base directory in which to place the class file structure
      */
-    fun writeToFile(targetDirectory: String) = ClassWriter.writeToFile(sootClass, targetDirectory)
+    internal fun writeToFile(targetDirectory: String) = ClassWriter.writeToFile(sootClass, targetDirectory)
 
     private fun addParameterAssignmentsToBody(jimpleBody: Body, methodParams: Set<Value>) {
         methodParams.forEachIndexed { paramIndex, param ->
@@ -133,4 +133,4 @@ class ClassGenerator(className: String) {
 /**
  * Exception to denote that a value cannot be stored as a local.
  */
-class ValueIsNotLocalException(value: Value) : RuntimeException("$value cannot be stored as a local.")
+internal class ValueIsNotLocalException(value: Value) : RuntimeException("$value cannot be stored as a local.")

--- a/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/ClassWriter.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/ClassWriter.kt
@@ -22,7 +22,7 @@ internal object ClassWriter {
      * @param sootClass the class to write to file
      * @param targetDirectory the path to the base directory in which to place the class file structure
      */
-    internal fun writeToFile(sootClass: SootClass, targetDirectory: String) {
+    fun writeToFile(sootClass: SootClass, targetDirectory: String) {
         val outputFile = Paths.get(targetDirectory, generateClassFilePath(sootClass.name)).toFile()
         outputFile.parentFile.mkdirs()
         FileOutputStream(outputFile).use {
@@ -36,7 +36,7 @@ internal object ClassWriter {
      * @param sootClass the class to write to a file
      * @param outputStream the [OutputStream] to write the bytecode to
      */
-    internal fun writeToOutputStream(sootClass: SootClass, outputStream: OutputStream) {
+    fun writeToOutputStream(sootClass: SootClass, outputStream: OutputStream) {
         val jasminOutputStream = JasminOutputStream(outputStream)
         val outputWriter = PrintWriter(OutputStreamWriter(jasminOutputStream))
 

--- a/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/ClassWriter.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/ClassWriter.kt
@@ -12,7 +12,7 @@ import java.nio.file.Paths
 /**
  * Functionality for serializing a [SootClass] to JVM bytecode.
  */
-object ClassWriter {
+internal object ClassWriter {
     /**
      * Writes the given [sootClass] to a class file.
      *
@@ -22,7 +22,7 @@ object ClassWriter {
      * @param sootClass the class to write to file
      * @param targetDirectory the path to the base directory in which to place the class file structure
      */
-    fun writeToFile(sootClass: SootClass, targetDirectory: String) {
+    internal fun writeToFile(sootClass: SootClass, targetDirectory: String) {
         val outputFile = Paths.get(targetDirectory, generateClassFilePath(sootClass.name)).toFile()
         outputFile.parentFile.mkdirs()
         FileOutputStream(outputFile).use {
@@ -36,7 +36,7 @@ object ClassWriter {
      * @param sootClass the class to write to a file
      * @param outputStream the [OutputStream] to write the bytecode to
      */
-    fun writeToOutputStream(sootClass: SootClass, outputStream: OutputStream) {
+    internal fun writeToOutputStream(sootClass: SootClass, outputStream: OutputStream) {
         val jasminOutputStream = JasminOutputStream(outputStream)
         val outputWriter = PrintWriter(OutputStreamWriter(jasminOutputStream))
 

--- a/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
@@ -29,7 +29,7 @@ internal class EvoSuiteRunner(
     /**
      * Runs the EvoSuite test generator in a new process.
      */
-    internal fun run() = receiveProcessOutput(buildProcess())
+    fun run() = receiveProcessOutput(buildProcess())
 
     private fun buildProcess() = ProcessBuilder(
         "java",

--- a/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
+++ b/modules/pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
@@ -18,7 +18,7 @@ import java.nio.charset.Charset
  * @property processStandardStream a stream to output EvoSuite's standard messages to
  * @property processErrorStream a stream to output EvoSuite's error messages to
  */
-class EvoSuiteRunner(
+internal class EvoSuiteRunner(
     private val fullyQualifiedClassName: String,
     private val classpath: String,
     private val outputDirectory: String,
@@ -29,7 +29,7 @@ class EvoSuiteRunner(
     /**
      * Runs the EvoSuite test generator in a new process.
      */
-    fun run() = receiveProcessOutput(buildProcess())
+    internal fun run() = receiveProcessOutput(buildProcess())
 
     private fun buildProcess() = ProcessBuilder(
         "java",
@@ -78,4 +78,4 @@ class EvoSuiteRunner(
 /**
  * A [RuntimeException] occurring during the execution of the EvoSuite test generation tool.
  */
-class EvoSuiteRuntimeException(message: String? = null) : RuntimeException(message)
+internal class EvoSuiteRuntimeException(message: String? = null) : RuntimeException(message)


### PR DESCRIPTION
Classes that do not implement the interface should not be public. Therefore, these have been made internal. Their functions have also been made internal, and some have been made private.

The `ValueIsNotLocalException` has been made internal as this should also not be part of the interface, it is only thrown.