### PR TITLE
Logger config

### DIFF
--- a/modules/application/src/main/resources/logback.xml
+++ b/modules/application/src/main/resources/logback.xml
@@ -1,0 +1,11 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/modules/application/src/main/resources/logback.xml
+++ b/modules/application/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
 
-    <root level="debug">
+    <root level="warn">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
Configures the logger to report only messages of levels `WARN` and up.