### PR TITLE
Make usagegraphgenerator module non-interface classes internal

### DIFF
--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
@@ -17,8 +17,7 @@ internal object ControlFlowGraphGenerator {
      * @param body a Soot method [Body]
      * @return the [Body]'s root [Stmt] wrapped in a [JimpleNode]
      */
-    fun create(body: Body): JimpleNode? =
-        BriefUnitGraph(body).let { transform(it, HashMap(), it.rootUnitIfExists()) }
+    fun create(body: Body): JimpleNode? = BriefUnitGraph(body).let { transform(it, HashMap(), it.rootUnitIfExists()) }
 
     /**
      * Wraps the control flow graph recursively within [JimpleNode] objects.

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
@@ -17,7 +17,7 @@ internal object ControlFlowGraphGenerator {
      * @param body a Soot method [Body]
      * @return the [Body]'s root [Stmt] wrapped in a [JimpleNode]
      */
-    internal fun create(body: Body): JimpleNode? =
+    fun create(body: Body): JimpleNode? =
         BriefUnitGraph(body).let { transform(it, HashMap(), it.rootUnitIfExists()) }
 
     /**

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
@@ -10,14 +10,15 @@ import soot.Unit as SootUnit
 /**
  * Creates the control flow graph of a method body.
  */
-object ControlFlowGraphGenerator {
+internal object ControlFlowGraphGenerator {
     /**
      * Creates the control flow graph of a method body.
      *
      * @param body a Soot method [Body]
      * @return the [Body]'s root [Stmt] wrapped in a [JimpleNode]
      */
-    fun create(body: Body): JimpleNode? = BriefUnitGraph(body).let { transform(it, HashMap(), it.rootUnitIfExists()) }
+    internal fun create(body: Body): JimpleNode? =
+        BriefUnitGraph(body).let { transform(it, HashMap(), it.rootUnitIfExists()) }
 
     /**
      * Wraps the control flow graph recursively within [JimpleNode] objects.
@@ -58,10 +59,10 @@ object ControlFlowGraphGenerator {
  *
  * @return the root of the control flow graph.
  */
-fun UnitGraph.rootUnitIfExists(): SootUnit =
+private fun UnitGraph.rootUnitIfExists(): SootUnit =
     if (heads.isEmpty()) throw NoRootInControlFlowGraphException() else heads[0]
 
 /**
  * Exception for control flow graphs that have no root [SootUnit].
  */
-class NoRootInControlFlowGraphException : Exception("The control flow graph does not contain a root unit.")
+private class NoRootInControlFlowGraphException : Exception("The control flow graph does not contain a root unit.")

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/DotGraphRenderer.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/DotGraphRenderer.kt
@@ -17,7 +17,7 @@ internal class DotGraphRenderer(private val name: String, private val cfg: Node)
      *
      * @return a control flow graph in DOT format.
      */
-    internal fun render(): String {
+    fun render(): String {
         result.append("digraph \"$name()\" {\n")
         render(cfg)
         result.append("}")

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/DotGraphRenderer.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/DotGraphRenderer.kt
@@ -8,7 +8,7 @@ import org.cafejojo.schaapi.models.Node
  * @property name name of the graph.
  * @property cfg control flow graph.
  */
-class DotGraphRenderer(private val name: String, private val cfg: Node) {
+internal class DotGraphRenderer(private val name: String, private val cfg: Node) {
     private val result = StringBuilder()
     private val visited = HashSet<Node>()
 
@@ -17,7 +17,7 @@ class DotGraphRenderer(private val name: String, private val cfg: Node) {
      *
      * @return a control flow graph in DOT format.
      */
-    fun render(): String {
+    internal fun render(): String {
         result.append("digraph \"$name()\" {\n")
         render(cfg)
         result.append("}")

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/BranchStatementFilter.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/BranchStatementFilter.kt
@@ -18,7 +18,7 @@ import soot.toolkits.graph.UnitGraph
  *
  * @param project library project
  */
-class BranchStatementFilter(project: JavaProject) : Filter {
+internal class BranchStatementFilter(project: JavaProject) : Filter {
     internal val valueFilter = ValueFilter(project)
 
     override fun apply(body: Body) {
@@ -41,14 +41,14 @@ class BranchStatementFilter(project: JavaProject) : Filter {
     private fun retain(branch: BranchStatement) =
         branch.hasNonEmptyBranches || valueFilter.retain(getConditionValue(branch.statement))
 
-    companion object {
-        internal fun isBranchStatement(statement: Unit) = when (statement) {
+    private companion object {
+        private fun isBranchStatement(statement: Unit) = when (statement) {
             is IfStmt -> true
             is SwitchStmt -> true
             else -> false
         }
 
-        internal fun getConditionValue(statement: Unit): Value = when (statement) {
+        private fun getConditionValue(statement: Unit): Value = when (statement) {
             is IfStmt -> statement.condition
             is SwitchStmt -> statement.key
             else -> throw IllegalArgumentException("Cannot get value of unsupported statement.")

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/BranchStatementFilter.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/BranchStatementFilter.kt
@@ -42,13 +42,13 @@ internal class BranchStatementFilter(project: JavaProject) : Filter {
         branch.hasNonEmptyBranches || valueFilter.retain(getConditionValue(branch.statement))
 
     private companion object {
-        private fun isBranchStatement(statement: Unit) = when (statement) {
+        fun isBranchStatement(statement: Unit) = when (statement) {
             is IfStmt -> true
             is SwitchStmt -> true
             else -> false
         }
 
-        private fun getConditionValue(statement: Unit): Value = when (statement) {
+        fun getConditionValue(statement: Unit): Value = when (statement) {
             is IfStmt -> statement.condition
             is SwitchStmt -> statement.key
             else -> throw IllegalArgumentException("Cannot get value of unsupported statement.")

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
@@ -28,7 +28,7 @@ internal class StatementFilter(project: JavaProject) : Filter {
      * @param unit a statement.
      * @return whether or not the statement should be kept.
      */
-    internal fun retain(unit: Unit) = when (unit) {
+    fun retain(unit: Unit) = when (unit) {
         is ThrowStmt -> valueFilter.retain(unit.op)
         is DefinitionStmt -> valueFilter.retain(unit.rightOp)
         is IfStmt -> true // defer to BranchStatementFilter

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
@@ -17,7 +17,7 @@ import soot.jimple.ThrowStmt
  *
  * @param project library project
  */
-class StatementFilter(project: JavaProject) : Filter {
+internal class StatementFilter(project: JavaProject) : Filter {
     private val valueFilter = ValueFilter(project)
 
     override fun apply(body: Body) = body.units.snapshotIterator().forEach { if (!retain(it)) body.units.remove(it) }
@@ -28,7 +28,7 @@ class StatementFilter(project: JavaProject) : Filter {
      * @param unit a statement.
      * @return whether or not the statement should be kept.
      */
-    fun retain(unit: Unit) = when (unit) {
+    internal fun retain(unit: Unit) = when (unit) {
         is ThrowStmt -> valueFilter.retain(unit.op)
         is DefinitionStmt -> valueFilter.retain(unit.rightOp)
         is IfStmt -> true // defer to BranchStatementFilter

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -40,7 +40,7 @@ internal class ValueFilter(private val project: JavaProject) {
      * @param value a value.
      * @return whether or not the value should be kept.
      */
-    internal fun retain(value: Value): Boolean = when (value) {
+    fun retain(value: Value): Boolean = when (value) {
         is Expr -> retainExpr(value)
         is Ref -> retainRef(value)
         is Immediate -> retainImmediate(value)

--- a/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/pipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -33,14 +33,14 @@ import soot.shimple.ShimpleExpr
  *
  * @property project library project
  */
-class ValueFilter(private val project: JavaProject) {
+internal class ValueFilter(private val project: JavaProject) {
     /**
      * Filters out non library-using values.
      *
      * @param value a value.
      * @return whether or not the value should be kept.
      */
-    fun retain(value: Value): Boolean = when (value) {
+    internal fun retain(value: Value): Boolean = when (value) {
         is Expr -> retainExpr(value)
         is Ref -> retainRef(value)
         is Immediate -> retainImmediate(value)
@@ -100,4 +100,4 @@ class ValueFilter(private val project: JavaProject) {
 /**
  * Exception for encountered values that are not supported by the [ValueFilter].
  */
-class UnsupportedValueException(message: String) : Exception(message)
+internal class UnsupportedValueException(message: String) : Exception(message)


### PR DESCRIPTION
* Make the `companion object` of `BranchStatementFilter` private, as it is not used elsewhere
* Make filters internal, as these are not part of the interface
* Make extension function in `ControlFlowGraphGenerator` private, including the accompanying Exception, as it used only by this class.
* Make `DotGraphRendered` internal, as it is not part of the interface