### PR TITLE
Fix jimple sequence duplication

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -176,10 +176,10 @@ private fun List<JimpleNode>.duplicate(): List<JimpleNode> {
     newNodes.forEach {
         val statement = it.statement
         when (statement) {
-            is GotoStmt -> statement.target = oldToNewStatements[statement]
-            is IfStmt -> statement.setTarget(oldToNewStatements[statement])
+            is GotoStmt -> statement.target = oldToNewStatements[statement.target]
+            is IfStmt -> statement.setTarget(oldToNewStatements[statement.target])
             is SwitchStmt -> {
-                statement.defaultTarget = oldToNewStatements[statement]
+                statement.defaultTarget = oldToNewStatements[statement.defaultTarget]
                 statement.targets.forEachIndexed { index, target ->
                     statement.setTarget(index, oldToNewStatements[target])
                 }

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -355,6 +355,22 @@ internal object ClassGeneratorTest : Spek({
                 .isEqualToComparingFieldByFieldRecursively(returnStmt)
         }
 
+        it("should replace statement target instances correctly in a loop") {
+            val ifStmt = Jimple.v().newIfStmt(
+                Jimple.v().newEqExpr(IntConstant.v(0), IntConstant.v(0)),
+                Jimple.v().newNopStmt()
+            )
+            ifStmt.setTarget(ifStmt)
+            val gotoStmt = Jimple.v().newGotoStmt(ifStmt)
+
+            val method = ClassGenerator("test").apply {
+                generateMethod("method", listOf(ifStmt, gotoStmt).map { JimpleNode(it) })
+            }.sootClass.methods.last()
+
+            val newIfStmt = method.activeBody.units.elementAt(0) as IfStmt
+            assertThat(newIfStmt.target).isEqualTo(newIfStmt)
+        }
+
         it("should replace statement target instances in if statements") {
             val value = Jimple.v().newLocal("value", RefType.v("myClass"))
             val ifCondition = Jimple.v().newConditionExprBox(JEqExpr(value, value)).value


### PR DESCRIPTION
#220 added duplication of statement sequences. While working correctly for jump statements pointing outside the unit chain, loop constructs are incorrectly handled. The current implementation fails to maintain referential integrity for these kinds of scenarios. This PR adds an (initially failing) test for this behavior and proposes a fix for it.

Credits to @FWDekker for spotting this one!