### PR TITLE
Fix duplicate locals

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -95,7 +95,10 @@ internal class ClassGenerator(className: String) {
             jimpleBody.units.add(statement)
             jimpleBody.locals.addAll(statement.defBoxes
                 .map { it.value }
-                .filterNot { methodParams.contains(it) || it is InstanceFieldRef || it is ArrayRef }
+                .filterNot {
+                    methodParams.contains(it) || jimpleBody.locals.contains(it)
+                        || it is InstanceFieldRef || it is ArrayRef
+                }
                 .map { it as? Local ?: throw ValueIsNotLocalException(it) }
             )
 

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -281,4 +281,16 @@ internal object ClassGeneratorTest : Spek({
             assertThat(switchStmt.defaultTarget).isEqualTo(returnStmt)
         }
     }
+
+    it("should not add a local twice if it is assigned twice") {
+        val local = Jimple.v().newLocal("local", IntType.v())
+        val userA = Jimple.v().newAssignStmt(local, IntConstant.v(48))
+        val userB = Jimple.v().newAssignStmt(local, IntConstant.v(86))
+
+        val method = ClassGenerator("test").apply {
+            generateMethod("method", listOf(userA, userB).map { JimpleNode(it) })
+        }.sootClass.methods.last()
+
+        assertThat(method.retrieveActiveBody().locals).containsExactly(local)
+    }
 })


### PR DESCRIPTION
When a local is assigned twice in a method body, the `ClassGenerator` will also try to add it twice as a local to the body, which is not possible in Soot.

The first commit in this PR adds a test that replicates the issue, and the second commit fixes the issue by preventing the addition of duplicate locals.
