### PR TITLE
Add JUnit test engine

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ allprojects {
         }
 
         useJUnitPlatform() {
-            includeEngines "spek"
+            includeEngines "junit-jupiter", "spek"
         }
     }
 


### PR DESCRIPTION
For some reason, Gradle did not discover JUnit tests. This PR adds the JUnit Jupiter test engine to discover those tests. Now we finally have coverage of the web module.
