### PR TITLE
Parallelize streaming statements in CCSpan

### DIFF
--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
@@ -77,7 +77,7 @@ internal class CCSpan<N : Node>(
 
     private fun identifyNonClosedSequences() {
         sequencesOfCurrentLength.forEach { (sequence, sequenceSupport, _) ->
-            sequencesOfPreviousLength
+            sequencesOfPreviousLength.parallelStream()
                 .filter {
                     it.isClosedSequence
                         && (it.sequence == sequence.pre() || it.sequence == sequence.post())
@@ -88,9 +88,9 @@ internal class CCSpan<N : Node>(
     }
 
     private fun calculateSupport(sequence: List<N>) =
-        sequences
-            .filter { it.size >= sequence.size }
-            .count { pathUtil.pathContainsSequence(it, sequence, nodeComparator) }
+        sequences.parallelStream()
+            .filter { it.size >= sequence.size && pathUtil.pathContainsSequence(it, sequence, nodeComparator) }
+            .count()
 
     private fun shiftCurrent() {
         sequencesOfPreviousLength.clear()
@@ -99,4 +99,4 @@ internal class CCSpan<N : Node>(
     }
 }
 
-private data class SequenceTriple<N>(val sequence: List<N>, val support: Int, var isClosedSequence: Boolean = true)
+private data class SequenceTriple<N>(val sequence: List<N>, val support: Long, var isClosedSequence: Boolean = true)

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathUtil.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathUtil.kt
@@ -26,8 +26,8 @@ class PathUtil<N : Node> {
      * @param minimumCount the minimum number of times a node needs to occur
      * @return the set of nodes occurring at least [minimumCount] times
      */
-    fun findFrequentNodesInPaths(paths: Collection<List<N>>, minimumCount: Int): Map<N, Int> {
-        val nodeCounts = CustomEqualsHashMap<N, Int>(Node.Companion::equiv, Node::equivHashCode)
+    fun findFrequentNodesInPaths(paths: Collection<List<N>>, minimumCount: Int): Map<N, Long> {
+        val nodeCounts = CustomEqualsHashMap<N, Long>(Node.Companion::equiv, Node::equivHashCode)
         val pathSets = paths.map { path ->
             CustomEqualsHashSet<N>(Node.Companion::equiv, Node::equivHashCode).also { it.addAll(path) }
         }


### PR DESCRIPTION
Converts two streaming calls in CCSpan to parallel streaming calls. Not all in this class could be converted, due to dependencies between steps.

In doing so, the size of the node count types was changed to 'Long' (instead of 'Int'), as the Java streaming API returns that format.