### PR TITLE
Fix key path on Windows in AppKeyGeneratorTest

### DIFF
--- a/modules/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/githubtestreporter/AppKeyGenerator.kt
+++ b/modules/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/githubtestreporter/AppKeyGenerator.kt
@@ -2,6 +2,7 @@ package org.cafejojo.schaapi.githubtestreporter
 
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
+import java.io.File
 import java.nio.file.Files
 import java.security.spec.PKCS8EncodedKeySpec
 import java.nio.file.Paths
@@ -37,7 +38,7 @@ object AppKeyGenerator {
     }
 
     private fun getPrivateKey(filename: String): RSAPrivateKey =
-        Files.readAllBytes(Paths.get(filename))
+        File(filename).readBytes()
             .let { keyBytes -> PKCS8EncodedKeySpec(keyBytes) }
             .let { spec -> KeyFactory.getInstance("RSA").generatePrivate(spec) }
             .let { it as? RSAPrivateKey ?: throw IllegalStateException("Key `$filename` is not a valid key.") }

--- a/modules/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/githubtestreporter/AppKeyGeneratorTest.kt
+++ b/modules/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/githubtestreporter/AppKeyGeneratorTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
 import java.net.URLDecoder
+import java.nio.file.Paths
 
 object AppKeyGeneratorTest : Spek({
     it("generates a jwt token to authenticate as GitHub app") {
@@ -17,4 +18,4 @@ object AppKeyGeneratorTest : Spek({
 })
 
 private fun getResourcePath(path: String) =
-    URLDecoder.decode(AppKeyGeneratorTest::class.java.getResource(path).path, "UTF-8")
+    URLDecoder.decode(Paths.get(AppKeyGeneratorTest::class.java.getResource(path).toURI()).toString(), "UTF-8")

--- a/modules/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/githubtestreporter/AppKeyGeneratorTest.kt
+++ b/modules/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/githubtestreporter/AppKeyGeneratorTest.kt
@@ -18,4 +18,4 @@ object AppKeyGeneratorTest : Spek({
 })
 
 private fun getResourcePath(path: String) =
-    URLDecoder.decode(Paths.get(AppKeyGeneratorTest::class.java.getResource(path).toURI()).toString(), "UTF-8")
+    URLDecoder.decode(AppKeyGeneratorTest::class.java.getResource(path).path, "UTF-8")


### PR DESCRIPTION
The path previously had a leading slash (`/D:/...`) which caused a test failure on Windows setups.

Note: PR builds here will likely fail until #199 (concerning Detekt fixes) is merged.

Also, PR #200 🎉😄 