### PR TITLE
Add empty loop filter

### DIFF
--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -8,6 +8,7 @@ import org.cafejojo.schaapi.miningpipeline.PatternFilter
 import org.cafejojo.schaapi.miningpipeline.miner.directory.DirectorySearchOptions
 import org.cafejojo.schaapi.miningpipeline.miner.directory.ProjectMiner
 import org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan.PatternDetector
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.EmptyLoopPatternFilterRule
 import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.IncompleteInitPatternFilterRule
 import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.LengthPatternFilterRule
 import org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.ProjectCompiler
@@ -60,7 +61,11 @@ internal class DirectoryMiningCommandLineInterface {
             userProjectCompiler = ProjectCompiler(),
             libraryUsageGraphGenerator = LibraryUsageGraphGenerator,
             patternDetector = PatternDetector(patternDetectorMinCount, maxSequenceLength, GeneralizedNodeComparator()),
-            patternFilter = PatternFilter(IncompleteInitPatternFilterRule(), LengthPatternFilterRule()),
+            patternFilter = PatternFilter(
+                IncompleteInitPatternFilterRule(),
+                LengthPatternFilterRule(),
+                EmptyLoopPatternFilterRule()
+            ),
             testGenerator = TestGenerator(
                 library = libraryMaven,
                 outputDirectory = output,

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -8,6 +8,7 @@ import org.cafejojo.schaapi.miningpipeline.PatternFilter
 import org.cafejojo.schaapi.miningpipeline.miner.github.MavenProjectSearchOptions
 import org.cafejojo.schaapi.miningpipeline.miner.github.ProjectMiner
 import org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan.PatternDetector
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.EmptyLoopPatternFilterRule
 import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.IncompleteInitPatternFilterRule
 import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.LengthPatternFilterRule
 import org.cafejojo.schaapi.miningpipeline.projectcompiler.javajar.ProjectCompiler
@@ -92,7 +93,11 @@ internal class GitHubMiningCommandLineInterface {
             userProjectCompiler = org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.ProjectCompiler(),
             libraryUsageGraphGenerator = LibraryUsageGraphGenerator,
             patternDetector = PatternDetector(patternDetectorMinCount, maxSequenceLength, GeneralizedNodeComparator()),
-            patternFilter = PatternFilter(IncompleteInitPatternFilterRule(), LengthPatternFilterRule()),
+            patternFilter = PatternFilter(
+                IncompleteInitPatternFilterRule(),
+                LengthPatternFilterRule(),
+                EmptyLoopPatternFilterRule()
+            ),
             testGenerator = TestGenerator(
                 library = libraryJar,
                 outputDirectory = output,

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRule.kt
@@ -14,7 +14,9 @@ class EmptyLoopPatternFilterRule : PatternFilterRule<JimpleNode> {
     override fun retain(pattern: List<JimpleNode>) =
         pattern
             .none { node ->
-                pattern.getOrNull(pattern.indexOf(node) - 1)?.statement === (node.statement as? GotoStmt)?.target
+                pattern.getOrNull(pattern.indexOf(node) - 1)?.let {
+                    it.statement === (node.statement as? GotoStmt)?.target
+                } ?: false
             }
             .also { if (!it) logger.debug { "Empty loop pattern was detected: $pattern" } }
 }

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRule.kt
@@ -13,10 +13,7 @@ class EmptyLoopPatternFilterRule : PatternFilterRule<JimpleNode> {
 
     override fun retain(pattern: List<JimpleNode>) =
         pattern
-            .none { node ->
-                pattern.getOrNull(pattern.indexOf(node) - 1)?.let {
-                    it.statement === (node.statement as? GotoStmt)?.target
-                } ?: false
-            }
+            .drop(1)
+            .none { node -> pattern[pattern.indexOf(node) - 1].statement === (node.statement as? GotoStmt)?.target }
             .also { if (!it) logger.debug { "Empty loop pattern was detected: $pattern" } }
 }

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRule.kt
@@ -13,11 +13,8 @@ class EmptyLoopPatternFilterRule : PatternFilterRule<JimpleNode> {
 
     override fun retain(pattern: List<JimpleNode>) =
         pattern
-            .filter { it.statement is GotoStmt }
-            .all { node ->
-                if (pattern.getOrNull(pattern.indexOf(node) - 1)?.statement === (node.statement as? GotoStmt)?.target)
-                    false.also { if (!it) logger.debug { "Empty loop pattern was detected: $pattern" } }
-                else
-                    true
+            .none { node ->
+                pattern.getOrNull(pattern.indexOf(node) - 1)?.statement === (node.statement as? GotoStmt)?.target
             }
+            .also { if (!it) logger.debug { "Empty loop pattern was detected: $pattern" } }
 }

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRule.kt
@@ -12,17 +12,12 @@ class EmptyLoopPatternFilterRule : PatternFilterRule<JimpleNode> {
     private companion object : KLogging()
 
     override fun retain(pattern: List<JimpleNode>) =
-        pattern.none { node ->
-            val statement = node.statement
-
-            if (statement is GotoStmt) {
-                val previousStatements = pattern.takeWhile { it.statement !== statement }
-
-                if (previousStatements.isNotEmpty() && statement.target === previousStatements.last().statement) {
-                    return@none true
-                        .also { if (!it) logger.debug { "Empty loop pattern was detected: $pattern" } }
-                }
+        pattern
+            .filter { it.statement is GotoStmt }
+            .all { node ->
+                if (pattern.getOrNull(pattern.indexOf(node) - 1)?.statement === (node.statement as? GotoStmt)?.target)
+                    false.also { if (!it) logger.debug { "Empty loop pattern was detected: $pattern" } }
+                else
+                    true
             }
-            false
-        }
 }

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRule.kt
@@ -1,0 +1,28 @@
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple
+
+import mu.KLogging
+import org.cafejojo.schaapi.miningpipeline.PatternFilterRule
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
+import soot.jimple.GotoStmt
+
+/**
+ * Filters out patterns containing an empty loop.
+ */
+class EmptyLoopPatternFilterRule : PatternFilterRule<JimpleNode> {
+    private companion object : KLogging()
+
+    override fun retain(pattern: List<JimpleNode>) =
+        pattern.none { node ->
+            val statement = node.statement
+
+            if (statement is GotoStmt) {
+                val previousStatements = pattern.takeWhile { it.statement !== statement }
+
+                if (previousStatements.isNotEmpty() && statement.target === previousStatements.last().statement) {
+                    return@none true
+                        .also { if (!it) logger.debug { "Empty loop pattern was detected: $pattern" } }
+                }
+            }
+            false
+        }
+}

--- a/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRuleTest.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/EmptyLoopPatternFilterRuleTest.kt
@@ -1,0 +1,106 @@
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple
+
+import org.assertj.core.api.Assertions.assertThat
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import soot.BooleanType
+import soot.jimple.IntConstant
+import soot.jimple.Jimple
+
+internal object EmptyLoopPatternFilterRuleTest : Spek({
+    describe("filtering of patterns containing empty loops") {
+        it("rejects patterns containing an empty loop, starting with an if-statement") {
+            val ifStmt = Jimple.v().newIfStmt(
+                Jimple.v().newEqExpr(IntConstant.v(0), IntConstant.v(0)),
+                Jimple.v().newReturnVoidStmt()
+            )
+            val gotoStmt = Jimple.v().newGotoStmt(ifStmt)
+            val pattern = listOf(
+                ifStmt,
+                gotoStmt
+            ).map { JimpleNode(it) }
+
+            assertThat(EmptyLoopPatternFilterRule().retain(pattern)).isFalse()
+        }
+
+        it("rejects patterns containing an empty loop, starting with an if-statement, surrounded by other statements") {
+            val nopStmt = Jimple.v().newNopStmt()
+            val returnStmt = Jimple.v().newReturnVoidStmt()
+            val ifStmt = Jimple.v().newIfStmt(
+                Jimple.v().newEqExpr(IntConstant.v(0), IntConstant.v(0)),
+                Jimple.v().newReturnVoidStmt()
+            )
+            val gotoStmt = Jimple.v().newGotoStmt(ifStmt)
+            val pattern = listOf(
+                nopStmt,
+                ifStmt,
+                gotoStmt,
+                returnStmt
+            ).map { JimpleNode(it) }
+
+            assertThat(EmptyLoopPatternFilterRule().retain(pattern)).isFalse()
+        }
+
+        it("rejects patterns containing an empty loop, starting with an assignment") {
+            val assignmentStmt = Jimple.v().newAssignStmt(
+                Jimple.v().newLocal("test", BooleanType.v()),
+                Jimple.v().newEqExpr(IntConstant.v(0), IntConstant.v(0))
+            )
+            val gotoStmt = Jimple.v().newGotoStmt(assignmentStmt)
+            val pattern = listOf(
+                assignmentStmt,
+                gotoStmt
+            ).map { JimpleNode(it) }
+
+            assertThat(EmptyLoopPatternFilterRule().retain(pattern)).isFalse()
+        }
+
+        it("rejects patterns containing a nested loop") {
+            val ifStmt = Jimple.v().newIfStmt(
+                Jimple.v().newEqExpr(IntConstant.v(0), IntConstant.v(0)),
+                Jimple.v().newReturnVoidStmt()
+            )
+            val innerIfStmt = Jimple.v().newIfStmt(
+                Jimple.v().newEqExpr(IntConstant.v(0), IntConstant.v(0)),
+                Jimple.v().newReturnVoidStmt()
+            )
+            val innerGotoStmt = Jimple.v().newGotoStmt(innerIfStmt)
+            val gotoStmt = Jimple.v().newGotoStmt(ifStmt)
+            val pattern = listOf(
+                ifStmt,
+                innerIfStmt,
+                innerGotoStmt,
+                gotoStmt
+            ).map { JimpleNode(it) }
+
+            assertThat(EmptyLoopPatternFilterRule().retain(pattern)).isFalse()
+        }
+
+        it("retains patterns containing a loop with one statement") {
+            val ifStmt = Jimple.v().newIfStmt(
+                Jimple.v().newEqExpr(IntConstant.v(0), IntConstant.v(0)),
+                Jimple.v().newReturnVoidStmt()
+            )
+            val innerIfStmt = Jimple.v().newIfStmt(
+                Jimple.v().newEqExpr(IntConstant.v(0), IntConstant.v(0)),
+                Jimple.v().newReturnVoidStmt()
+            )
+            val gotoStmt = Jimple.v().newGotoStmt(ifStmt)
+            val pattern = listOf(
+                ifStmt,
+                innerIfStmt,
+                gotoStmt
+            ).map { JimpleNode(it) }
+
+            assertThat(EmptyLoopPatternFilterRule().retain(pattern)).isTrue()
+        }
+
+        it("retains empty patterns") {
+            val pattern = emptyList<JimpleNode>()
+
+            assertThat(EmptyLoopPatternFilterRule().retain(pattern)).isTrue()
+        }
+    }
+})


### PR DESCRIPTION
In the process of filtering out library usages, it is common to see a `goto` statement pointing backwards in a ⛓ of statements. Methods were this produces an empty (likely infinite) :repeat: should be filtered out, to avoid the 🔥 of infinite 🔁.