### PR TITLE
Include test class files in the mining process

### DIFF
--- a/modules/mining-pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javajar/ProjectCompiler.kt
+++ b/modules/mining-pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javajar/ProjectCompiler.kt
@@ -14,7 +14,7 @@ class ProjectCompiler : ProjectCompiler<JavaJarProject> {
 
     override fun compile(project: JavaJarProject): JavaJarProject {
         val classNames = mutableListOf<String>()
-        val jarInputStream = JarInputStream(FileInputStream(project.classDir))
+        val jarInputStream = JarInputStream(FileInputStream(project.classDirs.first()))
         var jarEntry = jarInputStream.nextJarEntry
 
         if (jarEntry == null) {

--- a/modules/mining-pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/ProjectCompilerTest.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/ProjectCompilerTest.kt
@@ -57,7 +57,8 @@ internal object ProjectCompilerTest : Spek({
             assertThat(project.classNames).isEmpty()
             assertThat(project.dependencies).isEmpty()
             assertThat(project.classpath.split(File.pathSeparator)).containsExactlyInAnyOrder(
-                target.resolve("target/classes").absolutePath
+                target.resolve("target/classes").absolutePath,
+                target.resolve("target/test-classes").absolutePath
             )
         }
 
@@ -76,7 +77,8 @@ internal object ProjectCompilerTest : Spek({
             )
             assertThat(project.dependencies).isEmpty()
             assertThat(project.classpath.split(File.pathSeparator)).containsExactlyInAnyOrder(
-                target.resolve("target/classes").absolutePath
+                target.resolve("target/classes").absolutePath,
+                target.resolve("target/test-classes").absolutePath
             )
         }
 
@@ -98,6 +100,7 @@ internal object ProjectCompilerTest : Spek({
             )
             assertThat(project.classpath.split(File.pathSeparator)).containsExactlyInAnyOrder(
                 target.resolve("target/classes").absolutePath,
+                target.resolve("target/test-classes").absolutePath,
                 target.resolve("target/dependency").resolve("zip4j-1.3.2.jar").absolutePath
             )
         }

--- a/modules/mining-pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/ProjectCompilerTest.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/ProjectCompilerTest.kt
@@ -82,6 +82,28 @@ internal object ProjectCompilerTest : Spek({
             )
         }
 
+        it("compiles simple projects with a test class") {
+            setUpTestFiles("/ProjectCompiler/simple-with-tests", target)
+
+            val project = JavaMavenProject(target, mavenHome)
+            ProjectCompiler().compile(project)
+
+            assertThat(project.projectDir).isEqualTo(target)
+            assertThat(project.classes).containsExactlyInAnyOrder(
+                target.resolve("target/classes/org/cafejojo/schaapi/test/MyClass.class"),
+                target.resolve("target/test-classes/org/cafejojo/schaapi/test/MyTestClass.class")
+            )
+            assertThat(project.classNames).containsExactlyInAnyOrder(
+                "org.cafejojo.schaapi.test.MyClass",
+                "org.cafejojo.schaapi.test.MyTestClass"
+            )
+            assertThat(project.dependencies).isEmpty()
+            assertThat(project.classpath.split(File.pathSeparator)).containsExactlyInAnyOrder(
+                target.resolve("target/classes").absolutePath,
+                target.resolve("target/test-classes").absolutePath
+            )
+        }
+
         it("compiles projects with dependencies") {
             setUpTestFiles("/ProjectCompiler/dependencies", target)
 

--- a/modules/mining-pipeline/java-maven-project-compiler/src/test/resources/ProjectCompiler/simple-with-tests/pom.xml
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/test/resources/ProjectCompiler/simple-with-tests/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.cafejojo</groupId>
+    <artifactId>schaapi.test</artifactId>
+    <version>1.0.0</version>
+</project>

--- a/modules/mining-pipeline/java-maven-project-compiler/src/test/resources/ProjectCompiler/simple-with-tests/src/main/java/org/cafejojo/schaapi/test/MyClass.java
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/test/resources/ProjectCompiler/simple-with-tests/src/main/java/org/cafejojo/schaapi/test/MyClass.java
@@ -1,0 +1,7 @@
+package org.cafejojo.schaapi.test;
+
+public class MyClass {
+    public String foo() {
+        return "bar";
+    }
+}

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/LibraryUsageGraphGenerator.kt
@@ -28,7 +28,7 @@ object LibraryUsageGraphGenerator : LibraryUsageGraphGenerator<JavaProject, Java
         Scene.v().sootClassPath = arrayOf(
             System.getProperty("java.home") + "${File.separator}lib${File.separator}rt.jar",
             System.getProperty("java.home") + "${File.separator}lib${File.separator}jce.jar",
-            libraryProject.classDir.absolutePath,
+            libraryProject.classDirs.joinToString(File.pathSeparator) { it.absolutePath },
             userProject.classpath
         ).joinToString(File.pathSeparator)
         Options.v().set_whole_program(true)

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/Helpers.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/Helpers.kt
@@ -7,7 +7,7 @@ internal data class TestProject(
     override var classpath: String = "",
     override var classNames: List<String> = emptyList()
 ) : JavaProject {
-    override val classDir: File = File(".")
+    override val classDirs: List<File> = listOf(File("."))
     override val dependencyDir: File = File(".")
     override var dependencies: List<File> = emptyList()
     override val projectDir: File = File(".")

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaJarProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaJarProject.kt
@@ -7,13 +7,13 @@ import java.io.File
  */
 @SuppressWarnings("LateinitUsage") // Refer to PR #23
 class JavaJarProject(private val jar: File) : JavaProject {
-    override val classDir: File
-        get() = jar
-    override val dependencyDir: File = classDir
+    override val classDirs: List<File>
+        get() = listOf(jar)
+    override val dependencyDir: File = jar
     override var classes: List<File> = listOf()
     override var dependencies: List<File> = listOf()
-    override var classpath: String = classDir.absolutePath
-    override val projectDir: File = classDir
+    override var classpath: String = jar.absolutePath
+    override val projectDir: File = jar
 
     override lateinit var classNames: List<String>
 

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaMavenProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaMavenProject.kt
@@ -15,7 +15,7 @@ class JavaMavenProject(
     }
 
     override val pomFile = File(projectDir, "pom.xml")
-    override val classDir = File(projectDir, "target/classes")
+    override val classDirs = listOf(File(projectDir, "target/classes"), File(projectDir, "target/test-classes"))
     override val dependencyDir = File(projectDir, "target/dependency")
 
     override lateinit var classes: List<File>
@@ -31,7 +31,7 @@ class JavaMavenProject(
         require(pomFile.isFile) { "Given project directory is not a Maven project, '$pomFile' does not exist." }
         require(pomFile.canRead()) { "Cannot read POM file: '$pomFile'." }
 
-        classDir.mkdirs()
+        classDirs.forEach { it.mkdirs() }
         dependencyDir.mkdirs()
     }
 }

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaProject.kt
@@ -8,9 +8,9 @@ import java.io.File
  */
 interface JavaProject : Project {
     /**
-     * The directory containing the project's compiled class files.
+     * The directories containing the project's compiled class files.
      */
-    val classDir: File
+    val classDirs: List<File>
 
     /**
      * The directory containing the project's dependencies as JARs.


### PR DESCRIPTION
The MavenCompiler also outputs a `test-classes` folder, if test classes were present. These might contain library usages, and are therefore useful to analyze. This PR adds the classes in that directory to the analysis.