### PR TITLE
Stop unrolling loops in the `PathEnumerator`

### DIFF
--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathEnumerator.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathEnumerator.kt
@@ -43,13 +43,13 @@ class PathEnumerator<N : Node>(
     }
 
     private fun checkIfExitNodeIsReached(node: Node) =
-        node.successors.filter { hasBeenVisitedAtMostOnce(it) }
+        node.successors.filter { hasNotBeenVisited(it) }
             .find { it == exitNode }
             ?.let { allPaths.add(visited.toMutableList()) }
 
     private fun visitSuccessors(node: Node) =
         node.successors
-            .filter { hasBeenVisitedAtMostOnce(it) && it != exitNode }
+            .filter { hasNotBeenVisited(it) && it != exitNode }
             .forEach {
                 if (visited.size < maximumPathLength) {
                     visited.push(it)
@@ -58,7 +58,7 @@ class PathEnumerator<N : Node>(
                 }
             }
 
-    private fun hasBeenVisitedAtMostOnce(node: Node) = visited.count { it == node } <= 1
+    private fun hasNotBeenVisited(node: Node) = visited.none { it == node }
 }
 
 /**

--- a/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/PathEnumeratorTest.kt
+++ b/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/PathEnumeratorTest.kt
@@ -92,8 +92,7 @@ internal class PathEnumeratorTest : Spek({
             assertThat(paths)
                 .isEqualTo(
                     listOf(
-                        listOf(node1, node2, node3, node4),
-                        listOf(node1, node2, node3, node2, node3, node4)
+                        listOf(node1, node2, node3, node4)
                     )
                 )
         }
@@ -117,9 +116,7 @@ internal class PathEnumeratorTest : Spek({
             assertThat(paths)
                 .isEqualTo(
                     listOf(
-                        listOf(node1, node2, node3, node4, node5, node6),
-                        listOf(node1, node2, node3, node4, node5, node2, node3, node4, node5, node6),
-                        listOf(node1, node2, node3, node4, node3, node4, node5, node6)
+                        listOf(node1, node2, node3, node4, node5, node6)
                     )
                 )
         }


### PR DESCRIPTION
The current `PathEnumerator` is bugged because it is unable to detect loop blocks, and will therefore copy entire for loops including their condition (which is useless). This PR works around that issue by no longer unrolling loops, simply leaving the loops in the path.
