### PR TITLE
Speed up frequent singleton detection

### DIFF
--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
@@ -56,16 +56,8 @@ internal class CCSpan<N : Node>(
     }
 
     private fun findFrequentSingletonSequences() {
-        val checkedElements = mutableListOf<N>()
-
-        sequences.flatten().forEach { element ->
-            if (!checkedElements.contains(element)) {
-                val support = calculateSupport(listOf(element))
-                if (support >= minimumSupport) sequencesOfPreviousLength += SequenceTriple(listOf(element), support)
-
-                checkedElements += element
-            }
-        }
+        sequencesOfPreviousLength += pathUtil.findFrequentNodesInPaths(sequences, minimumSupport)
+            .map { (node, support) -> SequenceTriple(listOf(node), support) }
     }
 
     private fun findAllContiguousSequencesOfLength(

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
@@ -1,7 +1,6 @@
 package org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan
 
 import org.cafejojo.schaapi.miningpipeline.Pattern
-import org.cafejojo.schaapi.models.CustomEqualsHashMap
 import org.cafejojo.schaapi.models.GeneralizedNodeComparator
 import org.cafejojo.schaapi.models.Node
 import org.cafejojo.schaapi.models.PathUtil
@@ -38,8 +37,6 @@ internal class CCSpan<N : Node>(
 
         var subSequenceLength = 2
         while (sequencesOfPreviousLength.isNotEmpty()) {
-            val checkedSequences = mutableListOf<List<N>>()
-
             sequences
                 .filter { it.size >= subSequenceLength }
                 .forEach { findAllContiguousSequencesOfLength(it, subSequenceLength) }
@@ -90,20 +87,10 @@ internal class CCSpan<N : Node>(
         }
     }
 
-    private val sequenceSupportMap = CustomEqualsHashMap<List<N>, Int>(
-        { self, other ->
-            other is List<*> && self.size == other.size
-                && self.zip(other).all { it.first.equivTo(it.second as N) }
-        },
-        { self -> self.sumBy { it.equivHashCode() } }
-    )
-
     private fun calculateSupport(sequence: List<N>) =
-        sequenceSupportMap[sequence]
-            ?: sequences
-                .filter { it.size >= sequence.size }
-                .count { pathUtil.pathContainsSequence(it, sequence, nodeComparator) }
-                .also { sequenceSupportMap[sequence] = it }
+        sequences
+            .filter { it.size >= sequence.size }
+            .count { pathUtil.pathContainsSequence(it, sequence, nodeComparator) }
 
     private fun shiftCurrent() {
         sequencesOfPreviousLength.clear()

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
@@ -101,6 +101,7 @@ internal class CCSpan<N : Node>(
     private fun calculateSupport(sequence: List<N>) =
         sequenceSupportMap[sequence]
             ?: sequences
+                .filter { it.size >= sequence.size }
                 .count { pathUtil.pathContainsSequence(it, sequence, nodeComparator) }
                 .also { sequenceSupportMap[sequence] = it }
 

--- a/modules/mining-pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpan.kt
+++ b/modules/mining-pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpan.kt
@@ -71,7 +71,7 @@ internal class PrefixSpan<N : Node>(
      * @return the list of sequences, each a list of nodes, that are common within [sequences]
      */
     internal fun findFrequentPatterns(): List<Pattern<N>> {
-        frequentItems.addAll(pathUtil.findFrequentNodesInPaths(sequences, minimumSupport))
+        frequentItems.addAll(pathUtil.findFrequentNodesInPaths(sequences, minimumSupport).keys)
         runAlgorithm()
 
         return frequentPatterns

--- a/modules/mining-pipeline/prefix-span-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpanTest.kt
+++ b/modules/mining-pipeline/prefix-span-pattern-detector/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpanTest.kt
@@ -69,7 +69,7 @@ internal object PrefixSpanTest : Spek({
             assertThat(frequent).isEmpty()
         }
 
-        it("should find a pattern that occurs twice in the same sequence") {
+        it("should not find a pattern that occurs twice in the same sequence") {
             val node1 = SimpleNode()
             val node2 = SimpleNode()
             val node3 = SimpleNode()
@@ -77,7 +77,7 @@ internal object PrefixSpanTest : Spek({
             val sequence = listOf(node1, node2, node3, node1, node2, node3)
 
             val sequences = listOf(sequence)
-            val frequent = PrefixSpan(sequences, 2, TestNodeComparator()).findFrequentPatterns()
+            val frequent = PrefixSpan(sequences, 1, TestNodeComparator()).findFrequentPatterns()
 
             assertThat(frequent).contains(listOf(node1, node2, node3))
         }

--- a/modules/mining-pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/spam/Spam.kt
+++ b/modules/mining-pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/spam/Spam.kt
@@ -29,7 +29,7 @@ internal class Spam<N : Node>(
      * @return frequent sequences in [sequences]
      */
     internal fun findFrequentPatterns(): List<Pattern<N>> {
-        frequentItems.addAll(pathUtil.findFrequentNodesInPaths(sequences, minimumSupport))
+        frequentItems.addAll(pathUtil.findFrequentNodesInPaths(sequences, minimumSupport).keys)
         frequentItems.forEach { runAlgorithm(listOf(it), frequentItems) }
 
         return frequentPatterns

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathUtil.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathUtil.kt
@@ -26,10 +26,10 @@ class PathUtil<N : Node> {
      * @param minimumCount the minimum number of times a node needs to occur
      * @return the set of nodes occurring at least [minimumCount] times
      */
-    fun findFrequentNodesInPaths(paths: Collection<List<N>>, minimumCount: Int): Set<N> {
+    fun findFrequentNodesInPaths(paths: Collection<List<N>>, minimumCount: Int): Map<N, Int> {
         val nodeCounts = CustomEqualsHashMap<N, Int>(Node.Companion::equiv, Node::equivHashCode)
         paths.forEach { it.forEach { node -> nodeCounts[node] = nodeCounts[node]?.inc() ?: 1 } }
 
-        return nodeCounts.filter { (_, amount) -> amount >= minimumCount }.keys
+        return nodeCounts.filter { (_, amount) -> amount >= minimumCount }
     }
 }

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathUtil.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathUtil.kt
@@ -28,7 +28,11 @@ class PathUtil<N : Node> {
      */
     fun findFrequentNodesInPaths(paths: Collection<List<N>>, minimumCount: Int): Map<N, Int> {
         val nodeCounts = CustomEqualsHashMap<N, Int>(Node.Companion::equiv, Node::equivHashCode)
-        paths.forEach { it.forEach { node -> nodeCounts[node] = nodeCounts[node]?.inc() ?: 1 } }
+        val pathSets = paths.map { path ->
+            CustomEqualsHashSet<N>(Node.Companion::equiv, Node::equivHashCode).also { it.addAll(path) }
+        }
+
+        pathSets.forEach { pathSet -> pathSet.forEach { node -> nodeCounts[node] = nodeCounts[node]?.inc() ?: 1 } }
 
         return nodeCounts.filter { (_, amount) -> amount >= minimumCount }
     }


### PR DESCRIPTION
This PR:

* adapts CCSpan to make use of the PathUtil frequent node finder (which provides a speedup over the current implementation)
* fixes an issue in the PathUtil finder that caused erroneously high support counts in cases where the same element appeared multiple times in the same path
* adds an optimalization for the support check, traversing only sequences with appropriate length