### PR TITLE
Ignore Gradle wrapper jar and properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,13 +33,13 @@ build/
 gradle-app.setting
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
+# !gradle-wrapper.jar
 
 # Cache of project
 .gradletasknamecache
 
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties
+gradle/wrapper/gradle-wrapper.properties
 
 
 


### PR DESCRIPTION
Because of [this bug in IntelliJ](https://youtrack.jetbrains.com/issue/IDEA-116898), some users have the problem that IntelliJ automatically changes their Gradle wrapper properties and JAR, which makes these files constantly visible in `git status`, which is annoying.

This PR makes git ignore those files.
