### PR TITLE
Skip AppVeyor builds modifying only the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Schaap][schaap-status]](https://github.com/cafejojo/schaapi)
 [![Built with love][baby-dont-hurt-me]](https://github.com/cafejojo/)
 
-Schaapi ensures Safe Changes for APIs of libraries. It specifically focuses on semantic breaking changes, but provides a general-purpose pipeline that is also applicable to detection of other types of breaking changes. The default implementation detects incompatibilities between Java libraries and Java projects using that library.
+Schaapi ensures Safe Changes for APIs of libraries. It focuses on detection of semantic breaking changes, but provides a general-purpose pipeline that is also applicable to the detection of other types of breaking changes. The default implementation detects incompatibilities between Java libraries and Java projects using that library.
 
 ## Requirements and Installation
 Schaapi requires JRE 8 and has been tested on Windows and Unix systems.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,5 +23,5 @@ cache: C:\Users\appveyor\.gradle
 # Skip commits
 skip_commits:
   files:
-  - *.md
+  - '*.md'
   - .gitignore

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,3 +18,9 @@ test_script:
 
 # Caching
 cache: C:\Users\appveyor\.gradle
+
+
+# Skip commits
+skip_commits:
+  files:
+  - README.md

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,4 +23,5 @@ cache: C:\Users\appveyor\.gradle
 # Skip commits
 skip_commits:
   files:
-  - README.md
+  - *.md
+  - .gitignore


### PR DESCRIPTION
Commits only modifying the README.md shouldn't be built. AppVeyor supports such exclusion rules! Rephrases a passage in the README.md to test this.

Travis unfortunately [does not support this](https://github.com/travis-ci/travis-ci/issues/6301).