### PR TITLE
Change `equivTo` of Soot's `Local`

### DIFF
--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNode.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNode.kt
@@ -1,6 +1,7 @@
 package org.cafejojo.schaapi.models.libraryusagegraph.jimple
 
 import org.cafejojo.schaapi.models.Node
+import soot.Local
 import soot.jimple.DefinitionStmt
 import soot.jimple.GotoStmt
 import soot.jimple.IfStmt
@@ -52,16 +53,24 @@ class JimpleNode(val statement: Stmt, override val successors: MutableList<Node>
      */
     override fun equivTo(other: Node?) =
         if (other !is JimpleNode || this.statement::class != other.statement::class) false
-        else this.getTopLevelValues().zip(other.getTopLevelValues()).all { it.first.equivTo(it.second) }
+        else this.getTopLevelValues().zip(other.getTopLevelValues()).all {
+            if (it.first is Local && it.second is Local) {
+                it.first.type == it.second.type
+            } else {
+                it.first.equivTo(it.second)
+            }
+        }
 
     /**
-     * Generates a hashcode based on the values of the contained [Stmt] and their order.
+     * Generates a hash code based on the values of the contained [Stmt] and their order.
      *
-     * @return a hashcode based on the hashcodes of the values contained in the contained [Stmt]
+     * @return a hash code based on the hash codes of the values contained in the contained [Stmt]
      */
     override fun equivHashCode(): Int {
         var hash = 0
-        getTopLevelValues().forEachIndexed { index, value -> hash += (index + 1) * value.equivHashCode() }
+        getTopLevelValues().forEachIndexed { index, value ->
+            hash += (index + 1) * ((value as? Local)?.type?.hashCode() ?: value.equivHashCode())
+        }
         return hash
     }
 

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
@@ -7,6 +7,8 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import soot.BooleanType
+import soot.IntType
 import soot.jimple.DefinitionStmt
 import soot.jimple.Jimple
 
@@ -221,6 +223,42 @@ internal object JimpleNodeTest : Spek({
                 on { it.leftOp } doReturn leftOp
                 on { it.rightOp } doReturn rightOp
             })
+        }
+
+        it("should be equal if it contains a local") {
+            val local1 = Jimple.v().newLocal("local1", IntType.v())
+            val local2 = Jimple.v().newLocal("local2", IntType.v())
+            val node1 = JimpleNode(Jimple.v().newReturnStmt(local1))
+            val node2 = JimpleNode(Jimple.v().newReturnStmt(local2))
+
+            assertThat(node1.equivTo(node2)).isTrue()
+        }
+
+        it("should have the same hash code if it contains a local") {
+            val local1 = Jimple.v().newLocal("local1", IntType.v())
+            val local2 = Jimple.v().newLocal("local2", IntType.v())
+            val node1 = JimpleNode(Jimple.v().newReturnStmt(local1))
+            val node2 = JimpleNode(Jimple.v().newReturnStmt(local2))
+
+            assertThat(node1.equivHashCode()).isEqualTo(node2.equivHashCode())
+        }
+
+        it("should not equal if it contains a local with a different type") {
+            val local1 = Jimple.v().newLocal("local", IntType.v())
+            val local2 = Jimple.v().newLocal("local", BooleanType.v())
+            val node1 = JimpleNode(Jimple.v().newReturnStmt(local1))
+            val node2 = JimpleNode(Jimple.v().newReturnStmt(local2))
+
+            assertThat(node1.equivTo(node2)).isFalse()
+        }
+
+        it("should have the same hash code if it contains a local") {
+            val local1 = Jimple.v().newLocal("local", IntType.v())
+            val local2 = Jimple.v().newLocal("local", BooleanType.v())
+            val node1 = JimpleNode(Jimple.v().newReturnStmt(local1))
+            val node2 = JimpleNode(Jimple.v().newReturnStmt(local2))
+
+            assertThat(node1.equivHashCode()).isNotEqualTo(node2.equivHashCode())
         }
 
         it("should be equal if the values are in the same order and of the same type") {


### PR DESCRIPTION
Soot's `equivTo` works well, except for the `Local` class. Soot decided that two `Local`s are equivalent iff they  are the same (i.e. referential equality), but for our purposes we require only that the types are the same. This unexpected behaviour by Soot caused the pattern detector to detect duplicate patterns.

This PR "overrides" the behaviour of `Local`'s `equivTo` by adding an instance check whenever `equivTo` is called on a Soot object. Luckily, this happens only in `JimpleNode`.