### PR TITLE
Add GitHub sorting options

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ usage: schaapi -o <arg> -l <arg> -u <arg> [--maven_dir <arg>]
                                                        should be shown.
     --test_generator_timeout <arg>                     The time limit for
                                                        the test generator.
+    --sort_by_stargazers                               Mine projects on GitHub with
+                                                       the most stargazers.
+    --sort_by_watchers                                 Mine projects on GitHub with
+                                                       the most watchers.
 ```
 
 ## Pipeline Stages

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -1,5 +1,6 @@
 package org.cafejojo.schaapi
 
+import mu.KLogging
 import org.apache.commons.cli.CommandLine
 import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
@@ -27,6 +28,8 @@ internal const val DEFAULT_MAX_PROJECTS = "20"
  */
 internal class GitHubMiningCommandLineInterface {
     internal companion object {
+        val logger = KLogging().logger
+
         fun addOptionsTo(options: Options): Options =
             options
                 .addOption(Option
@@ -93,6 +96,10 @@ internal class GitHubMiningCommandLineInterface {
         val testGeneratorTimeout = cmd
             .getOptionOrDefault("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
         val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")
+
+        if (cmd.hasOption("sort_by_stargazers") && cmd.hasOption("sort_by_watchers")) {
+            logger.error { "Cannot sort repositories on both stargazers and watchers." }
+        }
 
         val libraryJar = JavaJarProject(library)
 

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -59,6 +59,18 @@ internal class GitHubMiningCommandLineInterface {
                     .desc("Version of library mined projects should have a dependency on.")
                     .hasArg()
                     .build())
+                .addOption(Option
+                    .builder()
+                    .longOpt("sort_by_stargazers")
+                    .desc("True if GitHub projects should be sorted by stars.")
+                    .hasArg(false)
+                    .build())
+                .addOption(Option
+                    .builder()
+                    .longOpt("sort_by_watchers")
+                    .desc("True if GitHub projects should be sorted by watchers.")
+                    .hasArg(false)
+                    .build())
     }
 
     /**
@@ -87,7 +99,10 @@ internal class GitHubMiningCommandLineInterface {
         MiningPipeline(
             outputDirectory = output,
             projectMiner = ProjectMiner(token, output) { JavaMavenProject(it, mavenDir) },
-            searchOptions = MavenProjectSearchOptions(groupId, artifactId, version, maxProjects),
+            searchOptions = MavenProjectSearchOptions(groupId, artifactId, version, maxProjects).apply {
+                this.sortByStargazers = cmd.hasOption("sort_by_stargazers")
+                this.sortByWatchers = cmd.hasOption("sort_by_watchers")
+            },
             libraryProjectCompiler = ProjectCompiler(),
             userProjectCompiler = org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.ProjectCompiler(),
             libraryUsageGraphGenerator = LibraryUsageGraphGenerator,

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -71,18 +71,6 @@ internal class GitHubMiningCommandLineInterface {
                     .desc("True if GitHub projects should be sorted by watchers.")
                     .hasArg(false)
                     .build())
-                .addOption(Option
-                    .builder()
-                    .longOpt("sort_by_stargazers")
-                    .desc("True if GitHub projects with the most stars should be mined.")
-                    .hasArg(false)
-                    .build())
-                .addOption(Option
-                    .builder()
-                    .longOpt("sort_by_watchers")
-                    .desc("True if GitHub projects with the most watchers should be mined.")
-                    .hasArg(false)
-                    .build())
     }
 
     /**

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -71,6 +71,18 @@ internal class GitHubMiningCommandLineInterface {
                     .desc("True if GitHub projects should be sorted by watchers.")
                     .hasArg(false)
                     .build())
+                .addOption(Option
+                    .builder()
+                    .longOpt("sort_by_stargazers")
+                    .desc("True if GitHub projects with the most stars should be mined.")
+                    .hasArg(false)
+                    .build())
+                .addOption(Option
+                    .builder()
+                    .longOpt("sort_by_watchers")
+                    .desc("True if GitHub projects with the most watchers should be mined.")
+                    .hasArg(false)
+                    .build())
     }
 
     /**

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
@@ -27,14 +27,14 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
         logger.info { "Found ${searchResults.totalCount} projects." }
         if (maxProjects < searchResults.totalCount) logger.info { "Will be capped at $maxProjects." }
 
-        val repositories = searchResults
+        val names = searchResults
             .apply { if (sortByStargazers) sortByStargazers(this) }
             .apply { if (sortByWatchers) sortByWatchers(this) }
             .take(maxProjects)
-            .map { it.owner }
+            .map { it.owner.fullName }
 
-        logger.info { "Found ${repositories.size} projects namesToStars using the Github v3 Search API." }
-        return repositories.map { it.fullName }
+        logger.info { "Found ${names.size} projects names using the Github v3 Search API." }
+        return names
     }
 
     protected abstract fun buildGitHubSearchContent(gitHub: GitHub): GHContentSearchBuilder

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
@@ -37,10 +37,9 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
         return repositories.map { it.fullName }
     }
 
-    abstract fun buildGitHubSearchContent(gitHub: GitHub): GHContentSearchBuilder
+    protected abstract fun buildGitHubSearchContent(gitHub: GitHub): GHContentSearchBuilder
 
-    private fun sortByStargazers(githubRepositories: PagedSearchIterable<GHContent>)
-        : PagedSearchIterable<GHContent> {
+    private fun sortByStargazers(githubRepositories: PagedSearchIterable<GHContent>): PagedSearchIterable<GHContent> {
         githubRepositories
             .also { logger.info { "Sorting owners by stargazers count." } }
             .sortedByDescending { it.owner.stargazersCount }
@@ -54,8 +53,7 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
         return githubRepositories
     }
 
-    private fun sortByWatchers(githubRepositories: PagedSearchIterable<GHContent>)
-        : PagedSearchIterable<GHContent> {
+    private fun sortByWatchers(githubRepositories: PagedSearchIterable<GHContent>): PagedSearchIterable<GHContent> {
         githubRepositories
             .also { logger.info { "Sorting owners by watcher count count." } }
             .sortedByDescending { it.owner.watchers }

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
@@ -3,19 +3,71 @@ package org.cafejojo.schaapi.miningpipeline.miner.github
 import mu.KLogging
 import org.cafejojo.schaapi.miningpipeline.SearchOptions
 import org.kohsuke.github.GHContent
+import org.kohsuke.github.GHContentSearchBuilder
 import org.kohsuke.github.GitHub
 import org.kohsuke.github.PagedSearchIterable
 
 /**
  * Represents options used to mine [GitHub].
  */
-interface GitHubSearchOptions : SearchOptions {
+abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions {
+    private companion object : KLogging()
+
+    var sortByStargazersCount = false
+    var sortByWatchersCount = false
+
     /**
      * Search content on GitHub with the given options and return a list of the full names of the found repositories.
      *
      * @return list of full names of found repositories on [GitHub] based on the passed options
      */
-    fun searchContent(gitHub: GitHub): List<String>
+    fun searchContent(gitHub: GitHub): List<String> {
+        val searchResults = buildGitHubSearchContent(gitHub).list()
+
+        logger.info { "Found ${searchResults.totalCount} projects." }
+        if (maxProjects < searchResults.totalCount) logger.info { "Will be capped at $maxProjects." }
+
+        val repositories = searchResults
+            .apply { if (sortByStargazersCount) sortByStargazersCount(this) }
+            .apply { if (sortByWatchersCount) sortByWatchersCount(this) }
+            .take(maxProjects)
+            .map { it.owner }
+
+        logger.info { "Found ${repositories.size} projects namesToStars using the Github v3 Search API." }
+        return repositories.map { it.fullName }
+    }
+
+    abstract fun buildGitHubSearchContent(gitHub: GitHub): GHContentSearchBuilder
+
+    private fun sortByStargazersCount(githubRepositories: PagedSearchIterable<GHContent>)
+        : PagedSearchIterable<GHContent> {
+        githubRepositories
+            .also { logger.info { "Sorting owners by stargazers count." } }
+            .sortedByDescending { it.owner.stargazersCount }
+
+        val max = githubRepositories.first().owner
+        val min = githubRepositories.last().owner
+        logger.info { "Maximum stargazers: ${max.stargazersCount}, repo: ${max.fullName}." }
+        logger.info { "Minimum stargazers: ${min.stargazersCount}, repo: ${min.fullName}." }
+        logger.info { "Average stargazers: ${githubRepositories.sumBy { it.owner.stargazersCount }}." }
+
+        return githubRepositories
+    }
+
+    private fun sortByWatchersCount(githubRepositories: PagedSearchIterable<GHContent>)
+        : PagedSearchIterable<GHContent> {
+        githubRepositories
+            .also { logger.info { "Sorting owners by watcher count count." } }
+            .sortedByDescending { it.owner.watchers }
+
+        val max = githubRepositories.first().owner
+        val min = githubRepositories.last().owner
+        logger.info { "Maximum watchers: ${max.watchers}, repo: ${max.watchers}." }
+        logger.info { "Minimum watchers: ${min.watchers}, repo: ${min.watchers}." }
+        logger.info { "Average watchers: ${githubRepositories.sumBy { it.owner.watchers }}." }
+
+        return githubRepositories
+    }
 }
 
 /**
@@ -31,67 +83,18 @@ class MavenProjectSearchOptions(
     private val artifactId: String,
     private val version: String,
     private val maxProjects: Int
-) : GitHubSearchOptions {
+) : GitHubSearchOptions(maxProjects) {
     private companion object : KLogging()
 
-    var sortByStargazersCount = false
-    var sortByWatchersCount = false
+    override fun buildGitHubSearchContent(gitHub: GitHub): GHContentSearchBuilder {
+        logger.info { "Mining a maximum of $maxProjects GitHub maven projects." }
+        logger.info { "Should depend on group id: $groupId, artifact id: $artifactId, version: $version." }
 
-    override fun searchContent(gitHub: GitHub): List<String> {
-        logger.info {
-            "Mining a maximum of $maxProjects GitHub maven projects which depend on " +
-                "group id: $groupId, artifact id: $artifactId, version: $version."
+        return gitHub.searchContent().apply {
+            q("dependency $groupId $artifactId $version")
+            `in`("file")
+            filename("pom")
+            extension("xml")
         }
-
-        val searchResults = gitHub.searchContent()
-            .apply {
-                q("dependency $groupId $artifactId $version")
-                `in`("file")
-                filename("pom")
-                extension("xml")
-            }
-            .list()
-
-        logger.info { "Found ${searchResults.totalCount} projects." }
-        if (maxProjects < searchResults.totalCount) logger.info { "Will be capped at $maxProjects." }
-
-        val repositories = searchResults
-            .apply { if (sortByStargazersCount) sortByStargazersCount(this) }
-            .apply { if (sortByWatchersCount) sortByWatchersCount(this) }
-            .take(maxProjects)
-            .map { it.owner }
-
-        logger.info { "Found ${repositories.size} projects namesToStars using the Github v3 Search API." }
-        return repositories.map { it.fullName }
-    }
-
-    private fun sortByStargazersCount(githubRepositories: PagedSearchIterable<GHContent>)
-        : PagedSearchIterable<GHContent> {
-        githubRepositories
-            .also { logger.info { "Sorting owners by stargazers count." } }
-            .sortedByDescending { it.owner.stargazersCount }
-
-        val max = githubRepositories.first().owner
-        val min = githubRepositories.last().owner
-        logger.info { "Maximum stargazers: ${max.stargazersCount}, repo: ${max.fullName}" }
-        logger.info { "Minimum stargazers: ${min.stargazersCount}, repo: ${min.fullName}" }
-        logger.info { "Average stargazers: ${githubRepositories.sumBy { it.owner.stargazersCount }}" }
-
-        return githubRepositories
-    }
-
-    private fun sortByWatchersCount(githubRepositories: PagedSearchIterable<GHContent>)
-        : PagedSearchIterable<GHContent> {
-        githubRepositories
-            .also { logger.info { "Sorting owners by watcher count count." } }
-            .sortedByDescending { it.owner.watchers }
-
-        val max = githubRepositories.first().owner
-        val min = githubRepositories.last().owner
-        logger.info { "Maximum watchers: ${max.watchers}, repo: ${max.watchers}" }
-        logger.info { "Minimum watchers: ${min.watchers}, repo: ${min.watchers}" }
-        logger.info { "Average watchers: ${githubRepositories.sumBy { it.owner.watchers }}" }
-
-        return githubRepositories
     }
 }

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
@@ -16,6 +16,11 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
     var sortByStargazers = false
     var sortByWatchers = false
 
+    private fun <T> Iterable<T>.averageOf(selector: (T) -> Int): Double {
+        val sum = this.map { selector(it) }.sum()
+        return if (this.count() > 0) sum.toDouble().div(this.count()) else 0.0
+    }
+
     /**
      * Search content on GitHub with the given options and return a list of the full names of the found repositories.
      *
@@ -46,23 +51,24 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
 
         val max = githubRepositories.first().owner
         val min = githubRepositories.last().owner
+
         logger.info { "Maximum stargazers: ${max.stargazersCount}, repository: ${max.fullName}." }
         logger.info { "Minimum stargazers: ${min.stargazersCount}, repository: ${min.fullName}." }
-        logger.info { "Average stargazers: ${githubRepositories.sumBy { it.owner.stargazersCount }}." }
+        logger.info { "Average stargazers: ${githubRepositories.averageOf { it.owner.stargazersCount }}." }
 
         return githubRepositories
     }
 
     private fun sortByWatchers(githubRepositories: PagedSearchIterable<GHContent>): PagedSearchIterable<GHContent> {
         githubRepositories
-            .also { logger.info { "Sorting owners by watcher count count." } }
+            .also { logger.info { "Sorting owners by watcher count." } }
             .sortedByDescending { it.owner.watchers }
 
         val max = githubRepositories.first().owner
         val min = githubRepositories.last().owner
         logger.info { "Maximum watchers: ${max.watchers}, repository: ${max.watchers}." }
         logger.info { "Minimum watchers: ${min.watchers}, repository: ${min.watchers}." }
-        logger.info { "Average watchers: ${githubRepositories.sumBy { it.owner.watchers }}." }
+        logger.info { "Average watchers: ${githubRepositories.averageOf { it.owner.watchers }}." }
 
         return githubRepositories
     }

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
@@ -13,8 +13,8 @@ import org.kohsuke.github.PagedSearchIterable
 abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions {
     private companion object : KLogging()
 
-    var sortByStargazersCount = false
-    var sortByWatchersCount = false
+    var sortByStargazers = false
+    var sortByWatchers = false
 
     /**
      * Search content on GitHub with the given options and return a list of the full names of the found repositories.
@@ -28,8 +28,8 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
         if (maxProjects < searchResults.totalCount) logger.info { "Will be capped at $maxProjects." }
 
         val repositories = searchResults
-            .apply { if (sortByStargazersCount) sortByStargazersCount(this) }
-            .apply { if (sortByWatchersCount) sortByWatchersCount(this) }
+            .apply { if (sortByStargazers) sortByStargazers(this) }
+            .apply { if (sortByWatchers) sortByWatchers(this) }
             .take(maxProjects)
             .map { it.owner }
 
@@ -39,7 +39,7 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
 
     abstract fun buildGitHubSearchContent(gitHub: GitHub): GHContentSearchBuilder
 
-    private fun sortByStargazersCount(githubRepositories: PagedSearchIterable<GHContent>)
+    private fun sortByStargazers(githubRepositories: PagedSearchIterable<GHContent>)
         : PagedSearchIterable<GHContent> {
         githubRepositories
             .also { logger.info { "Sorting owners by stargazers count." } }
@@ -47,14 +47,14 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
 
         val max = githubRepositories.first().owner
         val min = githubRepositories.last().owner
-        logger.info { "Maximum stargazers: ${max.stargazersCount}, repo: ${max.fullName}." }
-        logger.info { "Minimum stargazers: ${min.stargazersCount}, repo: ${min.fullName}." }
+        logger.info { "Maximum stargazers: ${max.stargazersCount}, repository: ${max.fullName}." }
+        logger.info { "Minimum stargazers: ${min.stargazersCount}, repository: ${min.fullName}." }
         logger.info { "Average stargazers: ${githubRepositories.sumBy { it.owner.stargazersCount }}." }
 
         return githubRepositories
     }
 
-    private fun sortByWatchersCount(githubRepositories: PagedSearchIterable<GHContent>)
+    private fun sortByWatchers(githubRepositories: PagedSearchIterable<GHContent>)
         : PagedSearchIterable<GHContent> {
         githubRepositories
             .also { logger.info { "Sorting owners by watcher count count." } }
@@ -62,8 +62,8 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
 
         val max = githubRepositories.first().owner
         val min = githubRepositories.last().owner
-        logger.info { "Maximum watchers: ${max.watchers}, repo: ${max.watchers}." }
-        logger.info { "Minimum watchers: ${min.watchers}, repo: ${min.watchers}." }
+        logger.info { "Maximum watchers: ${max.watchers}, repository: ${max.watchers}." }
+        logger.info { "Minimum watchers: ${min.watchers}, repository: ${min.watchers}." }
         logger.info { "Average watchers: ${githubRepositories.sumBy { it.owner.watchers }}." }
 
         return githubRepositories


### PR DESCRIPTION
At the moment we take a very random sample of GitHub projects and mine these for patterns. A problem however with this approach is that a lot of the projects downloaded seem to be incomplete hobby projects, with very few files and next to no patterns.

It might therefore be necessary to at times limit ourselves to more relevant projects. To facilitate this the option to sort by stars and watchers has been added. Before, a single query was done to search for `pom` files on GitHub which contain a dependency on said library. Afterwards, the results were trimmed to the `maxProjects` before in turn querying GitHub for the projects which contain said `pom` files. Now however,  after the first query a query has to be done for each code file to get the stargazer and/or watcher count of the containing repository if we want to sort by either, making the process a lot slower. 

These of course are optional arguments. It should be noted that downloading  takes a lot longer. However, seeing as in reality this will only be done every once in a while (not during every PR) it shouldn't be too big of a deal. For an emperical analysis of the tool this should be no problem at all. If speed is really of the essence then it is still possible to take a completely random sample as is the status quo.