### PR TITLE
Receive installation web hooks

### DIFF
--- a/modules/validation-pipeline/github-test-reporter/build.gradle
+++ b/modules/validation-pipeline/github-test-reporter/build.gradle
@@ -12,8 +12,6 @@ apply plugin: "org.springframework.boot"
 apply plugin: "io.spring.dependency-management"
 
 dependencies {
-    compile project(":validation-pipeline:github-test-reporter")
-
     compile group: "com.auth0", name: "java-jwt", version: javaJwtVersion
     compile group: "com.fasterxml.jackson.module", name: "jackson-module-kotlin"
     compile group: "com.github.kittinunf.fuel", name: "fuel", version: fuelVersion // for JVM

--- a/modules/validation-pipeline/github-test-reporter/build.gradle
+++ b/modules/validation-pipeline/github-test-reporter/build.gradle
@@ -12,6 +12,8 @@ apply plugin: "org.springframework.boot"
 apply plugin: "io.spring.dependency-management"
 
 dependencies {
+    compile project(":validation-pipeline:github-test-reporter")
+
     compile group: "com.auth0", name: "java-jwt", version: javaJwtVersion
     compile group: "com.fasterxml.jackson.module", name: "jackson-module-kotlin"
     compile group: "com.github.kittinunf.fuel", name: "fuel", version: fuelVersion // for JVM

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/CheckReporter.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/CheckReporter.kt
@@ -21,10 +21,9 @@ class CheckReporter(@Autowired private val appKeyGenerator: AppKeyGenerator) {
      *
      * When successful, a CheckRun object containing the ID needed for future check requests is returned.
      */
-    fun reportStarted(installationId: Int, owner: String, repository: String, headBranch: String, headSha: String) =
+    fun reportStarted(installationId: Int, repositoryFullName: String, headBranch: String, headSha: String) =
         GitHubApi.reportCheckStarted(
-            owner,
-            repository,
+            repositoryFullName,
             headBranch,
             headSha,
             checkName = "breaking change detection",

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/GitHubApi.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/GitHubApi.kt
@@ -25,15 +25,14 @@ internal sealed class GitHubApi : FuelRouting {
     }
 
     internal class reportCheckStarted(
-        owner: String,
-        repository: String,
+        repositoryFullName: String,
         headBranch: String,
         headSha: String,
         checkName: String,
         token: String
     ) : GitHubApi() {
         override val method = Method.POST
-        override val path = "/repos/$owner/$repository/check-runs"
+        override val path = "/repos/$repositoryFullName/check-runs"
         override val headers = mapOf(
             "Authorization" to "Token $token",
             "Accept" to "application/vnd.github.antiope-preview+json"

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/Properties.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/Properties.kt
@@ -9,6 +9,7 @@ import java.io.FileInputStream
 object Properties {
     val appId: String
     val appPrivateKeyLocation: String
+    val testsStorageLocation: File
 
     init {
         if (File("githubtestreporter.properties").exists()) {
@@ -17,6 +18,7 @@ object Properties {
 
         appId = getProperty("app_id")
         appPrivateKeyLocation = getProperty("app_private_key_location")
+        testsStorageLocation = File(getProperty("tests_storage_location"))
     }
 
     private fun getProperty(name: String) = System.getProperty(name) ?: throw PropertyNotSetException(name)

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiver.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiver.kt
@@ -64,6 +64,9 @@ class WebHookReceiver(val checkReporter: CheckReporter) {
                     )
                 }
             }
+            "installation" -> {
+                println("SOOO COOL WE HAVE A NEW USER")
+            }
             else -> throw IncomingWebHookException("Cannot process web hooks for events of type $eventType.")
         }
 

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiver.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiver.kt
@@ -3,12 +3,15 @@ package org.cafejojo.schaapi.validationpipeline.githubtestreporter
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import org.cafejojo.schaapi.validationpipeline.githubtestreporter.events.CheckSuiteEvent
+import org.cafejojo.schaapi.validationpipeline.githubtestreporter.events.InstallationEvent
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
+import java.io.File
 
 /**
  * Receives GitHub web hooks.
@@ -46,7 +49,7 @@ class WebHookReceiver(val checkReporter: CheckReporter) {
                         Installation id is ${checkSuiteEvent.installation.id}
                         For commit ${checkSuiteEvent.checkSuite.headSha}
                         On branch ${checkSuiteEvent.checkSuite.headBranch}
-                        For repository ${checkSuiteEvent.repository.owner.login}/${checkSuiteEvent.repository.name}
+                        For repository ${checkSuiteEvent.repository.fullName}
 
                         with status `in_progress` and started_at set to the current time
 
@@ -57,15 +60,27 @@ class WebHookReceiver(val checkReporter: CheckReporter) {
                 with(checkSuiteEvent) {
                     checkReporter.reportStarted(
                         installation.id,
-                        repository.owner.login,
-                        repository.name,
+                        repository.fullName,
                         checkSuite.headBranch,
                         checkSuite.headSha
                     )
                 }
             }
             "installation" -> {
-                println("SOOO COOL WE HAVE A NEW USER")
+                val installationEvent = mapper.readValue(body, InstallationEvent::class.java)
+
+                when {
+                    installationEvent.isCreated() -> {
+                        installationEvent.repositories?.forEach {
+                            File(Properties.testsStorageLocation, it.fullName).mkdirs()
+                        }
+                    }
+                    installationEvent.isDeleted() -> {
+                        installationEvent.installation.account?.let { account ->
+                            File(Properties.testsStorageLocation, account.login).deleteRecursively()
+                        }
+                    }
+                }
             }
             else -> throw IncomingWebHookException("Cannot process web hooks for events of type $eventType.")
         }

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/events/CheckSuiteEvent.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/events/CheckSuiteEvent.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.validationpipeline.githubtestreporter
+package org.cafejojo.schaapi.validationpipeline.githubtestreporter.events
 
 internal data class CheckSuiteEvent(
     val installation: Installation,
@@ -9,10 +9,4 @@ internal data class CheckSuiteEvent(
     fun isRequested() = action == "requested"
 }
 
-internal data class Installation(val id: Int = 0)
-
 internal data class CheckSuite(val headBranch: String = "", val headSha: String = "")
-
-internal data class Repository(val name: String, val owner: Owner)
-
-internal data class Owner(val login: String)

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/events/InstallationEvent.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/events/InstallationEvent.kt
@@ -1,0 +1,10 @@
+package org.cafejojo.schaapi.validationpipeline.githubtestreporter.events
+
+internal data class InstallationEvent(
+    val installation: Installation,
+    val action: String = "",
+    val repositories: List<Repository>? = null
+) {
+    fun isCreated() = action == "created"
+    fun isDeleted() = action == "deleted"
+}

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/events/Shared.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/events/Shared.kt
@@ -1,0 +1,7 @@
+package org.cafejojo.schaapi.validationpipeline.githubtestreporter.events
+
+internal data class Installation(val id: Int = 0, val account: Account? = null)
+
+internal data class Repository(val name: String, val fullName: String, val private: Boolean)
+
+internal data class Account(val login: String)

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/AppKeyGeneratorTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/AppKeyGeneratorTest.kt
@@ -6,6 +6,12 @@ import org.jetbrains.spek.api.dsl.it
 import java.net.URLDecoder
 
 object AppKeyGeneratorTest : Spek({
+    beforeEachTest {
+        System.getProperties().load(
+            AppKeyGeneratorTest::class.java.getResourceAsStream("/githubtestreporter.properties")
+        )
+    }
+
     it("generates a jwt token to authenticate as GitHub app") {
         System.setProperty("app_id", "12345")
         System.setProperty("app_private_key_location", getResourcePath("/pkcs8_key"))

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/CheckReporterTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/CheckReporterTest.kt
@@ -48,8 +48,7 @@ object CheckReporterTest : Spek({
 
         val checkRun = CheckReporter(appKeyGenerator).reportStarted(
             installationId = 123456,
-            owner = "cafejojo",
-            repository = "schaapi",
+            repositoryFullName = "cafejojo/schaapi",
             headBranch = "patch-1",
             headSha = "3c91f40ff5f92146e877488c1f3c7c1b3f9f252a"
         )

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/IntegrationTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/IntegrationTest.kt
@@ -61,7 +61,7 @@ class IntegrationTest {
     }
 
     @Test
-    fun `it can receive a check suite start web hook`() {
+    fun `it can receive a 'check suite started' web hook`() {
         val (futureRequest, _) = mockHttpClient(
             json("installation token request response") {
                 "token" to "this-is-the-installation-token"
@@ -97,7 +97,7 @@ class IntegrationTest {
     }
 
     @Test
-    fun `it can receive a installation created web hook`() {
+    fun `it can receive an 'installation created' web hook`() {
         val requestJson = IntegrationTest::class.java
             .getResourceAsStream("/fixtures/github/installation_created_webhook.resp").bufferedReader().readText()
 
@@ -117,7 +117,7 @@ class IntegrationTest {
     }
 
     @Test
-    fun `it can receive a installation deleted web hook`() {
+    fun `it can receive an 'installation deleted' web hook`() {
         val requestJson = IntegrationTest::class.java
             .getResourceAsStream("/fixtures/github/installation_deleted_webhook.resp").bufferedReader().readText()
 

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/IntegrationTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/IntegrationTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.mock
 import net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -19,6 +20,8 @@ import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 import org.springframework.test.context.junit.jupiter.SpringExtension
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
 @ExtendWith(SpringExtension::class)
@@ -27,6 +30,8 @@ import java.util.concurrent.TimeUnit
     classes = [IntegrationTest.TestConfig::class]
 )
 class IntegrationTest {
+    lateinit var testsStorageLocation: Path
+
     @Autowired
     private lateinit var restTemplate: TestRestTemplate
 
@@ -44,6 +49,15 @@ class IntegrationTest {
         System.getProperties().load(
             IntegrationTest::class.java.getResourceAsStream("/githubtestreporter.properties")
         )
+
+        testsStorageLocation = Files.createTempDirectory("schaapi-github")
+
+        System.setProperty("tests_storage_location", testsStorageLocation.toString())
+    }
+
+    @AfterEach
+    fun tearDown() {
+        testsStorageLocation.toFile().deleteRecursively()
     }
 
     @Test
@@ -84,8 +98,6 @@ class IntegrationTest {
 
     @Test
     fun `it can receive a installation created web hook`() {
-        System.setProperty("tests_storage_location", "/Development/tu/cafejojo/schaapi/output/")
-
         val requestJson = IntegrationTest::class.java
             .getResourceAsStream("/fixtures/github/installation_created_webhook.resp").bufferedReader().readText()
 
@@ -106,8 +118,6 @@ class IntegrationTest {
 
     @Test
     fun `it can receive a installation deleted web hook`() {
-        System.setProperty("tests_storage_location", "/Development/tu/cafejojo/schaapi/output/")
-
         val requestJson = IntegrationTest::class.java
             .getResourceAsStream("/fixtures/github/installation_deleted_webhook.resp").bufferedReader().readText()
 

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiverTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiverTest.kt
@@ -24,13 +24,11 @@ object WebHookReceiverTest : Spek({
             }
             "repository" to json {
                 "name" to "schaapi"
-                "owner" to json {
-                    "login" to "cafejojo"
-                }
+                "full_name" to "cafejojo/schaapi"
             }
         }.toString())
 
-        verify(checkReporter).reportStarted(12345, "cafejojo", "schaapi", "patch01", "abc123")
+        verify(checkReporter).reportStarted(12345, "cafejojo/schaapi", "patch01", "abc123")
     }
 
     it("cannot process general GitHub check suite web hooks") {
@@ -48,9 +46,7 @@ object WebHookReceiverTest : Spek({
             }
             "repository" to json {
                 "name" to "schaapi"
-                "owner" to json {
-                    "login" to "cafejojo"
-                }
+                "full_name" to "cafejojo/schaapi"
             }
         }.toString()
 
@@ -58,8 +54,30 @@ object WebHookReceiverTest : Spek({
             .isInstanceOf(IncomingWebHookException::class.java)
             .hasMessageContaining("general-action")
 
-        verify(checkReporter, never()).reportStarted(any(), any(), any(), any(), any())
+        verify(checkReporter, never()).reportStarted(any(), any(), any(), any())
     }
+
+//    it("can receive GitHub installation created web hooks") {
+//        val checkReporter = mock<CheckReporter>()
+//        val webHookReceiver = WebHookReceiver(checkReporter)
+//
+//        webHookReceiver.processWebHook("installation", json {
+//            "action" to "created"
+//            "installation" to json {
+//                "id" to "12345"
+//            }
+//            "check_suite" to json {
+//                "head_branch" to "patch01"
+//                "head_sha" to "abc123"
+//            }
+//            "repository" to json {
+//                "name" to "schaapi"
+//                "full_name" to "cafejojo/schaapi"
+//            }
+//        }.toString())
+//
+//        verify(checkReporter).reportStarted(12345, "cafejojo/schaapi", "patch01", "abc123")
+//    }
 
     it("cannot process general GitHub web hooks") {
         val webHookReceiver = WebHookReceiver(mock())

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiverTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiverTest.kt
@@ -57,28 +57,6 @@ object WebHookReceiverTest : Spek({
         verify(checkReporter, never()).reportStarted(any(), any(), any(), any())
     }
 
-//    it("can receive GitHub installation created web hooks") {
-//        val checkReporter = mock<CheckReporter>()
-//        val webHookReceiver = WebHookReceiver(checkReporter)
-//
-//        webHookReceiver.processWebHook("installation", json {
-//            "action" to "created"
-//            "installation" to json {
-//                "id" to "12345"
-//            }
-//            "check_suite" to json {
-//                "head_branch" to "patch01"
-//                "head_sha" to "abc123"
-//            }
-//            "repository" to json {
-//                "name" to "schaapi"
-//                "full_name" to "cafejojo/schaapi"
-//            }
-//        }.toString())
-//
-//        verify(checkReporter).reportStarted(12345, "cafejojo/schaapi", "patch01", "abc123")
-//    }
-
     it("cannot process general GitHub web hooks") {
         val webHookReceiver = WebHookReceiver(mock())
 

--- a/modules/validation-pipeline/github-test-reporter/src/test/resources/fixtures/github/installation_created_webhook.resp
+++ b/modules/validation-pipeline/github-test-reporter/src/test/resources/fixtures/github/installation_created_webhook.resp
@@ -1,0 +1,71 @@
+{
+  "action": "created",
+  "installation": {
+    "id": 203592,
+    "account": {
+      "login": "cabotest",
+      "id": 40028399,
+      "node_id": "MDQ6VXNlcjQwMDI4Mzk5",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/40028399?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/cabotest",
+      "html_url": "https://github.com/cabotest",
+      "followers_url": "https://api.github.com/users/cabotest/followers",
+      "following_url": "https://api.github.com/users/cabotest/following{/other_user}",
+      "gists_url": "https://api.github.com/users/cabotest/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/cabotest/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/cabotest/subscriptions",
+      "organizations_url": "https://api.github.com/users/cabotest/orgs",
+      "repos_url": "https://api.github.com/users/cabotest/repos",
+      "events_url": "https://api.github.com/users/cabotest/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/cabotest/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "repository_selection": "selected",
+    "access_tokens_url": "https://api.github.com/installations/203592/access_tokens",
+    "repositories_url": "https://api.github.com/installation/repositories",
+    "html_url": "https://github.com/settings/installations/203592",
+    "app_id": 12757,
+    "target_id": 40028399,
+    "target_type": "User",
+    "permissions": {
+      "checks": "write",
+      "metadata": "read"
+    },
+    "events": [
+      "check_run"
+    ],
+    "created_at": 1528375186,
+    "updated_at": 1528375186,
+    "single_file_name": null
+  },
+  "repositories": [
+    {
+      "id": 136471895,
+      "name": "hello-world",
+      "full_name": "cabotest/hello-world",
+      "private": false
+    }
+  ],
+  "sender": {
+    "login": "cabotest",
+    "id": 40028399,
+    "node_id": "MDQ6VXNlcjQwMDI4Mzk5",
+    "avatar_url": "https://avatars0.githubusercontent.com/u/40028399?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/cabotest",
+    "html_url": "https://github.com/cabotest",
+    "followers_url": "https://api.github.com/users/cabotest/followers",
+    "following_url": "https://api.github.com/users/cabotest/following{/other_user}",
+    "gists_url": "https://api.github.com/users/cabotest/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/cabotest/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/cabotest/subscriptions",
+    "organizations_url": "https://api.github.com/users/cabotest/orgs",
+    "repos_url": "https://api.github.com/users/cabotest/repos",
+    "events_url": "https://api.github.com/users/cabotest/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/cabotest/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/modules/validation-pipeline/github-test-reporter/src/test/resources/fixtures/github/installation_deleted_webhook.resp
+++ b/modules/validation-pipeline/github-test-reporter/src/test/resources/fixtures/github/installation_deleted_webhook.resp
@@ -1,0 +1,63 @@
+{
+  "action": "deleted",
+  "installation": {
+    "id": 203592,
+    "account": {
+      "login": "cabotest",
+      "id": 40028399,
+      "node_id": "MDQ6VXNlcjQwMDI4Mzk5",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/40028399?v=4",
+      "gravatar_id": "",
+      "url": "https://api.github.com/users/cabotest",
+      "html_url": "https://github.com/cabotest",
+      "followers_url": "https://api.github.com/users/cabotest/followers",
+      "following_url": "https://api.github.com/users/cabotest/following{/other_user}",
+      "gists_url": "https://api.github.com/users/cabotest/gists{/gist_id}",
+      "starred_url": "https://api.github.com/users/cabotest/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/cabotest/subscriptions",
+      "organizations_url": "https://api.github.com/users/cabotest/orgs",
+      "repos_url": "https://api.github.com/users/cabotest/repos",
+      "events_url": "https://api.github.com/users/cabotest/events{/privacy}",
+      "received_events_url": "https://api.github.com/users/cabotest/received_events",
+      "type": "User",
+      "site_admin": false
+    },
+    "repository_selection": "selected",
+    "access_tokens_url": "https://api.github.com/installations/203592/access_tokens",
+    "repositories_url": "https://api.github.com/installation/repositories",
+    "html_url": "https://github.com/settings/installations/203592",
+    "app_id": 12757,
+    "target_id": 40028399,
+    "target_type": "User",
+    "permissions": {
+      "checks": "write",
+      "metadata": "read"
+    },
+    "events": [
+      "check_run"
+    ],
+    "created_at": "2018-06-07T12:39:46.000Z",
+    "updated_at": "2018-06-07T12:39:46.000Z",
+    "single_file_name": null
+  },
+  "sender": {
+    "login": "cabotest",
+    "id": 40028399,
+    "node_id": "MDQ6VXNlcjQwMDI4Mzk5",
+    "avatar_url": "https://avatars0.githubusercontent.com/u/40028399?v=4",
+    "gravatar_id": "",
+    "url": "https://api.github.com/users/cabotest",
+    "html_url": "https://github.com/cabotest",
+    "followers_url": "https://api.github.com/users/cabotest/followers",
+    "following_url": "https://api.github.com/users/cabotest/following{/other_user}",
+    "gists_url": "https://api.github.com/users/cabotest/gists{/gist_id}",
+    "starred_url": "https://api.github.com/users/cabotest/starred{/owner}{/repo}",
+    "subscriptions_url": "https://api.github.com/users/cabotest/subscriptions",
+    "organizations_url": "https://api.github.com/users/cabotest/orgs",
+    "repos_url": "https://api.github.com/users/cabotest/repos",
+    "events_url": "https://api.github.com/users/cabotest/events{/privacy}",
+    "received_events_url": "https://api.github.com/users/cabotest/received_events",
+    "type": "User",
+    "site_admin": false
+  }
+}

--- a/modules/validation-pipeline/github-test-reporter/src/test/resources/githubtestreporter.properties
+++ b/modules/validation-pipeline/github-test-reporter/src/test/resources/githubtestreporter.properties
@@ -1,0 +1,3 @@
+app_id                   = 12345
+app_private_key_location = pkcs8_key
+tests_storage_location   = output/

--- a/modules/web/src/main/kotlin/org/cafejojo/schaapi/web/WebApplication.kt
+++ b/modules/web/src/main/kotlin/org/cafejojo/schaapi/web/WebApplication.kt
@@ -8,7 +8,10 @@ import org.springframework.context.annotation.ComponentScan
  * The web application.
  */
 @SpringBootApplication
-@ComponentScan(basePackages = ["org.cafejojo.schaapi.web", "org.cafejojo.schaapi.githubtestreporter"])
+@ComponentScan(basePackages = [
+    "org.cafejojo.schaapi.web",
+    "org.cafejojo.schaapi.validationpipeline.githubtestreporter"
+])
 open class WebApplication
 
 /**


### PR DESCRIPTION
This PR adds processing of installation web hooks.

For each new installation a directory will be created on the file system in which tests for the installation repos can be stored.

In a future PR we will also receive web hooks for adding/removing repositories from an already installed installation.