### PR TITLE
Speed up class name containment checks in Projects

### DIFF
--- a/modules/mining-pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javajar/ProjectCompiler.kt
+++ b/modules/mining-pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javajar/ProjectCompiler.kt
@@ -13,7 +13,7 @@ class ProjectCompiler : ProjectCompiler<JavaJarProject> {
     private companion object : KLogging()
 
     override fun compile(project: JavaJarProject): JavaJarProject {
-        val classNames = mutableListOf<String>()
+        val classNames = mutableSetOf<String>()
         val jarInputStream = JarInputStream(FileInputStream(project.classDir))
         var jarEntry = jarInputStream.nextJarEntry
 

--- a/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/ProjectCompiler.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/ProjectCompiler.kt
@@ -17,11 +17,11 @@ class ProjectCompiler : ProjectCompiler<JavaMavenProject> {
     override fun compile(project: JavaMavenProject): JavaMavenProject {
         runMaven(project)
 
-        project.classes = project.classDir.walk().filter { it.isFile && it.extension == "class" }.toList()
+        project.classes = project.classDir.walk().filter { it.isFile && it.extension == "class" }.toSet()
         project.classNames = project.classes.map {
             it.relativeTo(project.classDir).toString().dropLast(".class".length).replace(File.separatorChar, '.')
-        }
-        project.dependencies = project.dependencyDir.listFiles().orEmpty().toList()
+        }.toSet()
+        project.dependencies = project.dependencyDir.listFiles().orEmpty().toSet()
         project.classpath =
             if (project.dependencies.isEmpty()) {
                 project.classDir.absolutePath

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/Helpers.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/Helpers.kt
@@ -5,16 +5,16 @@ import java.io.File
 
 internal data class TestProject(
     override var classpath: String = "",
-    override var classNames: List<String> = emptyList()
+    override var classNames: Set<String> = emptySet()
 ) : JavaProject {
     override val classDir: File = File(".")
     override val dependencyDir: File = File(".")
-    override var dependencies: List<File> = emptyList()
+    override var dependencies: Set<File> = emptySet()
     override val projectDir: File = File(".")
-    override var classes: List<File> = emptyList()
+    override var classes: Set<File> = emptySet()
 }
 
-internal val libraryClasses = listOf(
+internal val libraryClasses = setOf(
     "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.Object1"
 )
 internal val libraryProject = TestProject(classNames = libraryClasses)

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -26,7 +26,7 @@ internal object IntegrationTest : Spek({
         it("converts a simple class to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.SimpleTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.SimpleTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -48,7 +48,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing an if with a library usage in the false-branch to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfFalseUseTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfFalseUseTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -73,7 +73,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing an if with a library usage in the true-branch to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfTrueUseTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfTrueUseTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -98,7 +98,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing an if with a library usage in both branches to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfBothUseTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfBothUseTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -125,7 +125,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing an if with a library usage in both branches to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfNoUseTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfNoUseTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -143,7 +143,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing an if with no successors of the true/false branch") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfNoEndTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfNoEndTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -159,7 +159,7 @@ internal object IntegrationTest : Spek({
         it("filters out a class containing an if with method exitting return statements") {
             val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfReturnsTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.ifconditional.IfReturnsTest"))
             )
 
             assertThat(libraryUsageGraphs).isEmpty()
@@ -170,7 +170,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing a switch with a library usage in a branch to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf(
+                TestProject(testClassesClassPath, setOf(
                     "$TEST_CLASSES_PACKAGE.users.switchconditional.SwitchOneUseTest"
                 ))
             )[0]
@@ -200,7 +200,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing a switch with a library usage in the default branch to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf(
+                TestProject(testClassesClassPath, setOf(
                     "$TEST_CLASSES_PACKAGE.users.switchconditional.SwitchDefaultUseTest"
                 ))
             )[0]
@@ -230,7 +230,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing a switch with no library usage in its branches to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf(
+                TestProject(testClassesClassPath, setOf(
                     "$TEST_CLASSES_PACKAGE.users.switchconditional.SwitchNoUseTest"
                 ))
             )[0]
@@ -252,7 +252,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing an arraylist and a lambda") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ArrayListAndLambdaTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.ArrayListAndLambdaTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -268,7 +268,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing annotations") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.AnnotationTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.AnnotationTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -286,7 +286,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing a throw statement with library usage to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ThrowTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.ThrowTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -303,7 +303,7 @@ internal object IntegrationTest : Spek({
             val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
                 TestProject(testClassesClassPath,
-                    listOf("$TEST_CLASSES_PACKAGE.users.ThrowOtherUncheckedExceptionTest"))
+                    setOf("$TEST_CLASSES_PACKAGE.users.ThrowOtherUncheckedExceptionTest"))
             )
 
             assertThat(libraryUsageGraphs).isEmpty()
@@ -312,7 +312,7 @@ internal object IntegrationTest : Spek({
         it("does not convert a class containing an unchecked throw statement without library usage") {
             val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.ThrowOtherCheckedExceptionTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.ThrowOtherCheckedExceptionTest"))
             )
 
             assertThat(libraryUsageGraphs).isEmpty()
@@ -321,7 +321,7 @@ internal object IntegrationTest : Spek({
         it("converts a class with a try-catch with library usage in the try block to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.TryCatchTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.TryCatchTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -341,7 +341,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing a static class call to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.StaticTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.StaticTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -355,7 +355,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing a nested loop to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.LoopTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.LoopTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -393,7 +393,7 @@ internal object IntegrationTest : Spek({
         it("converts a class containing a loop with a continue statement to a library usage graph") {
             val libraryUsageGraph = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf("$TEST_CLASSES_PACKAGE.users.LoopContinueTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.LoopContinueTest"))
             )[0]
 
             assertThatStructureMatches(
@@ -433,7 +433,7 @@ internal object IntegrationTest : Spek({
         it("ignores a non-concrete interface method declaration") {
             val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf(
+                TestProject(testClassesClassPath, setOf(
                     "$TEST_CLASSES_PACKAGE.users.InterfaceTest"
                 ))
             )
@@ -444,7 +444,7 @@ internal object IntegrationTest : Spek({
         it("ignores a non-concrete abstract class method declaration") {
             val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf(
+                TestProject(testClassesClassPath, setOf(
                     "$TEST_CLASSES_PACKAGE.users.AbstractClassTest"
                 ))
             )
@@ -455,7 +455,7 @@ internal object IntegrationTest : Spek({
         it("ignores a non-concrete abstract class method declaration") {
             val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf(
+                TestProject(testClassesClassPath, setOf(
                     "$TEST_CLASSES_PACKAGE.users.PartiallyAbstractClassTest"
                 ))
             )
@@ -469,7 +469,7 @@ internal object IntegrationTest : Spek({
         it("filters out patterns with only return statements") {
             val libraryUsageGraphs = LibraryUsageGraphGenerator.generate(
                 libraryProject,
-                TestProject(testClassesClassPath, listOf(
+                TestProject(testClassesClassPath, setOf(
                     "$TEST_CLASSES_PACKAGE.users.EmptyPatternTest"
                 ))
             )

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaJarProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaJarProject.kt
@@ -10,12 +10,12 @@ class JavaJarProject(private val jar: File) : JavaProject {
     override val classDir: File
         get() = jar
     override val dependencyDir: File = classDir
-    override var classes: List<File> = listOf()
-    override var dependencies: List<File> = listOf()
+    override var classes: Set<File> = setOf()
+    override var dependencies: Set<File> = setOf()
     override var classpath: String = classDir.absolutePath
     override val projectDir: File = classDir
 
-    override lateinit var classNames: List<String>
+    override lateinit var classNames: Set<String>
 
     init {
         require(jar.isFile) { "Given project JAR is not a file." }

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaMavenProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaMavenProject.kt
@@ -18,9 +18,9 @@ class JavaMavenProject(
     override val classDir = File(projectDir, "target/classes")
     override val dependencyDir = File(projectDir, "target/dependency")
 
-    override lateinit var classes: List<File>
-    override lateinit var classNames: List<String>
-    override lateinit var dependencies: List<File>
+    override lateinit var classes: Set<File>
+    override lateinit var classNames: Set<String>
+    override lateinit var dependencies: Set<File>
     override lateinit var classpath: String
 
     init {

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaProject.kt
@@ -20,28 +20,28 @@ interface JavaProject : Project {
     /**
      * The project's compiled class files.
      *
-     * May be null before the project is compiled.
+     * May be empty before the project is compiled.
      */
-    var classes: List<File>
+    var classes: Set<File>
 
     /**
      * The names of the project's compiled classes.
      *
-     * May be null before the project is compiled.
+     * May be empty before the project is compiled.
      */
-    var classNames: List<String>
+    var classNames: Set<String>
 
     /**
      * The project's dependencies as JARs.
      *
-     * May be null before the project is compiled.
+     * May be empty before the project is compiled.
      */
-    var dependencies: List<File>
+    var dependencies: Set<File>
 
     /**
      * The classpath needed to load the complete project.
      *
-     * May be null before the project is compiled.
+     * May be empty before the project is compiled.
      */
     var classpath: String
 }


### PR DESCRIPTION
Using a `List` to store the names of the classes in a `Project` is great and all, but it doesn't scale. I just ran the pipeline on a project with >30k classes, and the JLUG took an exceptionally long time to build the usage graphs; 30% of this time was spent on determining whether a given class belonged to the library project.

Instead, all class names (and also the dependencies, because why not?) are now stored in a `Set`, which means that `contains` is now O(1) instead of O(n). Insertion will now take O(log n) instead of O(1), but I estimate that we will have exponentially more containment checks than insertions.
