### PR TITLE
Move `Pipeline` to `miningpipeline.MiningPipeline`

### DIFF
--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -9,6 +9,7 @@ import org.apache.commons.cli.ParseException
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import org.cafejojo.schaapi.miningpipeline.PatternFilter
+import org.cafejojo.schaapi.miningpipeline.MiningPipeline
 import org.cafejojo.schaapi.miningpipeline.miner.directory.DirectorySearchOptions
 import org.cafejojo.schaapi.miningpipeline.miner.directory.ProjectMiner
 import org.cafejojo.schaapi.miningpipeline.patterndetector.prefixspan.PatternDetector
@@ -44,7 +45,7 @@ fun main(args: Array<String>) {
     val testGeneratorTimeout = cmd.getOptionOrDefault("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
     val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")
 
-    Pipeline(
+    MiningPipeline(
         projectMiner = ProjectMiner { JavaMavenProject(it, mavenDir) },
         searchOptions = DirectorySearchOptions(userBaseDir),
         libraryProjectCompiler = JavaMavenCompiler(),

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
@@ -1,19 +1,12 @@
-package org.cafejojo.schaapi
+package org.cafejojo.schaapi.miningpipeline
 
 import org.cafejojo.schaapi.models.Node
 import org.cafejojo.schaapi.models.Project
-import org.cafejojo.schaapi.miningpipeline.LibraryUsageGraphGenerator
-import org.cafejojo.schaapi.miningpipeline.PatternDetector
-import org.cafejojo.schaapi.miningpipeline.PatternFilter
-import org.cafejojo.schaapi.miningpipeline.ProjectCompiler
-import org.cafejojo.schaapi.miningpipeline.ProjectMiner
-import org.cafejojo.schaapi.miningpipeline.SearchOptions
-import org.cafejojo.schaapi.miningpipeline.TestGenerator
 
 /**
  * Represents the complete Schaapi pipeline.
  */
-class Pipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
+class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
     private val projectMiner: ProjectMiner<SO, UP>,
     private val searchOptions: SO,
     private val libraryProjectCompiler: ProjectCompiler<LP>,


### PR DESCRIPTION
Moves `o.c.s.Pipeline` to `o.c.s.miningpipeline.MiningPipeline`.