### PR TITLE
Jimple value visitor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ allprojects {
     repositories {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://jitpack.io" }
     }
 
     dependencies {

--- a/modules/application/build.gradle
+++ b/modules/application/build.gradle
@@ -5,6 +5,7 @@ mainClassName = "org.cafejojo.schaapi.CommandLineInterfaceKt"
 
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/build.gradle
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/build.gradle
@@ -1,5 +1,6 @@
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {
@@ -9,7 +10,7 @@ dependencies {
     compile project(":models:jimple-library-usage-graph")
 
     compile group: "org.evosuite", name: "evosuite-master", version: evosuiteMasterVersion
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+    compile group: "com.github.cafejojo", name: "soot", version: "7c97c52", {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
 }

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/build.gradle
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/build.gradle
@@ -1,5 +1,6 @@
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {
@@ -8,7 +9,7 @@ dependencies {
     compile project(":models:java-project")
     compile project(":models:jimple-library-usage-graph")
 
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+    compile group: "com.github.cafejojo", name: "soot", version: "7c97c52", {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
 

--- a/modules/mining-pipeline/jimple-pattern-filter/build.gradle
+++ b/modules/mining-pipeline/jimple-pattern-filter/build.gradle
@@ -1,5 +1,6 @@
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {
@@ -7,7 +8,7 @@ dependencies {
 
     compile project(":models:jimple-library-usage-graph")
 
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+    compile group: "com.github.cafejojo", name: "soot", version: "7c97c52", {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
 

--- a/modules/mining-pipeline/prefix-span-pattern-detector/build.gradle
+++ b/modules/mining-pipeline/prefix-span-pattern-detector/build.gradle
@@ -2,6 +2,7 @@ apply from: "$rootDir/gradle/tests/module-integration.gradle"
 
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {
@@ -10,7 +11,7 @@ dependencies {
     testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
 
     moduleIntegrationTestCompile project(":models:jimple-library-usage-graph")
-    moduleIntegrationTestCompile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+    compile group: "com.github.cafejojo", name: "soot", version: "7c97c52", {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
 }

--- a/modules/models/jimple-library-usage-graph/build.gradle
+++ b/modules/models/jimple-library-usage-graph/build.gradle
@@ -1,11 +1,12 @@
 repositories {
     maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/" }
 }
 
 dependencies {
     compile project(":models")
 
-    compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
+    compile group: "com.github.cafejojo", name: "soot", version: "7c97c52", {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
 

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNode.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNode.kt
@@ -1,7 +1,6 @@
 package org.cafejojo.schaapi.models.libraryusagegraph.jimple
 
 import org.cafejojo.schaapi.models.Node
-import soot.Local
 import soot.jimple.DefinitionStmt
 import soot.jimple.GotoStmt
 import soot.jimple.IfStmt
@@ -53,13 +52,7 @@ class JimpleNode(val statement: Stmt, override val successors: MutableList<Node>
      */
     override fun equivTo(other: Node?) =
         if (other !is JimpleNode || this.statement::class != other.statement::class) false
-        else this.getTopLevelValues().zip(other.getTopLevelValues()).all {
-            if (it.first is Local && it.second is Local) {
-                it.first.type == it.second.type
-            } else {
-                it.first.equivTo(it.second)
-            }
-        }
+        else this.getTopLevelValues().zip(other.getTopLevelValues()).all { it.first.equivTo(it.second) }
 
     /**
      * Generates a hash code based on the values of the contained [Stmt] and their order.
@@ -68,9 +61,7 @@ class JimpleNode(val statement: Stmt, override val successors: MutableList<Node>
      */
     override fun equivHashCode(): Int {
         var hash = 0
-        getTopLevelValues().forEachIndexed { index, value ->
-            hash += (index + 1) * ((value as? Local)?.type?.hashCode() ?: value.equivHashCode())
-        }
+        getTopLevelValues().forEachIndexed { index, value -> hash += (index + 1) * value.equivHashCode() }
         return hash
     }
 

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitor.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitor.kt
@@ -1,0 +1,191 @@
+package org.cafejojo.schaapi.models.libraryusagegraph.jimple
+
+import soot.Immediate
+import soot.Value
+import soot.jimple.AnyNewExpr
+import soot.jimple.BinopExpr
+import soot.jimple.CastExpr
+import soot.jimple.DynamicInvokeExpr
+import soot.jimple.InstanceInvokeExpr
+import soot.jimple.InstanceOfExpr
+import soot.jimple.Ref
+import soot.jimple.StaticInvokeExpr
+import soot.jimple.UnopExpr
+
+/**
+ * Recursively visits the [Value]s contained within a [Value] and accumulates a result based on the implemented methods.
+ */
+@SuppressWarnings("MethodOverloading", "TooManyFunctions") // Result of the inverted implementation of Visitor
+abstract class JimpleValueVisitor<R> {
+    /**
+     * This method is called at the start of [visit].
+     *
+     * @param value the [Value] that [visit] is called with
+     */
+    internal open fun beforeVisit(value: Value) {}
+
+    /**
+     * This method is called at the end of [visit].
+     *
+     * @param value the [Value] that [visit] is called with
+     */
+    internal open fun afterVisit(value: Value) {}
+
+    /**
+     * Recursively visits the [Value]s contained within [value], and applies the appropriate [apply] implementation to
+     * the visited [Value]s. The results of multiple [apply] calls are combined using the [accumulate] method.
+     *
+     * @param value the [value] to recursively visit
+     * @return the accumulated result of calling [apply] on all [Value]s recursively contained in [value]
+     */
+    fun visit(value: Value): R {
+        beforeVisit(value)
+
+        val result = when (value) {
+            is UnopExpr -> accumulate(apply(value), visit(value.op))
+            is BinopExpr -> accumulate(apply(value), visit(value.op1), visit(value.op2))
+            is AnyNewExpr -> apply(value)
+            is InstanceInvokeExpr ->
+                accumulate(
+                    accumulate(apply(value), visit(value.base)),
+                    value.args.map { visit(it) }
+                )
+            is StaticInvokeExpr -> accumulate(apply(value), value.args.map { visit(it) })
+            is DynamicInvokeExpr ->
+                accumulate(
+                    accumulate(
+                        apply(value),
+                        value.bootstrapArgs.map { visit(it) }
+                    ),
+                    value.args.map { visit(it) }
+                )
+            is Ref -> apply(value)
+            is Immediate -> apply(value)
+            is InstanceOfExpr -> accumulate(apply(value), visit(value.op))
+            is CastExpr -> accumulate(apply(value), visit(value.op))
+            else -> applyOther(value)
+        }
+
+        afterVisit(value)
+        return result
+    }
+
+    /**
+     * This method is called when a [UnopExpr] is visited by [visit].
+     *
+     * @param value a [UnopExpr]
+     */
+    open fun apply(value: UnopExpr) = defaultApply(value)
+
+    /**
+     * This method is called when a [BinopExpr] is visited by [visit].
+     *
+     * @param value a [BinopExpr]
+     */
+    open fun apply(value: BinopExpr) = defaultApply(value)
+
+    /**
+     * This method is called when an [AnyNewExpr] is visited by [visit].
+     *
+     * @param value an [AnyNewExpr]
+     */
+    open fun apply(value: AnyNewExpr) = defaultApply(value)
+
+    /**
+     * This method is called when a [StaticInvokeExpr] is visited by [visit].
+     *
+     * @param value a [StaticInvokeExpr]
+     */
+    open fun apply(value: StaticInvokeExpr) = defaultApply(value)
+
+    /**
+     * This method is called when an [InstanceInvokeExpr] is visited by [visit].
+     *
+     * @param value an [InstanceInvokeExpr]
+     */
+    open fun apply(value: InstanceInvokeExpr) = defaultApply(value)
+
+    /**
+     * This method is called when a [DynamicInvokeExpr] is visited by [visit].
+     *
+     * @param value a [DynamicInvokeExpr]
+     */
+    open fun apply(value: DynamicInvokeExpr) = defaultApply(value)
+
+    /**
+     * This method is called when a [Ref] is visited by [visit].
+     *
+     * @param value a [Ref]
+     */
+    open fun apply(value: Ref) = defaultApply(value)
+
+    /**
+     * This method is called when an [Immediate] is visited by [visit].
+     *
+     * @param value an [Immediate]
+     */
+    open fun apply(value: Immediate) = defaultApply(value)
+
+    /**
+     * This method is called when an [InstanceOfExpr] is visited by [visit].
+     *
+     * @param value an [InstanceOfExpr]
+     */
+    open fun apply(value: InstanceOfExpr) = defaultApply(value)
+
+    /**
+     * This method is called when a [CastExpr] is visited by [visit].
+     *
+     * @param value a [CastExpr]
+     */
+    open fun apply(value: CastExpr) = defaultApply(value)
+
+    /**
+     * This method is called when a [Value] is visited by [visit] and the other [apply] methods are not applicable.
+     *
+     * @param value a [Value]
+     */
+    open fun applyOther(value: Value) = defaultApply(value)
+
+    /**
+     * This method is called by default is an [apply] method is not implemented.
+     *
+     * @param value a [Value]
+     */
+    abstract fun defaultApply(value: Value): R
+
+    /**
+     * Combines two values of type [R].
+     *
+     * @param result1 a value
+     * @param result2 a value
+     * @return the combination of [result1] and [result2]
+     */
+    abstract fun accumulate(result1: R, result2: R): R
+
+    private fun accumulate(result1: R, results: List<R>) = results.fold(result1, { acc, cur -> accumulate(acc, cur) })
+
+    private fun accumulate(result1: R, vararg results: R) = accumulate(result1, results.toList())
+}
+
+/**
+ * Lists all [Value]s that are recursively contained in a given value.
+ */
+class JimpleValueAccumulator : JimpleValueVisitor<List<Value>>() {
+    /**
+     * Returns a singleton list containing [value].
+     *
+     * @param value the [Value] to return in a singleton list
+     * @return a singleton list containing [value]
+     */
+    override fun defaultApply(value: Value) = listOf(value)
+
+    /**
+     * Returns the union of the given lists.
+     *
+     * @param result1 a list
+     * @param result2 a list
+     * @return the union of the given lists
+     */
+    override fun accumulate(result1: List<Value>, result2: List<Value>) = result1.union(result2).toList()
+}

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitorTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitorTest.kt
@@ -1,0 +1,121 @@
+package org.cafejojo.schaapi.models.libraryusagegraph.jimple
+
+import com.nhaarman.mockito_kotlin.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import soot.IntType
+import soot.Modifier
+import soot.RefType
+import soot.SootClass
+import soot.SootMethod
+import soot.Value
+import soot.jimple.IntConstant
+import soot.jimple.Jimple
+
+/**
+ * Unit tests for [JimpleValueVisitor].
+ */
+internal object JimpleValueVisitorTest : Spek({
+    describe("Jimple value visitor") {
+        lateinit var visitor: JimpleValueAccumulator
+
+        beforeEachTest {
+            visitor = JimpleValueAccumulator()
+        }
+
+        it("returns the given element itself") {
+            val value = mock<Value> {}
+
+            assertThat(visitor.visit(value)).containsExactly(value)
+        }
+
+        it("returns the only value in an UnopExpr") {
+            val const = IntConstant.v(1)
+            val value = Jimple.v().newNegExpr(const)
+
+            assertThat(visitor.visit(value)).containsExactly(value, const)
+        }
+
+        it("returns both values in a BinopExpr") {
+            val constA = IntConstant.v(49)
+            val constB = IntConstant.v(53)
+            val value = Jimple.v().newSubExpr(constA, constB)
+
+            assertThat(visitor.visit(value)).containsExactly(value, constA, constB)
+        }
+
+        it("returns the value of an AnyNewExpr") {
+            val value = Jimple.v().newNewExpr(RefType.v("SomeClass"))
+
+            assertThat(visitor.visit(value)).containsExactly(value)
+        }
+
+        it("returns the base and arguments of an InstanceInvokeExpr") {
+            val base = Jimple.v().newLocal("base", RefType.v("BaseClass"))
+            val method = SootMethod("method", listOf(RefType.v("ArgTypeA"), RefType.v("ArgTypeB")), IntType.v())
+                .also { SootClass("SomeClass").addMethod(it) }
+            val argA = Jimple.v().newLocal("argA", RefType.v("ArgTypeA"))
+            val argB = Jimple.v().newLocal("argB", RefType.v("ArgTypeB"))
+            val value = Jimple.v().newSpecialInvokeExpr(base, method.makeRef(), listOf(argA, argB))
+
+            assertThat(visitor.visit(value)).containsExactly(value, base, argA, argB)
+        }
+
+        it("returns the arguments of a StaticInvokeExpr") {
+            val method = SootMethod(
+                "method",
+                listOf(RefType.v("ArgTypeA"), RefType.v("ArgTypeB")),
+                IntType.v(),
+                Modifier.STATIC
+            ).also { SootClass("SomeClass").addMethod(it) }
+            val argA = Jimple.v().newLocal("argA", RefType.v("ArgTypeA"))
+            val argB = Jimple.v().newLocal("argB", RefType.v("ArgTypeB"))
+            val value = Jimple.v().newStaticInvokeExpr(method.makeRef(), listOf(argA, argB))
+
+            assertThat(visitor.visit(value)).containsExactly(value, argA, argB)
+        }
+
+        it("returns the arguments of a DynamicInvokeExpr") {
+            val method = SootMethod("method", listOf(RefType.v("ArgTypeA"), RefType.v("ArgTypeB")), IntType.v())
+                .also { SootClass(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME).addMethod(it) }
+            val bsArgA = Jimple.v().newLocal("bsArgA", RefType.v("ArgTypeA"))
+            val bsArgB = Jimple.v().newLocal("bsArgB", RefType.v("ArgTypeB"))
+            val argA = Jimple.v().newLocal("argA", RefType.v("ArgTypeA"))
+            val argB = Jimple.v().newLocal("argB", RefType.v("ArgTypeB"))
+            val value = Jimple.v().newDynamicInvokeExpr(
+                method.makeRef(), listOf(bsArgA, bsArgB),
+                method.makeRef(), listOf(argA, argB)
+            )
+
+            assertThat(visitor.visit(value)).containsExactly(value, bsArgA, bsArgB, argA, argB)
+        }
+
+        it("returns the value of a Ref") {
+            val value = Jimple.v().newThisRef(RefType.v("SomeClass"))
+
+            assertThat(visitor.visit(value)).containsExactly(value)
+        }
+
+        it("returns the value of an Immediate") {
+            val value = Jimple.v().newLocal("local", RefType.v("SomeClass"))
+
+            assertThat(visitor.visit(value)).containsExactly(value)
+        }
+
+        it("returns the value of an InstanceOf") {
+            val local = Jimple.v().newLocal("local", RefType.v("SomeClass"))
+            val value = Jimple.v().newInstanceOfExpr(local, RefType.v("SomeOtherClass"))
+
+            assertThat(visitor.visit(value)).containsExactly(value, local)
+        }
+
+        it("returns the value of a CastExpr") {
+            val local = Jimple.v().newLocal("local", RefType.v("SomeClass"))
+            val value = Jimple.v().newCastExpr(local, RefType.v("SomeOtherClass"))
+
+            assertThat(visitor.visit(value)).containsExactly(value, local)
+        }
+    }
+})


### PR DESCRIPTION
Adds a custom visitor that recursively visits the expressions contained within a `Value`. I originally wrote this class in one of my attempts described in #233, but I found that I could also use it when writing a filter to remove patterns that did not have enough library usages (which ~~will be featured in an upcoming PR~~ is used in #235).

Reviewer's note: Only review 11fb9ac.
