### PR TITLE
Fix Detekt rule violations

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -25,6 +25,8 @@ style:
     active: false
   UnusedPrivateMember:
     active: false
+  MandatoryBracesIfStatements:
+    active: false
 
 
 test-pattern:

--- a/detekt.yml
+++ b/detekt.yml
@@ -19,13 +19,13 @@ naming:
     active: false
 
 style:
+  MandatoryBracesIfStatements:
+    active: false
   ReturnCount:
     active: false
   UnnecessaryAbstractClass:
     active: false
   UnusedPrivateMember:
-    active: false
-  MandatoryBracesIfStatements:
     active: false
 
 

--- a/modules/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/githubtestreporter/AppKeyGenerator.kt
+++ b/modules/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/githubtestreporter/AppKeyGenerator.kt
@@ -3,10 +3,10 @@ package org.cafejojo.schaapi.githubtestreporter
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import java.nio.file.Files
-import java.security.spec.PKCS8EncodedKeySpec
 import java.nio.file.Paths
 import java.security.KeyFactory
 import java.security.interfaces.RSAPrivateKey
+import java.security.spec.PKCS8EncodedKeySpec
 import java.util.Calendar
 import java.util.Date
 

--- a/modules/mining-pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpan.kt
+++ b/modules/mining-pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpan.kt
@@ -1,10 +1,10 @@
 package org.cafejojo.schaapi.miningpipeline.patterndetector.prefixspan
 
+import org.cafejojo.schaapi.miningpipeline.Pattern
 import org.cafejojo.schaapi.models.CustomEqualsHashSet
 import org.cafejojo.schaapi.models.GeneralizedNodeComparator
 import org.cafejojo.schaapi.models.Node
 import org.cafejojo.schaapi.models.PathUtil
-import org.cafejojo.schaapi.miningpipeline.Pattern
 
 /**
  * Finds all the frequent patterns of [Node]s in the given collection of sequences using the PrefixSpan algorithm by
@@ -87,7 +87,7 @@ internal class PrefixSpan<N : Node>(
     internal fun mapFrequentPatternsToSequences(): Map<Pattern<N>, List<List<N>>> =
         frequentPatterns
             .map { sequence ->
-                Pair(sequence, sequences.filter { pathUtil.pathContainsSequence(it, sequence, nodeComparator) })
+                sequence to sequences.filter { pathUtil.pathContainsSequence(it, sequence, nodeComparator) }
             }
             .toMap()
 

--- a/modules/mining-pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/spam/Spam.kt
+++ b/modules/mining-pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/spam/Spam.kt
@@ -1,10 +1,10 @@
 package org.cafejojo.schaapi.miningpipeline.patterndetector.spam
 
+import org.cafejojo.schaapi.miningpipeline.Pattern
 import org.cafejojo.schaapi.models.CustomEqualsHashSet
 import org.cafejojo.schaapi.models.GeneralizedNodeComparator
 import org.cafejojo.schaapi.models.Node
 import org.cafejojo.schaapi.models.PathUtil
-import org.cafejojo.schaapi.miningpipeline.Pattern
 
 /**
  * Finds frequent sequences of [Node]s in the given collection of sequences, using the SPAM algorithm by Ayres et al.
@@ -44,7 +44,7 @@ internal class Spam<N : Node>(
      */
     internal fun mapFrequentPatternsToSequences(): Map<Pattern<N>, List<List<N>>> =
         frequentPatterns.map { sequence ->
-            Pair(sequence, sequences.filter { pathUtil.pathContainsSequence(it, sequence, nodeComparator) })
+            sequence to sequences.filter { pathUtil.pathContainsSequence(it, sequence, nodeComparator) }
         }.toMap()
 
     @Suppress("UnsafeCast") // pattern: List<N> + extension: N is always a List<N>

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollections.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollections.kt
@@ -39,7 +39,7 @@ class CustomEqualsHashMap<K, V>(
 
     override fun put(key: K, value: V) = innerMap.put(wrapKey(key), value)
 
-    override fun putAll(from: Map<out K, V>) = innerMap.putAll(from.map { (key, value) -> Pair(wrapKey(key), value) })
+    override fun putAll(from: Map<out K, V>) = innerMap.putAll(from.map { (key, value) -> wrapKey(key) to value })
 
     override fun remove(key: K) = innerMap.remove(wrapKey(key))
 

--- a/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollectionsTest.kt
+++ b/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollectionsTest.kt
@@ -89,9 +89,9 @@ class CustomEqualsHashMapTest : Spek({
 
         it("can store multiple key-value pairs in one call") {
             val pairs = listOf(
-                Pair(EqualsWrapper(16445), Any()),
-                Pair(EqualsWrapper(91213), Any()),
-                Pair(EqualsWrapper(23669), Any())
+                EqualsWrapper(16445) to Any(),
+                EqualsWrapper(91213) to Any(),
+                EqualsWrapper(23669) to Any()
             ).toMap()
 
             map.putAll(pairs)

--- a/modules/validation-pipeline/junit-test-runner/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/testrunner/junit/TestRunner.kt
+++ b/modules/validation-pipeline/junit-test-runner/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/testrunner/junit/TestRunner.kt
@@ -30,9 +30,9 @@ class TestRunner : TestRunner {
                     val className = testFile.toRelativeString(rootDir)
                         .replace(Regex("[/\\\\]"), ".")
                         .removeSuffix(".class")
-                    Pair(className, JUnitCore.runClasses(this.javaClass.classLoader.loadClass(className)))
+                    className to JUnitCore.runClasses(this.javaClass.classLoader.loadClass(className))
                 }
-                .map { (name, results) -> Pair(name, gatherResults(results)) }
+                .map { (name, results) -> name to gatherResults(results) }
                 .toMap()
         )
     }


### PR DESCRIPTION
No idea how they got into `master`, but they did, so here are my fixes for them. I agree with the rule preferring 'to' expressions over 'Pair' statements - feel free to disagree, however.

I did not agree with the 'MandatoryBracesIfStatements' rule. Seeing as we don't consistently follow it in the rest of the codebase, either, I turned it off in `detekt.yml`.

Note: This build will likely fail until #200 is merged, as there still remains a failing Windows-test on this branch.