### PR TITLE
Make copies of nodes in each sequence, while maintaining referential integrity

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -162,28 +162,20 @@ internal class ClassGenerator(className: String) {
 }
 
 /**
- * Exception to denote that a value cannot be stored as a local.
+ * Duplicates the list of [JimpleNode]s, restoring references between [Stmt]s.
  */
-internal class ValueIsNotLocalException(value: Value) : RuntimeException("$value cannot be stored as a local.")
-
-fun List<JimpleNode>.duplicate(): List<JimpleNode> {
+internal fun List<JimpleNode>.duplicate(): List<JimpleNode> {
     val oldToNewNodes = mutableMapOf<Stmt, Stmt>()
     val newNodes = this.map { oldNode ->
         oldNode.copy().also { oldToNewNodes[oldNode.statement] = it.statement }
     }
 
     newNodes.forEach {
-        when (it.statement) {
-            is GotoStmt -> {
-                val statement = it.statement as GotoStmt
-                statement.target = oldToNewNodes[statement]
-            }
-            is IfStmt -> {
-                val statement = it.statement as IfStmt
-                statement.setTarget(oldToNewNodes[statement])
-            }
+        val statement = it.statement
+        when (statement) {
+            is GotoStmt -> statement.target = oldToNewNodes[statement]
+            is IfStmt -> statement.setTarget(oldToNewNodes[statement])
             is SwitchStmt -> {
-                val statement = it.statement as SwitchStmt
                 statement.defaultTarget = oldToNewNodes[statement]
                 statement.targets.forEachIndexed { index, target ->
                     statement.setTarget(index, oldToNewNodes[target])
@@ -194,3 +186,8 @@ fun List<JimpleNode>.duplicate(): List<JimpleNode> {
 
     return newNodes
 }
+
+/**
+ * Exception to denote that a value cannot be stored as a local.
+ */
+internal class ValueIsNotLocalException(value: Value) : RuntimeException("$value cannot be stored as a local.")

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -166,9 +166,9 @@ internal class ClassGenerator(className: String) {
  */
 private fun List<JimpleNode>.duplicate(): List<JimpleNode> {
     val newNodes = this.map { it.copy() }
-    val oldToNewStatements = newNodes.mapIndexed { index, newNode ->
-        get(index).statement to newNode.statement
-    }.toMap()
+    val oldToNewStatements = newNodes
+        .mapIndexed { index, newNode -> get(index).statement to newNode.statement }
+        .toMap()
 
     newNodes.forEach {
         val statement = it.statement

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -164,21 +164,21 @@ internal class ClassGenerator(className: String) {
 /**
  * Duplicates the list of [JimpleNode]s, restoring references between [Stmt]s.
  */
-internal fun List<JimpleNode>.duplicate(): List<JimpleNode> {
-    val oldToNewNodes = mutableMapOf<Stmt, Stmt>()
-    val newNodes = this.map { oldNode ->
-        oldNode.copy().also { oldToNewNodes[oldNode.statement] = it.statement }
-    }
+private fun List<JimpleNode>.duplicate(): List<JimpleNode> {
+    val newNodes = this.map { it.copy() }
+    val oldToNewStatements = newNodes.mapIndexed { index, newNode ->
+        get(index).statement to newNode.statement
+    }.toMap()
 
     newNodes.forEach {
         val statement = it.statement
         when (statement) {
-            is GotoStmt -> statement.target = oldToNewNodes[statement]
-            is IfStmt -> statement.setTarget(oldToNewNodes[statement])
+            is GotoStmt -> statement.target = oldToNewStatements[statement]
+            is IfStmt -> statement.setTarget(oldToNewStatements[statement])
             is SwitchStmt -> {
-                statement.defaultTarget = oldToNewNodes[statement]
+                statement.defaultTarget = oldToNewStatements[statement]
                 statement.targets.forEachIndexed { index, target ->
-                    statement.setTarget(index, oldToNewNodes[target])
+                    statement.setTarget(index, oldToNewStatements[target])
                 }
             }
         }

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -15,9 +15,11 @@ import soot.RefType
 import soot.Scene
 import soot.SootClass
 import soot.SootField
+import soot.Value
 import soot.VoidType
 import soot.jimple.IntConstant
 import soot.jimple.Jimple
+import soot.jimple.Stmt
 import soot.jimple.StringConstant
 import soot.jimple.internal.JEqExpr
 import soot.options.Options
@@ -46,7 +48,7 @@ internal object ClassGeneratorTest : Spek({
             val assignC = Jimple.v().newAssignStmt(c, Jimple.v().newAddExpr(a, b))
 
             val jimpleMethod = ClassGenerator("asdf").apply {
-                generateMethod("method", listOf(assignA, assignB, assignC).map { JimpleNode(it) })
+                generateMethod("method", listOf(assignA, assignB, assignC).map { JimpleNode(it!!) })
             }.sootClass.methods.last()
 
             assertThat(jimpleMethod.parameterCount).isZero()
@@ -243,7 +245,7 @@ internal object ClassGeneratorTest : Spek({
                 generateMethod("method", listOf(gotoStmt, returnStmt).map { JimpleNode(it) })
             }.sootClass.methods.last()
 
-            assertThat(gotoStmt.target).isEqualTo(returnStmt)
+            assertThat(JimpleNode(gotoStmt.target as Stmt).equivTo(JimpleNode(returnStmt))).isTrue()
         }
 
         it("should replace now-missing targets in if statements") {
@@ -258,7 +260,7 @@ internal object ClassGeneratorTest : Spek({
                 generateMethod("method", listOf(ifStmt, returnStmt).map { JimpleNode(it) })
             }.sootClass.methods.last()
 
-            assertThat(ifStmt.target).isEqualTo(returnStmt)
+            assertThat(JimpleNode(ifStmt.target as Stmt).equivTo(JimpleNode(returnStmt))).isTrue()
         }
 
         it("should replace now-missing targets in switch statements") {
@@ -277,8 +279,8 @@ internal object ClassGeneratorTest : Spek({
                 generateMethod("method", listOf(switchStmt, returnStmt).map { JimpleNode(it) })
             }.sootClass.methods.last()
 
-            assertThat(switchStmt.targets[0]).isEqualTo(returnStmt)
-            assertThat(switchStmt.defaultTarget).isEqualTo(returnStmt)
+            assertThat(JimpleNode(switchStmt.targets[0] as Stmt).equivTo(JimpleNode(returnStmt))).isTrue()
+            assertThat(JimpleNode(switchStmt.defaultTarget as Stmt).equivTo(JimpleNode(returnStmt))).isTrue()
         }
     }
 })

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -332,8 +332,9 @@ internal object ClassGeneratorTest : Spek({
             }.sootClass.methods.last()
 
             val newGotoStmt = method.activeBody.units.elementAt(1) as GotoStmt
-            assertThat(newGotoStmt.target).isNotEqualTo(returnStmt)
-            assertThat(newGotoStmt.target).isEqualToComparingFieldByFieldRecursively(returnStmt)
+            assertThat(newGotoStmt.target)
+                .isNotEqualTo(returnStmt)
+                .isEqualToComparingFieldByFieldRecursively(returnStmt)
         }
 
         it("should replace statement target instances in if statements") {
@@ -348,8 +349,9 @@ internal object ClassGeneratorTest : Spek({
             }.sootClass.methods.last()
 
             val newIfStmt = method.activeBody.units.elementAt(1) as IfStmt
-            assertThat(newIfStmt.target).isNotEqualTo(returnStmt)
-            assertThat(newIfStmt.target).isEqualToComparingFieldByFieldRecursively(returnStmt)
+            assertThat(newIfStmt.target)
+                .isNotEqualTo(returnStmt)
+                .isEqualToComparingFieldByFieldRecursively(returnStmt)
         }
 
         it("should replace statement target instances in switch statements") {
@@ -368,10 +370,12 @@ internal object ClassGeneratorTest : Spek({
             }.sootClass.methods.last()
 
             val newSwitchStmt = method.activeBody.units.elementAt(1) as SwitchStmt
-            assertThat(newSwitchStmt.targets[0]).isNotEqualTo(returnStmt)
-            assertThat(newSwitchStmt.targets[0]).isEqualToComparingFieldByFieldRecursively(returnStmt)
-            assertThat(newSwitchStmt.defaultTarget).isNotEqualTo(returnStmt)
-            assertThat(newSwitchStmt.defaultTarget).isEqualToComparingFieldByFieldRecursively(returnStmt)
+            assertThat(newSwitchStmt.targets[0])
+                .isNotEqualTo(returnStmt)
+                .isEqualToComparingFieldByFieldRecursively(returnStmt)
+            assertThat(newSwitchStmt.defaultTarget)
+                .isNotEqualTo(returnStmt)
+                .isEqualToComparingFieldByFieldRecursively(returnStmt)
         }
     }
 })

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -25,6 +25,7 @@ import soot.jimple.internal.JEqExpr
 import soot.options.Options
 import java.io.File
 
+@Suppress("UnsafeCast") // Casting statement targets to [Stmt] instances
 internal object ClassGeneratorTest : Spek({
     beforeGroup {
         Options.v().set_soot_classpath(
@@ -48,7 +49,7 @@ internal object ClassGeneratorTest : Spek({
             val assignC = Jimple.v().newAssignStmt(c, Jimple.v().newAddExpr(a, b))
 
             val jimpleMethod = ClassGenerator("asdf").apply {
-                generateMethod("method", listOf(assignA, assignB, assignC).map { JimpleNode(it!!) })
+                generateMethod("method", listOf(assignA, assignB, assignC).map { JimpleNode(it) })
             }.sootClass.methods.last()
 
             assertThat(jimpleMethod.parameterCount).isZero()

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -15,7 +15,6 @@ import soot.RefType
 import soot.Scene
 import soot.SootClass
 import soot.SootField
-import soot.Value
 import soot.VoidType
 import soot.jimple.IntConstant
 import soot.jimple.Jimple

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -331,8 +331,9 @@ internal object ClassGeneratorTest : Spek({
                 generateMethod("method", listOf(gotoStmt, returnStmt).map { JimpleNode(it) })
             }.sootClass.methods.last()
 
-            assertThat((method.activeBody.units.iterator().asSequence().toList()[1] as GotoStmt).target)
-                .isNotEqualTo(returnStmt)
+            val newGotoStmt = method.activeBody.units.elementAt(1) as GotoStmt
+            assertThat(newGotoStmt.target).isNotEqualTo(returnStmt)
+            assertThat(newGotoStmt.target).isEqualToComparingFieldByFieldRecursively(returnStmt)
         }
 
         it("should replace statement target instances in if statements") {
@@ -346,8 +347,9 @@ internal object ClassGeneratorTest : Spek({
                 generateMethod("method", listOf(ifStmt, returnStmt).map { JimpleNode(it) })
             }.sootClass.methods.last()
 
-            assertThat((method.activeBody.units.iterator().asSequence().toList()[1] as IfStmt).target)
-                .isNotEqualTo(returnStmt)
+            val newIfStmt = method.activeBody.units.elementAt(1) as IfStmt
+            assertThat(newIfStmt.target).isNotEqualTo(returnStmt)
+            assertThat(newIfStmt.target).isEqualToComparingFieldByFieldRecursively(returnStmt)
         }
 
         it("should replace statement target instances in switch statements") {
@@ -365,10 +367,11 @@ internal object ClassGeneratorTest : Spek({
                 generateMethod("method", listOf(switchStmt, returnStmt).map { JimpleNode(it) })
             }.sootClass.methods.last()
 
-            assertThat((method.activeBody.units.iterator().asSequence().toList()[1] as SwitchStmt).targets[0])
-                .isNotEqualTo(returnStmt)
-            assertThat((method.activeBody.units.iterator().asSequence().toList()[1] as SwitchStmt).defaultTarget)
-                .isNotEqualTo(returnStmt)
+            val newSwitchStmt = method.activeBody.units.elementAt(1) as SwitchStmt
+            assertThat(newSwitchStmt.targets[0]).isNotEqualTo(returnStmt)
+            assertThat(newSwitchStmt.targets[0]).isEqualToComparingFieldByFieldRecursively(returnStmt)
+            assertThat(newSwitchStmt.defaultTarget).isNotEqualTo(returnStmt)
+            assertThat(newSwitchStmt.defaultTarget).isEqualToComparingFieldByFieldRecursively(returnStmt)
         }
     }
 })


### PR DESCRIPTION
As attempted in #214  and #218, nodes should be duplicated before being used to generate bytecode. However, simply duplicating the nodes is not sufficient, as they often have links between them. These also need to be updated, which is what this PR does. 