### PR TITLE
Make All Tests Internal Objects

### DIFF
--- a/modules/mining-pipeline/directory-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/directory/ProjectMinerTest.kt
+++ b/modules/mining-pipeline/directory-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/directory/ProjectMinerTest.kt
@@ -12,7 +12,7 @@ import org.jetbrains.spek.api.dsl.it
 import java.io.File
 import java.net.URLDecoder
 
-internal class ProjectMinerTest : Spek({
+internal object ProjectMinerTest : Spek({
     fun getResourceAsFile(path: String) =
         File(URLDecoder.decode(ProjectMinerTest::class.java.getResource(path).path, "UTF-8"))
 

--- a/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GithubProjectDownloaderTest.kt
+++ b/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GithubProjectDownloaderTest.kt
@@ -14,7 +14,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.file.Files
 
-class GitHubProjectDownloaderTest : Spek({
+internal object GitHubProjectDownloaderTest : Spek({
     var output = Files.createTempDirectory("project-downloader").toFile()
 
     // Create zip file with given dir name (+ zip extension) in output with searchContent single text file with given

--- a/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/TestProject.kt
+++ b/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/TestProject.kt
@@ -3,6 +3,6 @@ package org.cafejojo.schaapi.miningpipeline.miner.github
 import org.cafejojo.schaapi.models.Project
 import java.io.File
 
-class TestProject(override val projectDir: File) : Project
+internal class TestProject(override val projectDir: File) : Project
 
-fun testProjectPacker(projectDir: File) = TestProject(projectDir)
+internal fun testProjectPacker(projectDir: File) = TestProject(projectDir)

--- a/modules/mining-pipeline/java-jar-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javajar/ProjectCompilerTest.kt
+++ b/modules/mining-pipeline/java-jar-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javajar/ProjectCompilerTest.kt
@@ -9,7 +9,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.net.URLDecoder
 
-internal class ProjectCompilerTest : Spek({
+internal object ProjectCompilerTest : Spek({
     describe("Java JAR project compilation") {
         it("compiles simple projects") {
             val projectFile = File(URLDecoder.decode(

--- a/modules/mining-pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/MavenInstallerTest.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/MavenInstallerTest.kt
@@ -7,7 +7,7 @@ import org.jetbrains.spek.api.dsl.it
 import java.io.File
 import java.nio.file.Files
 
-internal class MavenInstallerTest : Spek({
+internal object MavenInstallerTest : Spek({
     lateinit var target: File
 
     beforeEachTest {

--- a/modules/mining-pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/ProjectCompilerTest.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/ProjectCompilerTest.kt
@@ -10,7 +10,7 @@ import java.io.File
 import java.io.FileNotFoundException
 import java.nio.file.Files
 
-internal class ProjectCompilerTest : Spek({
+internal object ProjectCompilerTest : Spek({
     lateinit var mavenHome: File
     lateinit var target: File
 

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -18,7 +18,7 @@ import soot.jimple.StringConstant
 import soot.options.Options
 import java.io.File
 
-internal class ClassGeneratorTest : Spek({
+internal object ClassGeneratorTest : Spek({
     beforeGroup {
         Options.v().set_soot_classpath(
             arrayOf(

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassWriterTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassWriterTest.kt
@@ -9,7 +9,7 @@ import soot.Scene
 import java.nio.file.Paths
 import javax.xml.bind.DatatypeConverter
 
-internal class ClassWriterTest : Spek({
+internal object ClassWriterTest : Spek({
     val classPath = Paths.get(ClassWriterTest::class.java.getResource("../../../../").toURI()).toString()
     val classOutputDirectory = Paths.get(classPath, "class-writer-test/").toFile()
 

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/EvoSuiteRunnerTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/EvoSuiteRunnerTest.kt
@@ -7,7 +7,7 @@ import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import java.io.File
 
-internal class EvoSuiteRunnerTest : Spek({
+internal object EvoSuiteRunnerTest : Spek({
     val classPath = EvoSuiteRunnerTest::class.java.getResource("../../../../../../").toURI().path
     val evoSuiteTestOutput = File("$classPath/evosuite-tests/")
 

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/DotGraphRendererTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/DotGraphRendererTest.kt
@@ -7,7 +7,7 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
-internal class DotGraphRendererTest : Spek({
+internal object DotGraphRendererTest : Spek({
     describe("rendering of statement control flow graphs to dot graph files") {
         it("renders a simple graph") {
             val exitNode = TestNode(id = 5)

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -21,7 +21,7 @@ import soot.jimple.internal.JTableSwitchStmt
 private const val TEST_CLASSES_PACKAGE = "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses"
 private val testClassesClassPath = IntegrationTest::class.java.getResource("../../../../../../").toURI().path
 
-internal class IntegrationTest : Spek({
+internal object IntegrationTest : Spek({
     describe("the integration of different components of the package for simple classes") {
         it("converts a simple class to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
@@ -17,7 +17,7 @@ import soot.jimple.ReturnVoidStmt
 import soot.jimple.SwitchStmt
 import soot.jimple.ThrowStmt
 
-internal class StatementFilterTest : Spek({
+internal object StatementFilterTest : Spek({
     describe("filters statements based on library usage") {
         val libraryValue = constructInvokeExprMock(LIBRARY_CLASS)
         val nonLibraryValue = constructInvokeExprMock(NON_LIBRARY_CLASS)

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilterTest.kt
@@ -34,7 +34,7 @@ import soot.jimple.toolkits.thread.synchronization.NewStaticLock
 import soot.shimple.PhiExpr
 import soot.shimple.ShimpleExpr
 
-internal class ValueFilterTest : Spek({
+internal object ValueFilterTest : Spek({
     val libraryInvokeExpr = constructInvokeExprMock(LIBRARY_CLASS)
     val nonLibraryInvokeExpr = constructInvokeExprMock(NON_LIBRARY_CLASS)
 

--- a/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/IncompleteInitPatternFilterRuleTest.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/IncompleteInitPatternFilterRuleTest.kt
@@ -13,7 +13,7 @@ import soot.jimple.InvokeStmt
 import soot.jimple.ReturnVoidStmt
 import soot.jimple.internal.JSpecialInvokeExpr
 
-internal class IncompleteInitPatternFilterRuleTest : Spek({
+internal object IncompleteInitPatternFilterRuleTest : Spek({
     describe("filtering of init calls without new") {
         it("rejects patterns starting with init calls") {
             val initMethod = mock<SootMethod> {

--- a/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/LengthPatternFilterRuleTest.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/LengthPatternFilterRuleTest.kt
@@ -6,7 +6,7 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
-class LengthPatternFilterRuleTest : Spek({
+internal object LengthPatternFilterRuleTest : Spek({
     describe("when filtering a pattern") {
         it("should return true for a pattern equal to the default length") {
             assertThat(LengthPatternFilterRule().retain(listOf(mock {}, mock {}))).isTrue()

--- a/modules/mining-pipeline/prefix-span-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpanTest.kt
+++ b/modules/mining-pipeline/prefix-span-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpanTest.kt
@@ -7,7 +7,7 @@ import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import org.jetbrains.spek.api.dsl.xit
 
-internal class PrefixSpanTest : Spek({
+internal object PrefixSpanTest : Spek({
     describe("when extracting suffixes from sequences") {
         it("should not return any suffixes if no sequence has prefix") {
             val prefix = listOf(SimpleNode(), SimpleNode())

--- a/modules/mining-pipeline/prefix-span-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/TestNodeComparator.kt
+++ b/modules/mining-pipeline/prefix-span-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/TestNodeComparator.kt
@@ -8,7 +8,7 @@ import org.cafejojo.schaapi.models.Node
  *
  * Two [Node]s are considered equal if they have the same reference.
  */
-class TestNodeComparator<N : Node> : GeneralizedNodeComparator<N> {
+internal class TestNodeComparator<N : Node> : GeneralizedNodeComparator<N> {
     override fun structuresAreEqual(template: N, instance: N) = template === instance
     override fun generalizedValuesAreEqual(template: N, instance: N) = template === instance
     override fun satisfies(template: N, instance: N) = template === instance

--- a/modules/mining-pipeline/spam-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/spam/SpamTest.kt
+++ b/modules/mining-pipeline/spam-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/spam/SpamTest.kt
@@ -6,7 +6,7 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 
-internal class SpamTest : Spek({
+internal object SpamTest : Spek({
     describe("detecting patterns in a set of sequences") {
         it("should not find a pattern in a set of random nodes with support 2") {
             val node1 = SimpleNode()

--- a/modules/mining-pipeline/spam-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/spam/TestNodeComparator.kt
+++ b/modules/mining-pipeline/spam-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/spam/TestNodeComparator.kt
@@ -8,7 +8,7 @@ import org.cafejojo.schaapi.models.Node
  *
  * Two [Node]s are considered equal if they have the same reference.
  */
-class TestNodeComparator<N : Node> : GeneralizedNodeComparator<N> {
+internal class TestNodeComparator<N : Node> : GeneralizedNodeComparator<N> {
     override fun structuresAreEqual(template: N, instance: N) = template === instance
     override fun generalizedValuesAreEqual(template: N, instance: N) = template === instance
     override fun satisfies(template: N, instance: N) = template === instance

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparatorStructureTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparatorStructureTest.kt
@@ -13,7 +13,7 @@ import soot.jimple.ReturnStmt
 /**
  * Unit tests for [GeneralizedNodeComparator.structuresAreEqual].
  */
-internal class GeneralizedNodeComparatorStructureTest : Spek({
+internal object GeneralizedNodeComparatorStructureTest : Spek({
     lateinit var comparator: GeneralizedNodeComparator
 
     beforeEachTest {

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparatorValueTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparatorValueTest.kt
@@ -9,7 +9,7 @@ import org.jetbrains.spek.api.dsl.it
 /**
  * Unit tests for [GeneralizedNodeComparator.generalizedValuesAreEqual].
  */
-internal class GeneralizedNodeComparatorValueTest : Spek({
+internal object GeneralizedNodeComparatorValueTest : Spek({
     lateinit var comparator: GeneralizedNodeComparator
 
     beforeEachTest {

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
@@ -9,7 +9,7 @@ import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import soot.jimple.DefinitionStmt
 
-internal class JimpleNodeTest : Spek({
+internal object JimpleNodeTest : Spek({
     describe("contained values") {
         context("non-recursive statements") {
             it("returns the operator of a throw statement") {

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/SimpleSoot.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/SimpleSoot.kt
@@ -17,7 +17,7 @@ import soot.util.Switch
 /**
  * A [Value] that does not contain other values, and that implements only functionality related to equivalence.
  */
-fun mockValue(type: String): Value = mock {
+internal fun mockValue(type: String): Value = mock {
     on { it.type } doReturn RefType.v(type)
     on { it.useBoxes } doReturn emptyList<ValueBox>()
     on { it.equivTo(any()) } doAnswer { answer ->
@@ -31,7 +31,7 @@ fun mockValue(type: String): Value = mock {
 /**
  * An [InvokeExpr] that does not contain other values, and that implements only functionality related to equivalence.
  */
-fun mockInvokeExpr(type: String): InvokeExpr = mock {
+internal fun mockInvokeExpr(type: String): InvokeExpr = mock {
     on { it.type } doReturn RefType.v(type)
     on { it.useBoxes } doReturn emptyList<ValueBox>()
     on { it.equivTo(any()) } doAnswer { answer ->
@@ -45,13 +45,13 @@ fun mockInvokeExpr(type: String): InvokeExpr = mock {
 /**
  * A simple implementation of [SootMethod].
  */
-class SimpleSootMethod(name: String, parameterTypes: List<String>, returnType: String) :
+internal class SimpleSootMethod(name: String, parameterTypes: List<String>, returnType: String) :
     SootMethod(name, parameterTypes.map { RefType.v(it) }, RefType.v(returnType))
 
 /**
  * A simple implementation of [soot.jimple.internal.AbstractUnopExpr].
  */
-class SimpleUnopExpr(value: Value) : AbstractNegExpr(mockValueBox(value)) {
+internal class SimpleUnopExpr(value: Value) : AbstractNegExpr(mockValueBox(value)) {
     /**
      * Creates a [SimpleUnopExpr] containing a [Value] of the given type.
      */
@@ -63,7 +63,7 @@ class SimpleUnopExpr(value: Value) : AbstractNegExpr(mockValueBox(value)) {
 /**
  * A simple implementation of [soot.jimple.internal.AbstractBinopExpr].
  */
-class SimpleBinopExpr(leftValue: Value, rightValue: Value) : AbstractBinopExpr() {
+internal class SimpleBinopExpr(leftValue: Value, rightValue: Value) : AbstractBinopExpr() {
     init {
         op1Box = mockValueBox(leftValue)
         op2Box = mockValueBox(rightValue)
@@ -88,7 +88,7 @@ class SimpleBinopExpr(leftValue: Value, rightValue: Value) : AbstractBinopExpr()
  * A simple implementation of [soot.jimple.internal.AbstractInvokeExpr].
  */
 @SuppressWarnings("SpreadOperator") // No clean alternative
-class SimpleInvokeExpr(base: Value, sootMethod: SootMethod, vararg arguments: Value) :
+internal class SimpleInvokeExpr(base: Value, sootMethod: SootMethod, vararg arguments: Value) :
     AbstractSpecialInvokeExpr(
         mockValueBox(base),
         mockSootMethodRef(sootMethod),

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/SootMockFactory.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/SootMockFactory.kt
@@ -17,28 +17,28 @@ import soot.jimple.Stmt
 import soot.jimple.SwitchStmt
 import soot.jimple.ThrowStmt
 
-fun mockStmt() = mock<Stmt> {}
+internal fun mockStmt() = mock<Stmt> {}
 
-fun mockThrowStmt(op: Value) = mock<ThrowStmt> { on { it.op } doReturn op }
+internal fun mockThrowStmt(op: Value) = mock<ThrowStmt> { on { it.op } doReturn op }
 
-fun mockDefinitionStmt(leftOp: Value, rightOp: Value) =
+internal fun mockDefinitionStmt(leftOp: Value, rightOp: Value) =
     mock<DefinitionStmt> {
         on { it.leftOp } doReturn leftOp
         on { it.rightOp } doReturn rightOp
     }
 
-fun mockIfStmt(condition: Value) = mock<IfStmt> { on { it.condition } doReturn condition }
+internal fun mockIfStmt(condition: Value) = mock<IfStmt> { on { it.condition } doReturn condition }
 
-fun mockSwitchStmt(key: Value) = mock<SwitchStmt> { on { it.key } doReturn key }
+internal fun mockSwitchStmt(key: Value) = mock<SwitchStmt> { on { it.key } doReturn key }
 
-fun mockInvokeStmt(invokeExpr: InvokeExpr) = mock<InvokeStmt> { on { it.invokeExpr } doReturn invokeExpr }
+internal fun mockInvokeStmt(invokeExpr: InvokeExpr) = mock<InvokeStmt> { on { it.invokeExpr } doReturn invokeExpr }
 
-fun mockReturnStmt(op: Value) = mock<ReturnStmt> { on { it.op } doReturn op }
+internal fun mockReturnStmt(op: Value) = mock<ReturnStmt> { on { it.op } doReturn op }
 
-fun mockGotoStmt() = mock<GotoStmt> {}
+internal fun mockGotoStmt() = mock<GotoStmt> {}
 
-fun mockReturnVoidStmt() = mock<ReturnVoidStmt> {}
+internal fun mockReturnVoidStmt() = mock<ReturnVoidStmt> {}
 
-fun mockValueBox(value: Value) = mock<ValueBox> { on { it.value } doReturn value }
+internal fun mockValueBox(value: Value) = mock<ValueBox> { on { it.value } doReturn value }
 
-fun mockSootMethodRef(sootMethod: SootMethod) = mock<SootMethodRef> { on { it.resolve() } doReturn sootMethod }
+internal fun mockSootMethodRef(sootMethod: SootMethod) = mock<SootMethodRef> { on { it.resolve() } doReturn sootMethod }

--- a/modules/validation-pipeline/junit-test-runner/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/testrunner/junit/TestRunnerTest.kt
+++ b/modules/validation-pipeline/junit-test-runner/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/testrunner/junit/TestRunnerTest.kt
@@ -8,7 +8,7 @@ import org.jetbrains.spek.api.dsl.it
 import java.io.File
 import java.net.URLDecoder
 
-internal class TestRunnerTest : Spek({
+internal object TestRunnerTest : Spek({
     val testPackage = "org.cafejojo.schaapi.validationpipeline.testrunner.junit.test"
     val testDirectory = testPackage.replace(Regex("[.]"), "/")
 


### PR DESCRIPTION
This was done:
* To decrease visibility of tests. They should not be visible outside the module
* There is no need for mutiple instances of tests, so they are all `object`s. This also follows the Spek recommendations.