### PR TITLE
Multiple pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ usage: schaapi -o <arg> -l <arg> -u <arg> [--maven_dir <arg>]
                                                        should have a dependency on.
  -m,--max_projects <arg>                               Maximum amount of projects to 
                                                        download from GitHub. 
+    --flavor <arg>                                     The flavor of the desired pipeline.
     --maven_dir <arg>                                  The directory to
                                                        run Maven from.
     --repair_maven                                     Repairs the Maven

--- a/modules/application/build.gradle
+++ b/modules/application/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     compile project(":models:jimple-library-usage-graph")
 
     compile project(":mining-pipeline:github-project-miner")
+    compile project(":mining-pipeline:directory-project-miner")
     compile project(":mining-pipeline:java-jar-project-compiler")
     compile project(":mining-pipeline:java-maven-project-compiler")
     compile project(":mining-pipeline:jimple-evosuite-test-generator")

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -22,7 +22,7 @@ internal const val DEFAULT_MAX_SEQUENCE_LENGTH = "25"
 fun main(args: Array<String>) {
     val options = buildOptions()
         .apply { DirectoryMiningCommandLineInterface.addOptionsTo(this) }
-        .apply { GithubMiningCommandLineInterface.addOptionsTo(this) }
+        .apply { GitHubMiningCommandLineInterface.addOptionsTo(this) }
 
     val cmd = parseArgs(options, args) ?: return
 
@@ -38,7 +38,7 @@ fun main(args: Array<String>) {
     try {
         when (type) {
             "directory" -> DirectoryMiningCommandLineInterface().run(cmd, mavenDir, library, output)
-            "github" -> GithubMiningCommandLineInterface().run(cmd, mavenDir, library, output)
+            "github" -> GitHubMiningCommandLineInterface().run(cmd, mavenDir, library, output)
             else -> println("Given pipeline_type was not recognized.")
         }
     } catch (e: MissingArgumentException) {

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -51,8 +51,8 @@ private fun buildOptions(): Options =
     Options()
         .addOption(Option
             .builder()
-            .longOpt("pipeline_type")
-            .desc("The desired pipeline type")
+            .longOpt("flavor")
+            .desc("The desired pipeline flavor")
             .hasArg()
             .build())
         .addOption(Option
@@ -133,4 +133,14 @@ private fun printHelpMessage(options: Options) {
  * @param default the value to return if the option's value is null
  * @return [CommandLine.getOptionValue], unless this is null, in which case [default] is returned
  */
-fun CommandLine.getOptionOrDefault(option: String, default: String) = getOptionValue(option) ?: default
+internal fun CommandLine.getOptionOrDefault(option: String, default: String) = getOptionValue(option) ?: default
+
+/**
+ * Returns [CommandLine.getOptionValue], unless this is null, in which case a [MissingArgumentException] is thrown.
+ *
+ * @param option the name of the option
+ * @return [CommandLine.getOptionValue], unless this is null, in which case a [MissingArgumentException] is thrown
+ * with the [option] in its message
+ */
+internal fun CommandLine.getOptionOrThrowException(option: String) =
+    getOptionValue(option) ?: throw MissingArgumentException(option)

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -6,27 +6,13 @@ import org.apache.commons.cli.HelpFormatter
 import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
 import org.apache.commons.cli.ParseException
-import org.cafejojo.schaapi.miningpipeline.MiningPipeline
-import org.cafejojo.schaapi.miningpipeline.PatternFilter
-import org.cafejojo.schaapi.miningpipeline.miner.github.MavenProjectSearchOptions
-import org.cafejojo.schaapi.miningpipeline.miner.github.ProjectMiner
-import org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan.PatternDetector
-import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.IncompleteInitPatternFilterRule
-import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.LengthPatternFilterRule
-import org.cafejojo.schaapi.miningpipeline.projectcompiler.javajar.ProjectCompiler
 import org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.MavenInstaller
-import org.cafejojo.schaapi.miningpipeline.testgenerator.jimpleevosuite.TestGenerator
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.LibraryUsageGraphGenerator
-import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
-import org.cafejojo.schaapi.models.project.JavaJarProject
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import java.io.File
-import org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.ProjectCompiler as JavaMavenCompiler
 
-private const val DEFAULT_TEST_GENERATOR_TIMEOUT = "60"
-private const val DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT = "2"
-private const val DEFAULT_MAX_PROJECTS = "20"
-private const val DEFAULT_MAXIMUM_SEQUENCE_LENGTH = "25"
+internal const val DEFAULT_TEST_GENERATOR_TIMEOUT = "60"
+internal const val DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT = "2"
+internal const val DEFAULT_MAX_SEQUENCE_LENGTH = "25"
 
 /**
  * Runs the complete first phase of the Schaapi pipeline.
@@ -39,49 +25,34 @@ fun main(args: Array<String>) {
 
     val mavenDir = File(cmd.getOptionValue("maven_dir") ?: JavaMavenProject.DEFAULT_MAVEN_HOME.absolutePath)
     val output = File(cmd.getOptionValue('o')).apply { mkdirs() }
-    val library = JavaJarProject(File(cmd.getOptionValue('l')))
-
-    val token = cmd.getOptionValue("github_oauth_token") ?: return
-    val maxProjects = cmd.getOptionOrDefault("max_projects", DEFAULT_MAX_PROJECTS).toInt()
-    val groupId = cmd.getOptionValue("library_group_id") ?: return
-    val artifactId = cmd.getOptionValue("library_artifact_id") ?: return
-    val version = cmd.getOptionValue("library_version") ?: return
+    val library = File(cmd.getOptionValue('l'))
 
     if (!mavenDir.resolve("bin/mvn").exists() || cmd.hasOption("repair_maven")) {
         MavenInstaller().installMaven(mavenDir)
     }
 
-    val testGeneratorTimeout = cmd.getOptionOrDefault("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
-    val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")
-
-    MiningPipeline(
-        outputDirectory = output,
-        projectMiner = ProjectMiner(token, output) { JavaMavenProject(it, mavenDir) },
-        searchOptions = MavenProjectSearchOptions(groupId, artifactId, version, maxProjects),
-        libraryProjectCompiler = ProjectCompiler(),
-        userProjectCompiler = JavaMavenCompiler(),
-        libraryUsageGraphGenerator = LibraryUsageGraphGenerator,
-        patternDetector = PatternDetector(
-            cmd.getOptionOrDefault("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt(),
-            cmd.getOptionOrDefault("pattern_detector_maximum_sequence_length", DEFAULT_MAXIMUM_SEQUENCE_LENGTH).toInt(),
-            GeneralizedNodeComparator()
-        ),
-        patternFilter = PatternFilter(
-            IncompleteInitPatternFilterRule(),
-            LengthPatternFilterRule()
-        ),
-        testGenerator = TestGenerator(
-            library = library,
-            outputDirectory = output,
-            timeout = testGeneratorTimeout,
-            processStandardStream = if (testGeneratorEnableOutput) System.out else null,
-            processErrorStream = if (testGeneratorEnableOutput) System.out else null
-        )
-    ).run(library)
+    val type = cmd.getOptionOrDefault("pipeline_type", "")
+    try {
+        when (type) {
+            "directory" -> DirectoryMiningCommandLineInterface().run(cmd, mavenDir, library, output)
+            "github" -> GithubMiningCommandLineInterface().run(cmd, mavenDir, library, output)
+            else -> println("Given pipeline_type was not recognized.")
+        }
+    } catch (e: MissingArgumentException) {
+        println(e.messageForType(type))
+    }
 }
 
 private fun buildOptions(): Options =
     Options()
+        .addOption(Option
+            .builder()
+            .longOpt("pipeline_type")
+            .desc("The desired pipeline type")
+            .hasArg()
+            .required()
+            .build()
+        )
         .addOption(Option
             .builder("o")
             .longOpt("output_dir")
@@ -119,21 +90,18 @@ private fun buildOptions(): Options =
             .longOpt("library_group_id")
             .desc("Group id of library mined projects should have a dependency on.")
             .hasArg()
-            .required()
             .build())
         .addOption(Option
             .builder()
             .longOpt("library_artifact_id")
             .desc("Artifact id of library mined projects should have a dependency on.")
             .hasArg()
-            .required()
             .build())
         .addOption(Option
             .builder()
             .longOpt("library_version")
             .desc("Version of library mined projects should have a dependency on.")
             .hasArg()
-            .required()
             .build())
         .addOption(Option
             .builder()
@@ -180,6 +148,7 @@ private fun parseArgs(options: Options, args: Array<String>): CommandLine? {
     return try {
         parser.parse(options, args)
     } catch (e: ParseException) {
+        println(e.message)
         printHelpMessage(options)
         null
     }
@@ -198,5 +167,4 @@ private fun printHelpMessage(options: Options) {
  * @param default the value to return if the option's value is null
  * @return [CommandLine.getOptionValue], unless this is null, in which case [default] is returned
  */
-fun CommandLine.getOptionOrDefault(option: String, default: String) =
-    getOptionValue(option) ?: default
+fun CommandLine.getOptionOrDefault(option: String, default: String) = getOptionValue(option) ?: default

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -1,5 +1,6 @@
 package org.cafejojo.schaapi
 
+import mu.KLogging
 import org.apache.commons.cli.CommandLine
 import org.apache.commons.cli.DefaultParser
 import org.apache.commons.cli.HelpFormatter
@@ -40,10 +41,10 @@ fun main(args: Array<String>) {
         when (flavor) {
             "directory" -> DirectoryMiningCommandLineInterface().run(cmd, mavenDir, library, output)
             "github" -> GitHubMiningCommandLineInterface().run(cmd, mavenDir, library, output)
-            else -> println("Given pipeline_type was not recognized.")
+            else -> KLogging().logger.error { "Given pipeline flavor was not recognized." }
         }
     } catch (e: MissingArgumentException) {
-        println(e.messageForFlavor(flavor))
+        KLogging().logger.error { e.messageForFlavor(flavor) }
     }
 }
 

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -21,6 +21,9 @@ internal const val DEFAULT_MAX_SEQUENCE_LENGTH = "25"
  */
 fun main(args: Array<String>) {
     val options = buildOptions()
+        .apply { DirectoryMiningCommandLineInterface.addOptionsTo(this) }
+        .apply { GithubMiningCommandLineInterface.addOptionsTo(this) }
+
     val cmd = parseArgs(options, args) ?: return
 
     val mavenDir = File(cmd.getOptionValue("maven_dir") ?: JavaMavenProject.DEFAULT_MAVEN_HOME.absolutePath)
@@ -51,8 +54,7 @@ private fun buildOptions(): Options =
             .desc("The desired pipeline type")
             .hasArg()
             .required()
-            .build()
-        )
+            .build())
         .addOption(Option
             .builder("o")
             .longOpt("output_dir")
@@ -66,42 +68,6 @@ private fun buildOptions(): Options =
             .desc("The library directory.")
             .hasArg()
             .required()
-            .build())
-        .addOption(Option
-            .builder("u")
-            .longOpt("user_base_dir")
-            .desc("The directory containing user project directories.")
-            .hasArg()
-            .build())
-        .addOption(Option
-            .builder("t")
-            .longOpt("github_oauth_token")
-            .desc("Token of GitHub account used for searching.")
-            .hasArg()
-            .build())
-        .addOption(Option
-            .builder()
-            .longOpt("max_projects")
-            .desc("Maximum amount of projects to download from GitHub.")
-            .hasArg()
-            .build())
-        .addOption(Option
-            .builder()
-            .longOpt("library_group_id")
-            .desc("Group id of library mined projects should have a dependency on.")
-            .hasArg()
-            .build())
-        .addOption(Option
-            .builder()
-            .longOpt("library_artifact_id")
-            .desc("Artifact id of library mined projects should have a dependency on.")
-            .hasArg()
-            .build())
-        .addOption(Option
-            .builder()
-            .longOpt("library_version")
-            .desc("Version of library mined projects should have a dependency on.")
-            .hasArg()
             .build())
         .addOption(Option
             .builder()

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -10,6 +10,7 @@ import org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.MavenInstal
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import java.io.File
 
+internal const val DEFAULT_PIPELINE_TYPE = "directory"
 internal const val DEFAULT_TEST_GENERATOR_TIMEOUT = "60"
 internal const val DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT = "2"
 internal const val DEFAULT_MAX_SEQUENCE_LENGTH = "25"
@@ -34,7 +35,7 @@ fun main(args: Array<String>) {
         MavenInstaller().installMaven(mavenDir)
     }
 
-    val type = cmd.getOptionOrDefault("pipeline_type", "")
+    val type = cmd.getOptionOrDefault("pipeline_type", DEFAULT_PIPELINE_TYPE)
     try {
         when (type) {
             "directory" -> DirectoryMiningCommandLineInterface().run(cmd, mavenDir, library, output)
@@ -53,7 +54,6 @@ private fun buildOptions(): Options =
             .longOpt("pipeline_type")
             .desc("The desired pipeline type")
             .hasArg()
-            .required()
             .build())
         .addOption(Option
             .builder("o")

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -43,7 +43,7 @@ fun main(args: Array<String>) {
             else -> println("Given pipeline_type was not recognized.")
         }
     } catch (e: MissingArgumentException) {
-        println(e.messageForType(type))
+        println(e.messageForFlavor(type))
     }
 }
 

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -35,15 +35,15 @@ fun main(args: Array<String>) {
         MavenInstaller().installMaven(mavenDir)
     }
 
-    val type = cmd.getOptionOrDefault("pipeline_type", DEFAULT_PIPELINE_TYPE)
+    val flavor = cmd.getOptionOrDefault("flavor", DEFAULT_PIPELINE_TYPE)
     try {
-        when (type) {
+        when (flavor) {
             "directory" -> DirectoryMiningCommandLineInterface().run(cmd, mavenDir, library, output)
             "github" -> GitHubMiningCommandLineInterface().run(cmd, mavenDir, library, output)
             else -> println("Given pipeline_type was not recognized.")
         }
     } catch (e: MissingArgumentException) {
-        println(e.messageForFlavor(type))
+        println(e.messageForFlavor(flavor))
     }
 }
 

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -1,6 +1,8 @@
 package org.cafejojo.schaapi
 
 import org.apache.commons.cli.CommandLine
+import org.apache.commons.cli.Option
+import org.apache.commons.cli.Options
 import org.cafejojo.schaapi.miningpipeline.MiningPipeline
 import org.cafejojo.schaapi.miningpipeline.PatternFilter
 import org.cafejojo.schaapi.miningpipeline.miner.directory.DirectorySearchOptions
@@ -21,6 +23,16 @@ import java.io.File
  * Assumes that the passed library is a java maven project.
  */
 internal class DirectoryMiningCommandLineInterface {
+    companion object {
+        internal fun addOptionsTo(options: Options) = options
+            .addOption(Option
+                .builder("u")
+                .longOpt("user_base_dir")
+                .desc("The directory containing user project directories.")
+                .hasArg()
+                .build())
+    }
+
     /**
      * Mines a Directory.
      *

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -50,7 +50,7 @@ internal class DirectoryMiningCommandLineInterface {
         val maxSequenceLength = cmd
             .getOptionOrDefault("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
 
-        val libraryMaven = JavaMavenProject(library)
+        val libraryMaven = JavaMavenProject(library, mavenDir)
 
         MiningPipeline(
             outputDirectory = output,

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -24,8 +24,8 @@ import java.io.File
  */
 internal class DirectoryMiningCommandLineInterface {
     internal companion object {
-        fun addOptionsTo(options: Options): Options = options
-            .addOption(Option
+        fun addOptionsTo(options: Options): Options =
+            options.addOption(Option
                 .builder("u")
                 .longOpt("user_base_dir")
                 .desc("The directory containing user project directories.")

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -39,7 +39,7 @@ internal class DirectoryMiningCommandLineInterface {
      * @throws [MissingArgumentException] if required arguments not set in [CommandLine].
      */
     fun run(cmd: CommandLine, mavenDir: File, library: File, output: File) {
-        val userDirDirs = cmd.getOptionValue('u') ?: throw MissingArgumentException("u")
+        val userDirDirs = cmd.getOptionOrThrowException("u")
 
         val testGeneratorTimeout = cmd
             .getOptionOrDefault("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -1,0 +1,61 @@
+package org.cafejojo.schaapi
+
+import org.apache.commons.cli.CommandLine
+import org.cafejojo.schaapi.miningpipeline.MiningPipeline
+import org.cafejojo.schaapi.miningpipeline.PatternFilter
+import org.cafejojo.schaapi.miningpipeline.miner.directory.DirectorySearchOptions
+import org.cafejojo.schaapi.miningpipeline.miner.directory.ProjectMiner
+import org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan.PatternDetector
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.IncompleteInitPatternFilterRule
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.LengthPatternFilterRule
+import org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.ProjectCompiler
+import org.cafejojo.schaapi.miningpipeline.testgenerator.jimpleevosuite.TestGenerator
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.LibraryUsageGraphGenerator
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
+import org.cafejojo.schaapi.models.project.JavaMavenProject
+import java.io.File
+
+/**
+ * Mines a directory for user projects and generates tests based on these projects.
+ *
+ * Assumes that the passed library is a java maven project.
+ */
+internal class DirectoryMiningCommandLineInterface {
+    /**
+     * Mines a Directory.
+     *
+     * @throws [MissingArgumentException] if required arguments not set in [CommandLine].
+     */
+    fun run(cmd: CommandLine, mavenDir: File, library: File, output: File) {
+        val userDirDirs = cmd.getOptionValue('u') ?: throw MissingArgumentException("u")
+
+        val testGeneratorTimeout = cmd
+            .getOptionOrDefault("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
+        val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")
+
+        val patternDetectorMinCount = cmd
+            .getOptionOrDefault("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
+        val maxSequenceLength = cmd
+            .getOptionOrDefault("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
+
+        val libraryMaven = JavaMavenProject(library)
+
+        MiningPipeline(
+            outputDirectory = output,
+            projectMiner = ProjectMiner { JavaMavenProject(it, mavenDir) },
+            searchOptions = DirectorySearchOptions(File(userDirDirs)),
+            libraryProjectCompiler = ProjectCompiler(),
+            userProjectCompiler = ProjectCompiler(),
+            libraryUsageGraphGenerator = LibraryUsageGraphGenerator,
+            patternDetector = PatternDetector(patternDetectorMinCount, maxSequenceLength, GeneralizedNodeComparator()),
+            patternFilter = PatternFilter(IncompleteInitPatternFilterRule(), LengthPatternFilterRule()),
+            testGenerator = TestGenerator(
+                library = libraryMaven,
+                outputDirectory = output,
+                timeout = testGeneratorTimeout,
+                processStandardStream = if (testGeneratorEnableOutput) System.out else null,
+                processErrorStream = if (testGeneratorEnableOutput) System.out else null
+            )
+        ).run(libraryMaven)
+    }
+}

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -20,7 +20,7 @@ import java.io.File
 /**
  * Mines a directory for user projects and generates tests based on these projects.
  *
- * Assumes that the passed library is a java maven project.
+ * Assumes that the passed library is a Java Maven project.
  */
 internal class DirectoryMiningCommandLineInterface {
     internal companion object {

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -23,7 +23,7 @@ import java.io.File
  * Assumes that the passed library is a java maven project.
  */
 internal class DirectoryMiningCommandLineInterface {
-    companion object {
+    internal companion object {
         fun addOptionsTo(options: Options): Options = options
             .addOption(Option
                 .builder("u")

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -24,7 +24,7 @@ import java.io.File
  */
 internal class DirectoryMiningCommandLineInterface {
     companion object {
-        internal fun addOptionsTo(options: Options) = options
+        fun addOptionsTo(options: Options): Options = options
             .addOption(Option
                 .builder("u")
                 .longOpt("user_base_dir")

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -18,7 +18,7 @@ import org.cafejojo.schaapi.models.project.JavaJarProject
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import java.io.File
 
-private const val DEFAULT_MAX_PROJECTS = "20"
+internal const val DEFAULT_MAX_PROJECTS = "20"
 
 /**
  * Mines GitHub for user projects and generates tests based on these projects.

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -27,37 +27,38 @@ internal const val DEFAULT_MAX_PROJECTS = "20"
  */
 internal class GitHubMiningCommandLineInterface {
     internal companion object {
-        fun addOptionsTo(options: Options): Options = options
-            .addOption(Option
-                .builder()
-                .longOpt("github_oauth_token")
-                .desc("Token of GitHub account used for searching.")
-                .hasArg()
-                .build())
-            .addOption(Option
-                .builder()
-                .longOpt("max_projects")
-                .desc("Maximum amount of projects to download from GitHub.")
-                .hasArg()
-                .build())
-            .addOption(Option
-                .builder()
-                .longOpt("library_group_id")
-                .desc("Group id of library mined projects should have a dependency on.")
-                .hasArg()
-                .build())
-            .addOption(Option
-                .builder()
-                .longOpt("library_artifact_id")
-                .desc("Artifact id of library mined projects should have a dependency on.")
-                .hasArg()
-                .build())
-            .addOption(Option
-                .builder()
-                .longOpt("library_version")
-                .desc("Version of library mined projects should have a dependency on.")
-                .hasArg()
-                .build())
+        fun addOptionsTo(options: Options): Options =
+            options
+                .addOption(Option
+                    .builder()
+                    .longOpt("github_oauth_token")
+                    .desc("Token of GitHub account used for searching.")
+                    .hasArg()
+                    .build())
+                .addOption(Option
+                    .builder()
+                    .longOpt("max_projects")
+                    .desc("Maximum amount of projects to download from GitHub.")
+                    .hasArg()
+                    .build())
+                .addOption(Option
+                    .builder()
+                    .longOpt("library_group_id")
+                    .desc("Group id of library mined projects should have a dependency on.")
+                    .hasArg()
+                    .build())
+                .addOption(Option
+                    .builder()
+                    .longOpt("library_artifact_id")
+                    .desc("Artifact id of library mined projects should have a dependency on.")
+                    .hasArg()
+                    .build())
+                .addOption(Option
+                    .builder()
+                    .longOpt("library_version")
+                    .desc("Version of library mined projects should have a dependency on.")
+                    .hasArg()
+                    .build())
     }
 
     /**
@@ -65,7 +66,6 @@ internal class GitHubMiningCommandLineInterface {
      *
      * @throws [MissingArgumentException] if required arguments not set in [CommandLine].
      */
-    @Suppress("ThrowsCount") // No real reason to do it differently
     fun run(cmd: CommandLine, mavenDir: File, library: File, output: File) {
         val token = cmd.getOptionOrThrowException("github_oauth_token")
         val maxProjects = cmd.getOptionOrDefault("max_projects", DEFAULT_MAX_PROJECTS).toInt()

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -67,12 +67,11 @@ internal class GitHubMiningCommandLineInterface {
      */
     @Suppress("ThrowsCount") // No real reason to do it differently
     fun run(cmd: CommandLine, mavenDir: File, library: File, output: File) {
-        val token = cmd.getOptionValue("github_oauth_token") ?: throw MissingArgumentException("github_oauth_token")
+        val token = cmd.getOptionOrThrowException("github_oauth_token")
         val maxProjects = cmd.getOptionOrDefault("max_projects", DEFAULT_MAX_PROJECTS).toInt()
-        val groupId = cmd.getOptionValue("library_group_id") ?: throw MissingArgumentException("library_group_id")
-        val artifactId = cmd.getOptionValue("library_artifact_id")
-            ?: throw MissingArgumentException("library_artifact_id")
-        val version = cmd.getOptionValue("library_version") ?: throw MissingArgumentException("library_version")
+        val groupId = cmd.getOptionOrThrowException("library_group_id")
+        val artifactId = cmd.getOptionOrThrowException("library_artifact_id")
+        val version = cmd.getOptionOrThrowException("library_version")
 
         val patternDetectorMinCount = cmd
             .getOptionOrDefault("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -25,9 +25,9 @@ private const val DEFAULT_MAX_PROJECTS = "20"
  *
  * Assumes that the passed library is a java jar project.
  */
-internal class GithubMiningCommandLineInterface {
+internal class GitHubMiningCommandLineInterface {
     companion object {
-        internal fun addOptionsTo(options: Options) = options
+        fun addOptionsTo(options: Options): Options = options
             .addOption(Option
                 .builder()
                 .longOpt("github_oauth_token")

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -26,7 +26,7 @@ private const val DEFAULT_MAX_PROJECTS = "20"
  * Assumes that the passed library is a java jar project.
  */
 internal class GitHubMiningCommandLineInterface {
-    companion object {
+    internal companion object {
         fun addOptionsTo(options: Options): Options = options
             .addOption(Option
                 .builder()

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -62,7 +62,7 @@ internal class GitHubMiningCommandLineInterface {
     }
 
     /**
-     * Mine GitHub.
+     * Mines GitHub.
      *
      * @throws [MissingArgumentException] if required arguments not set in [CommandLine].
      */

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -23,7 +23,7 @@ internal const val DEFAULT_MAX_PROJECTS = "20"
 /**
  * Mines GitHub for user projects and generates tests based on these projects.
  *
- * Assumes that the passed library is a java jar project.
+ * Assumes that the passed library is a Java JAR project.
  */
 internal class GitHubMiningCommandLineInterface {
     internal companion object {

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GithubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GithubMiningCommandLineInterface.kt
@@ -1,6 +1,8 @@
 package org.cafejojo.schaapi
 
 import org.apache.commons.cli.CommandLine
+import org.apache.commons.cli.Option
+import org.apache.commons.cli.Options
 import org.cafejojo.schaapi.miningpipeline.MiningPipeline
 import org.cafejojo.schaapi.miningpipeline.PatternFilter
 import org.cafejojo.schaapi.miningpipeline.miner.github.MavenProjectSearchOptions
@@ -24,6 +26,40 @@ private const val DEFAULT_MAX_PROJECTS = "20"
  * Assumes that the passed library is a java jar project.
  */
 internal class GithubMiningCommandLineInterface {
+    companion object {
+        internal fun addOptionsTo(options: Options) = options
+            .addOption(Option
+                .builder()
+                .longOpt("github_oauth_token")
+                .desc("Token of GitHub account used for searching.")
+                .hasArg()
+                .build())
+            .addOption(Option
+                .builder()
+                .longOpt("max_projects")
+                .desc("Maximum amount of projects to download from GitHub.")
+                .hasArg()
+                .build())
+            .addOption(Option
+                .builder()
+                .longOpt("library_group_id")
+                .desc("Group id of library mined projects should have a dependency on.")
+                .hasArg()
+                .build())
+            .addOption(Option
+                .builder()
+                .longOpt("library_artifact_id")
+                .desc("Artifact id of library mined projects should have a dependency on.")
+                .hasArg()
+                .build())
+            .addOption(Option
+                .builder()
+                .longOpt("library_version")
+                .desc("Version of library mined projects should have a dependency on.")
+                .hasArg()
+                .build())
+    }
+
     /**
      * Mine GitHub.
      *

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GithubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GithubMiningCommandLineInterface.kt
@@ -1,0 +1,70 @@
+package org.cafejojo.schaapi
+
+import org.apache.commons.cli.CommandLine
+import org.cafejojo.schaapi.miningpipeline.MiningPipeline
+import org.cafejojo.schaapi.miningpipeline.PatternFilter
+import org.cafejojo.schaapi.miningpipeline.miner.github.MavenProjectSearchOptions
+import org.cafejojo.schaapi.miningpipeline.miner.github.ProjectMiner
+import org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan.PatternDetector
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.IncompleteInitPatternFilterRule
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.LengthPatternFilterRule
+import org.cafejojo.schaapi.miningpipeline.projectcompiler.javajar.ProjectCompiler
+import org.cafejojo.schaapi.miningpipeline.testgenerator.jimpleevosuite.TestGenerator
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.LibraryUsageGraphGenerator
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
+import org.cafejojo.schaapi.models.project.JavaJarProject
+import org.cafejojo.schaapi.models.project.JavaMavenProject
+import java.io.File
+
+private const val DEFAULT_MAX_PROJECTS = "20"
+
+/**
+ * Mines GitHub for user projects and generates tests based on these projects.
+ *
+ * Assumes that the passed library is a java jar project.
+ */
+internal class GithubMiningCommandLineInterface {
+    /**
+     * Mine GitHub.
+     *
+     * @throws [MissingArgumentException] if required arguments not set in [CommandLine].
+     */
+    @Suppress("ThrowsCount") // No real reason to do it differently
+    fun run(cmd: CommandLine, mavenDir: File, library: File, output: File) {
+        val token = cmd.getOptionValue("github_oauth_token") ?: throw MissingArgumentException("github_oauth_token")
+        val maxProjects = cmd.getOptionOrDefault("max_projects", DEFAULT_MAX_PROJECTS).toInt()
+        val groupId = cmd.getOptionValue("library_group_id") ?: throw MissingArgumentException("library_group_id")
+        val artifactId = cmd.getOptionValue("library_artifact_id")
+            ?: throw MissingArgumentException("library_artifact_id")
+        val version = cmd.getOptionValue("library_version") ?: throw MissingArgumentException("library_version")
+
+        val patternDetectorMinCount = cmd
+            .getOptionOrDefault("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
+        val maxSequenceLength = cmd
+            .getOptionOrDefault("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
+
+        val testGeneratorTimeout = cmd
+            .getOptionOrDefault("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
+        val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")
+
+        val libraryJar = JavaJarProject(library)
+
+        MiningPipeline(
+            outputDirectory = output,
+            projectMiner = ProjectMiner(token, output) { JavaMavenProject(it, mavenDir) },
+            searchOptions = MavenProjectSearchOptions(groupId, artifactId, version, maxProjects),
+            libraryProjectCompiler = ProjectCompiler(),
+            userProjectCompiler = org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.ProjectCompiler(),
+            libraryUsageGraphGenerator = LibraryUsageGraphGenerator,
+            patternDetector = PatternDetector(patternDetectorMinCount, maxSequenceLength, GeneralizedNodeComparator()),
+            patternFilter = PatternFilter(IncompleteInitPatternFilterRule(), LengthPatternFilterRule()),
+            testGenerator = TestGenerator(
+                library = libraryJar,
+                outputDirectory = output,
+                timeout = testGeneratorTimeout,
+                processStandardStream = if (testGeneratorEnableOutput) System.out else null,
+                processErrorStream = if (testGeneratorEnableOutput) System.out else null
+            )
+        ).run(libraryJar)
+    }
+}

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/MissingArgumentException.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/MissingArgumentException.kt
@@ -1,5 +1,11 @@
 package org.cafejojo.schaapi
 
+/**
+ * Thrown when a required argument on the command line is missing.
+ */
 internal class MissingArgumentException(argument: String) : RuntimeException("Missing the '$argument' argument.") {
-    fun messageForType(type: String): String = "${this.message} Was required for pipeline type $type."
+    /**
+     * Creates specific message for the desired pipeline flavor.
+     */
+    fun messageForFlavor(flavor: String): String = "${this.message} Was required for pipeline flavor $flavor."
 }

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/MissingArgumentException.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/MissingArgumentException.kt
@@ -7,5 +7,5 @@ internal class MissingArgumentException(argument: String) : RuntimeException("Mi
     /**
      * Creates specific message for the desired pipeline flavor.
      */
-    fun messageForFlavor(flavor: String): String = "${this.message} Was required for pipeline flavor $flavor."
+    fun messageForFlavor(flavor: String): String = "${this.message} was required for pipeline flavor $flavor."
 }

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/MissingArgumentException.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/MissingArgumentException.kt
@@ -1,0 +1,5 @@
+package org.cafejojo.schaapi
+
+internal class MissingArgumentException(argument: String) : RuntimeException("Missing the '$argument' argument.") {
+    fun messageForType(type: String): String = "${this.message} Was required for pipeline type $type."
+}

--- a/modules/application/src/module-integration-test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
+++ b/modules/application/src/module-integration-test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
@@ -2,7 +2,7 @@ package org.cafejojo.schaapi
 
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
-import org.jetbrains.spek.api.dsl.xit
+import org.jetbrains.spek.api.dsl.it
 import java.io.File
 import java.net.URLDecoder
 import java.nio.file.Files
@@ -24,9 +24,9 @@ internal class SchaapiSmokeTest : Spek({
         mavenDir.deleteRecursively()
     }
 
-    // TODO rewrite smoketest for new github mining interface
-    xit("generates a test class from the patterns in a project using a library") {
+    it("generates a test class from the patterns in a project using a library") {
         main(arrayOf(
+            "--pipeline_type", "directory",
             "-o", target.absolutePath,
             "-l", getResourcePath("/library/"),
             "-u", getResourcePath("/user/"),

--- a/modules/application/src/module-integration-test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
+++ b/modules/application/src/module-integration-test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
@@ -26,7 +26,6 @@ internal class SchaapiSmokeTest : Spek({
 
     it("generates a test class from the patterns in a project using a library") {
         main(arrayOf(
-            "--pipeline_type", "directory",
             "-o", target.absolutePath,
             "-l", getResourcePath("/library/"),
             "-u", getResourcePath("/user/"),

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
@@ -28,7 +28,7 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
     fun run(libraryProject: LP) {
         logger.info { "Compiling library project." }
         libraryProjectCompiler.compile(libraryProject)
-        logger.info { "Compiled library project" }
+        logger.info { "Compiled library project." }
 
         logger.info { "Mining has started." }
         logger.info { "Output directory is ${outputDirectory.absolutePath}." }

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
@@ -26,7 +26,9 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
      */
     @Suppress("TooGenericExceptionCaught") // In this case it is relevant to catch and log an Exception
     fun run(libraryProject: LP) {
+        logger.info { "Compiling library project." }
         libraryProjectCompiler.compile(libraryProject)
+        logger.info { "Compiled library project" }
 
         logger.info { "Mining has started." }
         logger.info { "Output directory is ${outputDirectory.absolutePath}." }


### PR DESCRIPTION
Add option to the command line to switch between pipelines. It is not the most elegant solution I admit but in the interest of time I think it's best to do it this way for the time being.

Few things of note:
* The GitHub mining pipeline requires the library be a jar, the directory mining pipeline requires the library be a maven project
* I'm not sure whether the command line arguments are too vague. It might be an idea to have multiple arguments where you for instance specify `library-type` (`jar`/`maven`) `language`, etc. For now however that felt slightly overkill.