### PR TITLE
Replace missing targets with returns

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -142,15 +142,15 @@ internal class ClassGenerator(className: String) {
     private fun replaceInvalidTargets(statements: List<Unit>) {
         val targetReplacement = statements.last()
 
-        statements.forEach { stmt ->
-            when (stmt) {
-                is GotoStmt -> if (!statements.contains(stmt.target)) stmt.target = targetReplacement
-                is IfStmt -> if (!statements.contains(stmt.target)) stmt.setTarget(targetReplacement)
+        statements.forEach { statement ->
+            when (statement) {
+                is GotoStmt -> if (!statements.contains(statement.target)) statement.target = targetReplacement
+                is IfStmt -> if (!statements.contains(statement.target)) statement.setTarget(targetReplacement)
                 is SwitchStmt -> {
-                    if (!statements.contains(stmt.defaultTarget)) stmt.defaultTarget = targetReplacement
+                    if (!statements.contains(statement.defaultTarget)) statement.defaultTarget = targetReplacement
 
-                    stmt.targets.forEachIndexed { index, target ->
-                        if (!statements.contains(target)) stmt.setTarget(index, targetReplacement)
+                    statement.targets.forEachIndexed { index, target ->
+                        if (!statements.contains(target)) statement.setTarget(index, targetReplacement)
                     }
                 }
             }

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -12,7 +12,10 @@ import soot.Type
 import soot.Unit
 import soot.Value
 import soot.VoidType
+import soot.jimple.GotoStmt
+import soot.jimple.IfStmt
 import soot.jimple.Jimple
+import soot.jimple.SwitchStmt
 import soot.jimple.internal.JReturnStmt
 import soot.jimple.internal.JReturnVoidStmt
 
@@ -62,6 +65,8 @@ internal class ClassGenerator(className: String) {
         addParameterAssignmentsToBody(jimpleBody, methodParams)
         addStatementsToBody(jimpleBody, statements, methodParams)
         sootMethod.returnType = addReturnStatement(jimpleBody)
+
+        replaceInvalidTargets(statements)
     }
 
     /**
@@ -127,6 +132,29 @@ internal class ClassGenerator(className: String) {
         }
 
         return methodParams
+    }
+
+    /**
+     * Replaces invalid targets in [statements] with targets to the last statement.
+     *
+     * @param statements the statements to replace invalid targets in
+     */
+    private fun replaceInvalidTargets(statements: List<Unit>) {
+        val targetReplacement = statements.last()
+
+        statements.forEach { stmt ->
+            when (stmt) {
+                is GotoStmt -> if (!statements.contains(stmt.target)) stmt.target = targetReplacement
+                is IfStmt -> if (!statements.contains(stmt.target)) stmt.setTarget(targetReplacement)
+                is SwitchStmt -> {
+                    if (!statements.contains(stmt.defaultTarget)) stmt.defaultTarget = targetReplacement
+
+                    stmt.targets.forEachIndexed { index, target ->
+                        if (!statements.contains(target)) stmt.setTarget(index, targetReplacement)
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -143,10 +143,10 @@ internal class ClassGenerator(className: String) {
         val targetReplacement = statements.last()
 
         statements.forEach { statement ->
-            when (statement) {
-                is GotoStmt -> if (!statements.contains(statement.target)) statement.target = targetReplacement
-                is IfStmt -> if (!statements.contains(statement.target)) statement.setTarget(targetReplacement)
-                is SwitchStmt -> {
+            when {
+                statement is GotoStmt && !statements.contains(statement.target) -> statement.target = targetReplacement
+                statement is IfStmt && !statements.contains(statement.target) -> statement.setTarget(targetReplacement)
+                statement is SwitchStmt -> {
                     if (!statements.contains(statement.defaultTarget)) statement.defaultTarget = targetReplacement
 
                     statement.targets.forEachIndexed { index, target ->


### PR DESCRIPTION
Overcomes the bug where the `target` of an `GotoStmt`, `IfStmt`, or `SwitchStmt` has been filtered out in the LUG or the pattern detector while a reference to it remains in another statement, making the body invalid.
