### PR TITLE
Properly delete zip files

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -32,11 +32,16 @@ internal class GitHubProjectDownloader<P : Project>(
      * Extracts the directory denoting the master branch in a GitHub project by moving the up one level.
      */
     private fun File.extractMasterFile() {
-        require(this.listFiles().isNotEmpty()) { "GitHub project must contain files." }
-        require(this.listFiles().first().isDirectory) { "GitHub project must contain a directory for master." }
+        require(this.listFiles().size == 1) {
+            "GitHub project must contain exactly one file, but contained ${this.listFiles().size} files."
+        }
 
         val masterFile = this.listFiles().first()
-        masterFile.listFiles()?.forEach { it.moveUpOneLevel() }
+        require(masterFile.isDirectory) { "GitHub Project must contain a directory for master." }
+
+        if (masterFile.listFiles().isEmpty()) logger.warn { "${masterFile.absolutePath} did not contain any files." }
+        masterFile.listFiles().forEach { it.moveUpOneLevel() }
+
         masterFile.delete()
     }
 

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -79,28 +79,28 @@ internal class GitHubProjectDownloader<P : Project>(
 
     internal fun saveZipToFile(input: InputStream, projectName: String): File? {
         val alphaNumericRegex = Regex("[^A-Za-z0-9]")
-        val outputFile = File(
+        val zipFile = File(
             outputDirectory,
             "${alphaNumericRegex.replace(projectName, "")}${projectNames.indexOf(projectName)}.zip"
         )
 
         try {
-            if (outputFile.exists()) {
-                logger.debug { "Output file ${outputFile.path} already exists and will be deleted." }
-                outputFile.delete()
+            if (zipFile.exists()) {
+                logger.debug { "Output file ${zipFile.path} already exists and will be deleted." }
+                zipFile.delete()
             }
 
-            if (outputFile.createNewFile()) {
-                input.copyTo(FileOutputStream(outputFile))
+            if (zipFile.createNewFile()) {
+                input.copyTo(FileOutputStream(zipFile))
             } else {
-                logger.warn("Output file ${outputFile.path} could not be created.")
+                logger.warn("Output file ${zipFile.path} could not be created.")
             }
         } catch (e: IOException) {
-            logger.warn("Could not save project to ${outputFile.path}.", e)
+            logger.warn("Could not save project to ${zipFile.path}.", e)
             return null
         }
 
-        return outputFile
+        return zipFile
     }
 
     internal fun unzip(projectZipFile: File): File? {
@@ -112,16 +112,18 @@ internal class GitHubProjectDownloader<P : Project>(
 
         try {
             ZipUtil.unpack(projectZipFile, githubProject)
-            logger.debug { "Successfully unzipped file ${projectZipFile.name}." }
+            logger.debug { "Successfully unzipped file ${projectZipFile.absolutePath}." }
         } catch (e: IOException) {
-            logger.warn("Could not unzip ${projectZipFile.name}.", e)
+            logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e)
             return null
         } catch (e: ZipException) {
-            logger.warn("Could not unzip ${projectZipFile.name}.", e)
+            logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e)
             return null
         } finally {
+            projectZipFile.outputStream().close()
+
             if (projectZipFile.exists()) {
-                logger.debug { "Deleting $projectZipFile." }
+                logger.debug { "Deleting ${projectZipFile.absolutePath}." }
                 projectZipFile.delete()
             }
         }

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -5,7 +5,6 @@ import org.cafejojo.schaapi.models.Project
 import org.zeroturnaround.zip.ZipException
 import org.zeroturnaround.zip.ZipUtil
 import java.io.File
-import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStream
 import java.net.HttpURLConnection
@@ -97,7 +96,7 @@ internal class GitHubProjectDownloader<P : Project>(
             }
 
             if (zipFile.createNewFile()) {
-                input.copyTo(FileOutputStream(zipFile))
+                zipFile.outputStream().use { input.copyTo(it) }
             } else {
                 logger.warn("Output file ${zipFile.path} could not be created.")
             }
@@ -126,12 +125,7 @@ internal class GitHubProjectDownloader<P : Project>(
             logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e)
             return null
         } finally {
-            projectZipFile.outputStream().close()
-
-            if (projectZipFile.exists()) {
-                logger.debug { "Deleting ${projectZipFile.absolutePath}." }
-                projectZipFile.delete()
-            }
+            projectZipFile.delete()
         }
 
         return githubProject

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -32,8 +32,8 @@ internal class GitHubProjectDownloader<P : Project>(
      * Extracts the directory denoting the master branch in a GitHub project by moving the up one level.
      */
     private fun File.extractMasterFile() {
-        require(this.listFiles().isNotEmpty()) { "GitHub Project must contain files." }
-        require(this.listFiles().first().isDirectory) { "GitHub Project must contain a directory for master." }
+        require(this.listFiles().isNotEmpty()) { "GitHub project must contain files." }
+        require(this.listFiles().first().isDirectory) { "GitHub project must contain a directory for master." }
 
         val masterFile = this.listFiles().first()
         masterFile.listFiles()?.forEach { it.moveUpOneLevel() }

--- a/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GithubProjectDownloaderTest.kt
+++ b/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GithubProjectDownloaderTest.kt
@@ -120,7 +120,7 @@ internal object GitHubProjectDownloaderTest : Spek({
             val zipFile = addZipFile("testZipDirectory", "test text")
             val unzippedFile = GitHubProjectDownloader(emptyList(), output, ::testProjectPacker).unzip(zipFile)
 
-            assertThat(unzippedFile?.listFiles()?.first()?.readText()).isEqualTo("test text")
+            assertThat(unzippedFile?.listFiles()?.first()?.listFiles()?.first()?.readText()).isEqualTo("test text")
         }
 
         it("should delete the zip file after extraction") {
@@ -190,6 +190,7 @@ internal object GitHubProjectDownloaderTest : Spek({
 
             downloader.download()
 
+            assertThat(output.listFiles()).hasSize(1)
             assertThat(output.listFiles().first().listFiles().first().readText()).isEqualTo("content")
         }
     }

--- a/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GithubProjectDownloaderTest.kt
+++ b/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GithubProjectDownloaderTest.kt
@@ -22,9 +22,10 @@ internal object GitHubProjectDownloaderTest : Spek({
     fun addZipFile(dirName: String, fileContent: String, customOutput: File = output): File {
         // Directory which represents what should be zipped
         val tempDir = File(customOutput, dirName)
-        val tempFile = File(tempDir, "temp.txt")
+        val tempMasterDir = File(tempDir, "master")
+        val tempFile = File(tempMasterDir, "temp.txt")
 
-        tempDir.mkdirs()
+        tempMasterDir.mkdirs()
         tempFile.createNewFile()
         tempFile.writeText(fileContent)
 
@@ -174,7 +175,7 @@ internal object GitHubProjectDownloaderTest : Spek({
             assertThat(connection?.requestMethod).isEqualTo("GET")
         }
 
-        it("should save the unzipped file") {
+        it("should save the unzipped file and delete the old zip file") {
             val zipFile = addZipFile("testProject", "content", Files.createTempDirectory("project-downloader").toFile())
 
             val downloader = spy(GitHubProjectDownloader(listOf("testProject"), output, ::testProjectPacker))
@@ -189,7 +190,6 @@ internal object GitHubProjectDownloaderTest : Spek({
 
             downloader.download()
 
-            assertThat(output.listFiles()).isNotEmpty()
             assertThat(output.listFiles().first().listFiles().first().readText()).isEqualTo("content")
         }
     }


### PR DESCRIPTION
See issue #229 

In addition to this, project files are now propely extracted. Before, projects contained a directory within which denoted the master branch which within contained the project. This is now directly extracted.

Before:
```
projects
 |- project0
  |- master
   |-files...
 |- project1
  |- master
   |-files...
```

After:
```
projects
 |- project0
  |-files...
 |- project1
  |-files...
```