### PR TITLE
Recursive definition fix

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -125,16 +125,19 @@ internal class ClassGenerator(className: String) {
         val definitions = mutableSetOf<String>()
 
         statements.forEach { statement ->
-            statement.useAndDefBoxes
-                .filter { it.value is Local }
-                .forEach { box ->
-                    val identifier =
-                        (box.value as? Local)?.name ?: throw IllegalStateException("Value is no longer a local.")
-                    when {
-                        statement.defBoxes.contains(box) -> definitions.add(identifier)
-                        !definitions.contains(identifier) -> methodParams.add(box.value)
-                    }
+            statement.useBoxes
+                .map { it.value }
+                .filterIsInstance(Local::class.java)
+                .filter { !definitions.contains(it.name) }
+                .forEach {
+                    methodParams.add(it)
+                    definitions.add(it.name)
                 }
+
+            statement.defBoxes
+                .map { it.value }
+                .filterIsInstance(Local::class.java)
+                .forEach { definitions.add(it.name) }
         }
 
         return methodParams

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -168,6 +168,29 @@ internal object ClassGeneratorTest : Spek({
             assertThat(method2.parameterCount).isZero()
             assertThat(generator.sootClass.methodCount).isEqualTo(2)
         }
+
+        it("adds a parameter for a value that is initialised recursively") {
+            val local = Jimple.v().newLocal("a", IntType.v())
+            val assign = Jimple.v().newAssignStmt(local, local)
+
+            val method = ClassGenerator("Test").also {
+                it.generateMethod("method", listOf(assign).map { JimpleNode(it) })
+            }.sootClass.methods.last()
+
+            assertThat(method.parameterCount).isEqualTo(1)
+        }
+
+        it("does not add a parameter for a value that is assigned recursively after initialization") {
+            val local = Jimple.v().newLocal("a", IntType.v())
+            val assignA = Jimple.v().newAssignStmt(local, IntConstant.v(58))
+            val assignB = Jimple.v().newAssignStmt(local, local)
+
+            val method = ClassGenerator("Test").also {
+                it.generateMethod("method", listOf(assignA, assignB).map { JimpleNode(it) })
+            }.sootClass.methods.last()
+
+            assertThat(method.parameterCount).isEqualTo(0)
+        }
     }
 
     it("should generate a valid body") {


### PR DESCRIPTION
Currently, the `ClassGenerator` wrongly thinks that a variable is initialised if it is set to itself in the first assignment where it appears. For example, it will think that the variable `r9` is correctly initialised in the following two snippets and will conclude that it does not need a method parameter:

* ```r9 = r9```
* ```r9 = r9.doSomething()```

The issue is that the `ClassGenerator` looks at the use and def boxes of a `Statement` in no particular order, which means that it may look at the definition before looking at the usage. When this happens, it will gladly add the variable to the list of defined variables before moving on to the usage.

This PR fixes the issue by making the `ClassGenerator` look at the usages before looking at the definitions. As an extra, the `findUnboundVariables` method now looks a bit nicer and has no unsafe casts anymore.
