### PR TITLE
Use default default default

### DIFF
--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -36,7 +36,7 @@ fun main(args: Array<String>) {
         MavenInstaller().installMaven(mavenDir)
     }
 
-    val flavor = cmd.getOptionOrDefault("flavor", DEFAULT_PIPELINE_TYPE)
+    val flavor = cmd.getOptionValue("flavor", DEFAULT_PIPELINE_TYPE)
     try {
         when (flavor) {
             "directory" -> DirectoryMiningCommandLineInterface().run(cmd, mavenDir, library, output)
@@ -126,15 +126,6 @@ private fun printHelpMessage(options: Options) {
     helpFormatter.optionComparator = null
     helpFormatter.printHelp("schaapi", options, true)
 }
-
-/**
- * Returns [CommandLine.getOptionValue], unless this is null, in which case [default] is returned.
- *
- * @param option the name of the option
- * @param default the value to return if the option's value is null
- * @return [CommandLine.getOptionValue], unless this is null, in which case [default] is returned
- */
-internal fun CommandLine.getOptionOrDefault(option: String, default: String) = getOptionValue(option) ?: default
 
 /**
  * Returns [CommandLine.getOptionValue], unless this is null, in which case a [MissingArgumentException] is thrown.

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -10,6 +10,7 @@ import org.apache.commons.cli.ParseException
 import org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.MavenInstaller
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import java.io.File
+import kotlin.system.exitProcess
 
 internal const val DEFAULT_PIPELINE_TYPE = "directory"
 internal const val DEFAULT_TEST_GENERATOR_TIMEOUT = "60"
@@ -26,7 +27,7 @@ fun main(args: Array<String>) {
         .apply { DirectoryMiningCommandLineInterface.addOptionsTo(this) }
         .apply { GitHubMiningCommandLineInterface.addOptionsTo(this) }
 
-    val cmd = parseArgs(options, args) ?: return
+    val cmd = parseArgs(options, args) ?: exitProcess(-1)
 
     val mavenDir = File(cmd.getOptionValue("maven_dir") ?: JavaMavenProject.DEFAULT_MAVEN_HOME.absolutePath)
     val output = File(cmd.getOptionValue('o')).apply { mkdirs() }
@@ -41,10 +42,14 @@ fun main(args: Array<String>) {
         when (flavor) {
             "directory" -> DirectoryMiningCommandLineInterface().run(cmd, mavenDir, library, output)
             "github" -> GitHubMiningCommandLineInterface().run(cmd, mavenDir, library, output)
-            else -> KLogging().logger.error { "Given pipeline flavor was not recognized." }
+            else -> {
+                KLogging().logger.error { "Given pipeline flavor was not recognized." }
+                exitProcess(-1)
+            }
         }
     } catch (e: MissingArgumentException) {
         KLogging().logger.error { e.messageForFlavor(flavor) }
+        exitProcess(-1)
     }
 }
 

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -41,14 +41,13 @@ internal class DirectoryMiningCommandLineInterface {
     fun run(cmd: CommandLine, mavenDir: File, library: File, output: File) {
         val userDirDirs = cmd.getOptionOrThrowException("u")
 
-        val testGeneratorTimeout = cmd
-            .getOptionOrDefault("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
+        val testGeneratorTimeout = cmd.getOptionValue("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
         val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")
 
         val patternDetectorMinCount = cmd
-            .getOptionOrDefault("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
+            .getOptionValue("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
         val maxSequenceLength = cmd
-            .getOptionOrDefault("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
+            .getOptionValue("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
 
         val libraryMaven = JavaMavenProject(library, mavenDir)
 

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -34,7 +34,7 @@ internal class DirectoryMiningCommandLineInterface {
     }
 
     /**
-     * Mines a Directory.
+     * Mines a directory.
      *
      * @throws [MissingArgumentException] if required arguments not set in [CommandLine].
      */
@@ -44,12 +44,12 @@ internal class DirectoryMiningCommandLineInterface {
         val testGeneratorTimeout = cmd.getOptionValue("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
         val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")
 
-        val patternDetectorMinCount = cmd
-            .getOptionValue("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
-        val maxSequenceLength = cmd
-            .getOptionValue("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
+        val patternDetectorMinCount =
+            cmd.getOptionValue("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
+        val maxSequenceLength =
+            cmd.getOptionValue("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
 
-        val libraryMaven = JavaMavenProject(library, mavenDir)
+        val libraryProject = JavaMavenProject(library, mavenDir)
 
         MiningPipeline(
             outputDirectory = output,
@@ -61,12 +61,12 @@ internal class DirectoryMiningCommandLineInterface {
             patternDetector = PatternDetector(patternDetectorMinCount, maxSequenceLength, GeneralizedNodeComparator()),
             patternFilter = PatternFilter(IncompleteInitPatternFilterRule(), LengthPatternFilterRule()),
             testGenerator = TestGenerator(
-                library = libraryMaven,
+                library = libraryProject,
                 outputDirectory = output,
                 timeout = testGeneratorTimeout,
                 processStandardStream = if (testGeneratorEnableOutput) System.out else null,
                 processErrorStream = if (testGeneratorEnableOutput) System.out else null
             )
-        ).run(libraryMaven)
+        ).run(libraryProject)
     }
 }

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -27,9 +27,7 @@ internal const val DEFAULT_MAX_PROJECTS = "20"
  * Assumes that the passed library is a Java JAR project.
  */
 internal class GitHubMiningCommandLineInterface {
-    internal companion object {
-        val logger = KLogging().logger
-
+    internal companion object : KLogging() {
         fun addOptionsTo(options: Options): Options =
             options
                 .addOption(Option

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -83,18 +83,18 @@ internal class GitHubMiningCommandLineInterface {
      */
     fun run(cmd: CommandLine, mavenDir: File, library: File, output: File) {
         val token = cmd.getOptionOrThrowException("github_oauth_token")
-        val maxProjects = cmd.getOptionOrDefault("max_projects", DEFAULT_MAX_PROJECTS).toInt()
+        val maxProjects = cmd.getOptionValue("max_projects", DEFAULT_MAX_PROJECTS).toInt()
         val groupId = cmd.getOptionOrThrowException("library_group_id")
         val artifactId = cmd.getOptionOrThrowException("library_artifact_id")
         val version = cmd.getOptionOrThrowException("library_version")
 
         val patternDetectorMinCount = cmd
-            .getOptionOrDefault("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
+            .getOptionValue("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
         val maxSequenceLength = cmd
-            .getOptionOrDefault("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
+            .getOptionValue("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
 
         val testGeneratorTimeout = cmd
-            .getOptionOrDefault("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
+            .getOptionValue("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
         val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")
 
         if (cmd.hasOption("sort_by_stargazers") && cmd.hasOption("sort_by_watchers")) {

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -86,20 +86,19 @@ internal class GitHubMiningCommandLineInterface {
         val artifactId = cmd.getOptionOrThrowException("library_artifact_id")
         val version = cmd.getOptionOrThrowException("library_version")
 
-        val patternDetectorMinCount = cmd
-            .getOptionValue("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
-        val maxSequenceLength = cmd
-            .getOptionValue("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
-
-        val testGeneratorTimeout = cmd
-            .getOptionValue("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
+        val testGeneratorTimeout = cmd.getOptionValue("test_generator_timeout", DEFAULT_TEST_GENERATOR_TIMEOUT).toInt()
         val testGeneratorEnableOutput = cmd.hasOption("test_generator_enable_output")
+
+        val patternDetectorMinCount =
+            cmd.getOptionValue("pattern_detector_minimum_count", DEFAULT_PATTERN_DETECTOR_MINIMUM_COUNT).toInt()
+        val maxSequenceLength =
+            cmd.getOptionValue("pattern_detector_maximum_sequence_length", DEFAULT_MAX_SEQUENCE_LENGTH).toInt()
 
         if (cmd.hasOption("sort_by_stargazers") && cmd.hasOption("sort_by_watchers")) {
             logger.error { "Cannot sort repositories on both stargazers and watchers." }
         }
 
-        val libraryJar = JavaJarProject(library)
+        val libraryProject = JavaJarProject(library)
 
         MiningPipeline(
             outputDirectory = output,
@@ -114,12 +113,12 @@ internal class GitHubMiningCommandLineInterface {
             patternDetector = PatternDetector(patternDetectorMinCount, maxSequenceLength, GeneralizedNodeComparator()),
             patternFilter = PatternFilter(IncompleteInitPatternFilterRule(), LengthPatternFilterRule()),
             testGenerator = TestGenerator(
-                library = libraryJar,
+                library = libraryProject,
                 outputDirectory = output,
                 timeout = testGeneratorTimeout,
                 processStandardStream = if (testGeneratorEnableOutput) System.out else null,
                 processErrorStream = if (testGeneratorEnableOutput) System.out else null
             )
-        ).run(libraryJar)
+        ).run(libraryProject)
     }
 }


### PR DESCRIPTION
Fixes a few things:

* Uses Apache-CLI's own method for getting the default values of options rather than a custom-built one. (My mistake, oops.)
* Renames `libraryMaven` and `libraryJar` to `libraryProject` because there is no such thing as "a Maven".
* Sorts variables in both CLI implementations to make them more consistent.
* Makes the program return a non-zero exit code if the program did not execute successfully.