### PR TITLE
Filter more field refs

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -95,7 +95,10 @@ internal class ClassGenerator(className: String) {
             jimpleBody.units.add(statement)
             jimpleBody.locals.addAll(statement.defBoxes
                 .map { it.value }
-                .filterNot { methodParams.contains(it) || it is InstanceFieldRef || it is ArrayRef }
+                .filterNot {
+                    methodParams.contains(it) || jimpleBody.locals.contains(it)
+                        || it is InstanceFieldRef || it is ArrayRef
+                }
                 .map { it as? Local ?: throw ValueIsNotLocalException(it) }
             )
 

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -13,9 +13,9 @@ import soot.Unit
 import soot.Value
 import soot.VoidType
 import soot.jimple.ArrayRef
+import soot.jimple.FieldRef
 import soot.jimple.GotoStmt
 import soot.jimple.IfStmt
-import soot.jimple.InstanceFieldRef
 import soot.jimple.Jimple
 import soot.jimple.SwitchStmt
 import soot.jimple.internal.JReturnStmt
@@ -97,7 +97,7 @@ internal class ClassGenerator(className: String) {
                 .map { it.value }
                 .filterNot {
                     methodParams.contains(it) || jimpleBody.locals.contains(it)
-                        || it is InstanceFieldRef || it is ArrayRef
+                        || it is FieldRef || it is ArrayRef
                 }
                 .map { it as? Local ?: throw ValueIsNotLocalException(it) }
             )

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -281,4 +281,16 @@ internal object ClassGeneratorTest : Spek({
             assertThat(switchStmt.defaultTarget).isEqualTo(returnStmt)
         }
     }
+
+    it("should not add a local twice if it is assigned twice") {
+        val local = Jimple.v().newLocal("local", IntType.v())
+        val userA = Jimple.v().newAssignStmt(local, IntConstant.v(48))
+        val userB = Jimple.v().newAssignStmt(local, IntConstant.v(86))
+
+        val method = ClassGenerator("test").apply {
+            generateMethod("method", listOf(userA, userB).map { JimpleNode(it) })
+        }.sootClass.methods.last()
+
+        assertThat(method.retrieveActiveBody().locals).containsExactly(local)
+    }
 })


### PR DESCRIPTION
While #217 made the `ClassGenerator` filter instance field refs, this PR will also make it filter static field refs. 

The first commit (after the commits from #219) adds a test that replicates the buggy behavior, and the second commits fixes it.