### PR TITLE
Fix equivalence of `Local`s

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ allprojects {
     repositories {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://jitpack.io" }
     }
 
     dependencies {

--- a/modules/application/build.gradle
+++ b/modules/application/build.gradle
@@ -5,6 +5,7 @@ mainClassName = "org.cafejojo.schaapi.CommandLineInterfaceKt"
 
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/build.gradle
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/build.gradle
@@ -1,5 +1,6 @@
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {
@@ -9,7 +10,7 @@ dependencies {
     compile project(":models:jimple-library-usage-graph")
 
     compile group: "org.evosuite", name: "evosuite-master", version: evosuiteMasterVersion
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+    compile group: "com.github.cafejojo", name: "soot", version: "7c97c52", {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
 }

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/build.gradle
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/build.gradle
@@ -1,5 +1,6 @@
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {
@@ -8,7 +9,7 @@ dependencies {
     compile project(":models:java-project")
     compile project(":models:jimple-library-usage-graph")
 
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+    compile group: "com.github.cafejojo", name: "soot", version: "7c97c52", {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
 

--- a/modules/mining-pipeline/jimple-pattern-filter/build.gradle
+++ b/modules/mining-pipeline/jimple-pattern-filter/build.gradle
@@ -1,5 +1,6 @@
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {
@@ -7,7 +8,7 @@ dependencies {
 
     compile project(":models:jimple-library-usage-graph")
 
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+    compile group: "com.github.cafejojo", name: "soot", version: "7c97c52", {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
 

--- a/modules/mining-pipeline/prefix-span-pattern-detector/build.gradle
+++ b/modules/mining-pipeline/prefix-span-pattern-detector/build.gradle
@@ -2,6 +2,7 @@ apply from: "$rootDir/gradle/tests/module-integration.gradle"
 
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {
@@ -10,7 +11,7 @@ dependencies {
     testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
 
     moduleIntegrationTestCompile project(":models:jimple-library-usage-graph")
-    moduleIntegrationTestCompile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+    compile group: "com.github.cafejojo", name: "soot", version: "7c97c52", {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
 }

--- a/modules/models/jimple-library-usage-graph/build.gradle
+++ b/modules/models/jimple-library-usage-graph/build.gradle
@@ -1,11 +1,12 @@
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {
     compile project(":models")
 
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+    compile group: "com.github.cafejojo", name: "soot", version: "7c97c52", {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
 

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNode.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNode.kt
@@ -1,7 +1,6 @@
 package org.cafejojo.schaapi.models.libraryusagegraph.jimple
 
 import org.cafejojo.schaapi.models.Node
-import soot.Local
 import soot.jimple.DefinitionStmt
 import soot.jimple.GotoStmt
 import soot.jimple.IfStmt
@@ -53,13 +52,7 @@ class JimpleNode(val statement: Stmt, override val successors: MutableList<Node>
      */
     override fun equivTo(other: Node?) =
         if (other !is JimpleNode || this.statement::class != other.statement::class) false
-        else this.getTopLevelValues().zip(other.getTopLevelValues()).all {
-            if (it.first is Local && it.second is Local) {
-                it.first.type == it.second.type
-            } else {
-                it.first.equivTo(it.second)
-            }
-        }
+        else this.getTopLevelValues().zip(other.getTopLevelValues()).all { it.first.equivTo(it.second) }
 
     /**
      * Generates a hash code based on the values of the contained [Stmt] and their order.
@@ -68,9 +61,7 @@ class JimpleNode(val statement: Stmt, override val successors: MutableList<Node>
      */
     override fun equivHashCode(): Int {
         var hash = 0
-        getTopLevelValues().forEachIndexed { index, value ->
-            hash += (index + 1) * ((value as? Local)?.type?.hashCode() ?: value.equivHashCode())
-        }
+        getTopLevelValues().forEachIndexed { index, value -> hash += (index + 1) * value.equivHashCode() }
         return hash
     }
 


### PR DESCRIPTION
PR #226 tried to fix the `equivTo` and `equivHashCode` of Soot's `Local`s by changing the behaviour when `equivTo` was called on a `JimpleNode` that contained a `Local`, but this fix did not prevent the incorrect implementation from being called when a `Local` was inside another `Value`. Therefore, PR #226 did not fix the issue of duplicate patterns because Soot thinks two `Local` are not equivalent (even though they are).  Since the changes from #226 are not longer necessary, they have been removed in this PR. The regression tests added by that PR are still in place, of course.

This issue has been reported to Soot (see Sable/soot#953) and a PR has been opened by @gandreadis to fix this issue (Sable/soot#954), but it has not been merged yet. Because the issue has to be solved quickly in order to refine the patterns that we output, I've decided to use [Jitpack](https://jitpack.io) to create an artificial dependency on our own fix. That is, I've added a dependency on a commit on GitHub that contains the necessary fixes. Once the above-mentioned PR has been merged and released, this artificial dependency can be changed into a real dependency.

I tried to implement my own visitor that imitates Soot's `equivTo` but changes the behaviour where necessary. Sadly, Soot's own visitor is not recursive (i.e. it does not visit the elements it contains, i.e. it's not much of a visitor) and it contains a bunch of weird typecasts, so I had to write my own visitor from scratch. To facilitate the equivalence, I either had to compare classes (because comparing at the level of `BinopExpr` would mean that an `AddExpr` and a `SubExpr` could be equivalent) or I would have to implement a method for each "leaf" class (i.e. one for `AddExpr` and one for `SubExpr`). The former solution (class comparisons) had the problem of potentially being very slow (#premature-optimisation) and, more importantly, not working for mocks (because one mock will have class `AddExpr$1238182` and another will have `AddExpr$57171731`), which would mean that I'd have to rewrite hundreds if not thousands of lines of tests to make it work again (I tried that, and I failed). The latter solution (methods for each leaf class) would require me to write a class with 66 methods (and I wasn't even done yet), lots of code duplication, and then I would still have to test all the mehods.

The drawbacks of the Jitpack approach are as follows:
* The resolution dependency takes much longer. Clicking the "Refresh all Gradle projects" button in IntelliJ takes one or two minutes instead of just half a minute. I don't know what the impact on Travis and AppVeyor will be; I just hope that the caches do their work.
* It replaces the behaviour of the `equivTo` method _everywhere_, and I don't know what the consequences will be _exactly_. For example, this change might impact the `ClassWriter` and `JLUG` implementations indirectly. Even if our PR at the Soot repo is merged, their small amount of tests (they have a total of 200-something tests, which is one test class per five production classes on average, iirc) does not guarantee that their own code keeps working. I don't see why it wouldn't, but after this endeavour I can't say I have a lot of confidence in Soot anymore.

**Edit:** There is an ongoing discussion on the Soot PR about whether the behaviour suggested by us is even correct, and we're looking for alternatives.
