### PR TITLE
Add log messages to PatternFilterRules

### DIFF
--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/IncompleteInitPatternFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/IncompleteInitPatternFilterRule.kt
@@ -19,6 +19,6 @@ class IncompleteInitPatternFilterRule : PatternFilterRule<JimpleNode> {
         val firstUnit = firstStatement.statement as? InvokeStmt ?: return true
 
         return (firstUnit.invokeExpr !is JSpecialInvokeExpr || firstUnit.invokeExpr.method.name != "<init>")
-            .also { if (it) logger.debug { "Incomplete init pattern was detected: $pattern" } }
+            .also { if (!it) logger.debug { "Incomplete init pattern was detected: $pattern" } }
     }
 }

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/IncompleteInitPatternFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/IncompleteInitPatternFilterRule.kt
@@ -1,7 +1,8 @@
 package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple
 
-import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
+import mu.KLogging
 import org.cafejojo.schaapi.miningpipeline.PatternFilterRule
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import soot.jimple.InvokeStmt
 import soot.jimple.internal.JSpecialInvokeExpr
 
@@ -9,12 +10,15 @@ import soot.jimple.internal.JSpecialInvokeExpr
  * Filters out patterns that start with `<init>` invokes but do not have a new statement.
  */
 class IncompleteInitPatternFilterRule : PatternFilterRule<JimpleNode> {
+    private companion object : KLogging()
+
     override fun retain(pattern: List<JimpleNode>): Boolean {
         if (pattern.isEmpty()) return true
 
         val firstStatement = pattern[0]
         val firstUnit = firstStatement.statement as? InvokeStmt ?: return true
 
-        return firstUnit.invokeExpr !is JSpecialInvokeExpr || firstUnit.invokeExpr.method.name != "<init>"
+        return (firstUnit.invokeExpr !is JSpecialInvokeExpr || firstUnit.invokeExpr.method.name != "<init>")
+            .also { if (it) logger.debug { "Incomplete init pattern was detected: $pattern" } }
     }
 }

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/LengthPatternFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/LengthPatternFilterRule.kt
@@ -1,7 +1,8 @@
 package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple
 
-import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
+import mu.KLogging
 import org.cafejojo.schaapi.miningpipeline.PatternFilterRule
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 
 private const val DEFAULT_MINIMUM_PATTERN_LENGTH = 2
 
@@ -13,5 +14,8 @@ private const val DEFAULT_MINIMUM_PATTERN_LENGTH = 2
  */
 class LengthPatternFilterRule(private val minimumLength: Int = DEFAULT_MINIMUM_PATTERN_LENGTH) :
     PatternFilterRule<JimpleNode> {
-    override fun retain(pattern: List<JimpleNode>): Boolean = pattern.size >= minimumLength
+    private companion object : KLogging()
+
+    override fun retain(pattern: List<JimpleNode>): Boolean =
+        (pattern.size >= minimumLength).also { if (it) logger.debug { "Short pattern was detected: $pattern" } }
 }

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/LengthPatternFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/LengthPatternFilterRule.kt
@@ -1,6 +1,5 @@
 package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple
 
-import mu.KLogging
 import org.cafejojo.schaapi.miningpipeline.PatternFilterRule
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 
@@ -14,8 +13,5 @@ private const val DEFAULT_MINIMUM_PATTERN_LENGTH = 2
  */
 class LengthPatternFilterRule(private val minimumLength: Int = DEFAULT_MINIMUM_PATTERN_LENGTH) :
     PatternFilterRule<JimpleNode> {
-    private companion object : KLogging()
-
-    override fun retain(pattern: List<JimpleNode>): Boolean =
-        (pattern.size >= minimumLength).also { if (it) logger.debug { "Short pattern was detected: $pattern" } }
+    override fun retain(pattern: List<JimpleNode>): Boolean = pattern.size >= minimumLength
 }


### PR DESCRIPTION
What the title says. This makes it easier to see what happens in the pipeline. I'll be adding more log messages to the other pipeline steps soon so we can get a better view of what is happening as well.

Log messages which are not in the `MiningPipeline`, and are in the pipeline steps themselves should usually be `debug`, and sometimes `warn` or `error`, but rarely if ever `info`.