### PR TITLE
Do not retain non-library usages on LHS

### DIFF
--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
@@ -30,7 +30,7 @@ internal class StatementFilter(project: JavaProject) : Filter {
      */
     fun retain(unit: Unit) = when (unit) {
         is ThrowStmt -> valueFilter.retain(unit.op)
-        is DefinitionStmt -> valueFilter.retain(unit.rightOp)
+        is DefinitionStmt -> valueFilter.retain(unit.leftOp) && valueFilter.retain(unit.rightOp)
         is IfStmt -> true // defer to BranchStatementFilter
         is SwitchStmt -> true // defer to BranchStatementFilter
         is InvokeStmt -> valueFilter.retain(unit.invokeExpr)

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -274,9 +274,7 @@ internal object IntegrationTest : Spek({
             assertThatStructureMatches(
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
-                        node<JAssignStmt>(
-                            node<JReturnStmt>()
-                        )
+                        node<JReturnStmt>()
                     )
                 ),
                 libraryUsageGraph
@@ -291,9 +289,7 @@ internal object IntegrationTest : Spek({
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
-                    node<JInvokeStmt>(
-                        node<JAssignStmt>()
-                    )
+                    node<JInvokeStmt>()
                 ),
                 libraryUsageGraph
             )
@@ -362,26 +358,22 @@ internal object IntegrationTest : Spek({
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
                         node<JAssignStmt>(
-                            node<JAssignStmt>(
-                                node<JIfStmt>(
-                                    node<JInvokeStmt>(
-                                        node<JAssignStmt>(
-                                            node<JIfStmt>(
-                                                node<JInvokeStmt>(
-                                                    node<JGotoStmt>(
-                                                        PreviousBranchNode()
-                                                    )
-                                                ),
-                                                node<JInvokeStmt>(
-                                                    node<JGotoStmt>(
-                                                        PreviousBranchNode()
-                                                    )
-                                                )
+                            node<JIfStmt>(
+                                node<JInvokeStmt>(
+                                    node<JIfStmt>(
+                                        node<JInvokeStmt>(
+                                            node<JGotoStmt>(
+                                                PreviousBranchNode()
+                                            )
+                                        ),
+                                        node<JInvokeStmt>(
+                                            node<JGotoStmt>(
+                                                PreviousBranchNode()
                                             )
                                         )
-                                    ),
-                                    node<JReturnVoidStmt>()
-                                )
+                                    )
+                                ),
+                                node<JReturnVoidStmt>()
                             )
                         )
                     )
@@ -400,26 +392,22 @@ internal object IntegrationTest : Spek({
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
                         node<JAssignStmt>(
-                            node<JAssignStmt>(
-                                node<JIfStmt>(
-                                    node<JInvokeStmt>(
-                                        node<JAssignStmt>(
-                                            node<JIfStmt>(
-                                                node<JGotoStmt>(
-                                                    node<JGotoStmt>(
-                                                        PreviousBranchNode()
-                                                    )
-                                                ),
-                                                node<JInvokeStmt>(
-                                                    node<JGotoStmt>(
-                                                        PreviousBranchNode()
-                                                    )
-                                                )
+                            node<JIfStmt>(
+                                node<JInvokeStmt>(
+                                    node<JIfStmt>(
+                                        node<JGotoStmt>(
+                                            node<JGotoStmt>(
+                                                PreviousBranchNode()
+                                            )
+                                        ),
+                                        node<JInvokeStmt>(
+                                            node<JGotoStmt>(
+                                                PreviousBranchNode()
                                             )
                                         )
-                                    ),
-                                    node<JReturnVoidStmt>()
-                                )
+                                    )
+                                ),
+                                node<JReturnVoidStmt>()
                             )
                         )
                     )

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
@@ -33,9 +33,19 @@ internal object StatementFilterTest : Spek({
 
         it("filters definition statements") {
             assertThatItRetains(mock<DefinitionStmt> {
+                on { leftOp } doReturn libraryValue
                 on { rightOp } doReturn libraryValue
             })
             assertThatItDoesNotRetain(mock<DefinitionStmt> {
+                on { leftOp } doReturn nonLibraryValue
+                on { rightOp } doReturn libraryValue
+            })
+            assertThatItDoesNotRetain(mock<DefinitionStmt> {
+                on { leftOp } doReturn libraryValue
+                on { rightOp } doReturn nonLibraryValue
+            })
+            assertThatItDoesNotRetain(mock<DefinitionStmt> {
+                on { leftOp } doReturn nonLibraryValue
                 on { rightOp } doReturn nonLibraryValue
             })
         }


### PR DESCRIPTION
Consider the following statement:

`UserClass.STATIC = libraryClassInstance()`

The `ValueFilter` will think that this statement exclusively uses the library, even though the LHS does not. This is because it does not check the usages in the LHS. This PR makes it check the LHS. Simple as that.