### PR TITLE
Copy nodes in enumerator

### DIFF
--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNode.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNode.kt
@@ -64,4 +64,9 @@ class JimpleNode(val statement: Stmt, override val successors: MutableList<Node>
         getTopLevelValues().forEachIndexed { index, value -> hash += (index + 1) * value.equivHashCode() }
         return hash
     }
+
+    override fun copy() = JimpleNode(
+        statement.clone() as? Stmt ?: throw IllegalStateException("Stmt::clone did not return a Stmt."),
+        successors.toMutableList()
+    )
 }

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
@@ -8,6 +8,7 @@ import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import soot.jimple.DefinitionStmt
+import soot.jimple.Jimple
 
 internal object JimpleNodeTest : Spek({
     describe("contained values") {
@@ -255,6 +256,38 @@ internal object JimpleNodeTest : Spek({
             val node2 = mockDefinitionStmt("right", "left")
 
             assertThat(node1.equivHashCode()).isNotEqualTo(node2.equivHashCode())
+        }
+    }
+
+    describe("Jimple node copy") {
+        it("does not equal the old node") {
+            val stmt = Jimple.v().newBreakpointStmt()
+            val node = JimpleNode(stmt, mutableListOf())
+            val copy = node.copy()
+
+            assertThat(copy).isNotSameAs(stmt)
+            assertThat(copy).isNotEqualTo(stmt)
+        }
+
+        it("is equivalent to the old node") {
+            val stmt = Jimple.v().newBreakpointStmt()
+            val node = JimpleNode(stmt, mutableListOf())
+            val copy = node.copy()
+
+            assertThat(copy.equivTo(node))
+            assertThat(copy.equivHashCode()).isEqualTo(node.equivHashCode())
+        }
+
+        it("uses a different list for the successors") {
+            val stmt = Jimple.v().newBreakpointStmt()
+            val successors = Array(3, { JimpleNode(Jimple.v().newBreakpointStmt()) })
+            val node = JimpleNode(stmt, successors.toMutableList())
+            val copy = node.copy()
+
+            node.successors.removeAt(0)
+
+            assertThat(node.successors).hasSize(2)
+            assertThat(copy.successors).hasSize(3)
         }
     }
 })

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/Node.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/Node.kt
@@ -25,6 +25,13 @@ interface Node : Iterable<Node> {
      */
     fun equivHashCode(): Int
 
+    /**
+     * Constructs an identical copy of this [Node] such that it is [equivTo] this.
+     *
+     * @return an identical copy of this [Node] such that it is [equivTo] this
+     */
+    fun copy(): Node
+
     companion object {
         /**
          * Returns true iff [left] and [right] are [Node]s and [equivTo] returns true.
@@ -44,4 +51,6 @@ open class SimpleNode(override val successors: MutableList<Node> = mutableListOf
     override fun equivTo(other: Node?) = this === other
 
     override fun equivHashCode() = super.hashCode()
+
+    override fun copy() = SimpleNode(successors.toMutableList())
 }

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathEnumerator.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathEnumerator.kt
@@ -45,7 +45,7 @@ class PathEnumerator<N : Node>(
     private fun checkIfExitNodeIsReached(node: Node) =
         node.successors.filter { hasBeenVisitedAtMostOnce(it) }
             .find { it == exitNode }
-            ?.let { allPaths.add(visited.toMutableList()) }
+            ?.let { allPaths.add(visited.map { it.copy() }.toMutableList()) }
 
     private fun visitSuccessors(node: Node) =
         node.successors


### PR DESCRIPTION
## This PR requires #213

When the `PathEnumerator` encounters a loop, it will unroll this loop into a path. However, Soot's `Body` cannot contain duplicates. This means that (part of) the unrolled loop must be copied to be functionally identical, yet still referentially different.

This PR solves that problem by simply copying all nodes while enumerating, ensuring that there are no duplicates in the code.
