### PR TITLE
Filter instance and array references in ClassGenerator

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -12,8 +12,10 @@ import soot.Type
 import soot.Unit
 import soot.Value
 import soot.VoidType
+import soot.jimple.ArrayRef
 import soot.jimple.GotoStmt
 import soot.jimple.IfStmt
+import soot.jimple.InstanceFieldRef
 import soot.jimple.Jimple
 import soot.jimple.SwitchStmt
 import soot.jimple.internal.JReturnStmt
@@ -93,7 +95,7 @@ internal class ClassGenerator(className: String) {
             jimpleBody.units.add(statement)
             jimpleBody.locals.addAll(statement.defBoxes
                 .map { it.value }
-                .filter { !methodParams.contains(it) }
+                .filter { !methodParams.contains(it) && it !is InstanceFieldRef && it !is ArrayRef }
                 .map { it as? Local ?: throw ValueIsNotLocalException(it) }
             )
 

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -95,7 +95,7 @@ internal class ClassGenerator(className: String) {
             jimpleBody.units.add(statement)
             jimpleBody.locals.addAll(statement.defBoxes
                 .map { it.value }
-                .filter { !methodParams.contains(it) && it !is InstanceFieldRef && it !is ArrayRef }
+                .filterNot { methodParams.contains(it) || it is InstanceFieldRef || it is ArrayRef }
                 .map { it as? Local ?: throw ValueIsNotLocalException(it) }
             )
 


### PR DESCRIPTION
These should be ignored and not added as locals. Field references to the library should be persisted (they are not 'unbound variables'), and array references should not be added as complete references (e.g. a[2]) but only as base objects (a), which are in the use-def boxes, anyways.