### PR TITLE
Add validation events

### DIFF
--- a/modules/validation-pipeline/ci-job/build.gradle
+++ b/modules/validation-pipeline/ci-job/build.gradle
@@ -1,0 +1,22 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+
+    dependencies {
+        classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
+    }
+}
+
+apply plugin: "org.springframework.boot"
+apply plugin: "io.spring.dependency-management"
+
+dependencies {
+    compile project(":validation-pipeline")
+
+    compile group: "org.springframework.boot", name: "spring-boot-starter-web"
+
+    testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
+}
+
+bootJar.enabled = false

--- a/modules/validation-pipeline/ci-job/gradle.properties
+++ b/modules/validation-pipeline/ci-job/gradle.properties
@@ -1,0 +1,2 @@
+mockitoKotlinVersion = 1.5.0
+springBootVersion    = 2.0.2.RELEASE

--- a/modules/validation-pipeline/ci-job/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobInitiator.kt
+++ b/modules/validation-pipeline/ci-job/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobInitiator.kt
@@ -1,13 +1,19 @@
 package org.cafejojo.schaapi.validationpipeline.cijob
 
-import org.cafejojo.schaapi.validationpipeline.events.ValidateRequestReceivedEvent
+import org.cafejojo.schaapi.validationpipeline.events.ValidationRequestReceivedEvent
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
 
+/**
+ * Starts up the execution of a CI job.
+ */
 @Component
 class CIJobInitiator {
+    /**
+     * Listens to [ValidationRequestReceivedEvent] events.
+     */
     @EventListener
-    fun handleValidateRequestReceivedEvent(event: ValidateRequestReceivedEvent) {
+    fun handleValidateRequestReceivedEvent(event: ValidationRequestReceivedEvent) {
         println("Received event $event")
     }
 }

--- a/modules/validation-pipeline/ci-job/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobInitiator.kt
+++ b/modules/validation-pipeline/ci-job/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobInitiator.kt
@@ -1,0 +1,13 @@
+package org.cafejojo.schaapi.validationpipeline.cijob
+
+import org.cafejojo.schaapi.validationpipeline.events.ValidateRequestReceivedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+
+@Component
+class CIJobInitiator {
+    @EventListener
+    fun handleValidateRequestReceivedEvent(event: ValidateRequestReceivedEvent) {
+        println("Received event $event")
+    }
+}

--- a/modules/validation-pipeline/github-test-reporter/build.gradle
+++ b/modules/validation-pipeline/github-test-reporter/build.gradle
@@ -12,6 +12,8 @@ apply plugin: "org.springframework.boot"
 apply plugin: "io.spring.dependency-management"
 
 dependencies {
+    compile project(":validation-pipeline")
+
     compile group: "com.auth0", name: "java-jwt", version: javaJwtVersion
     compile group: "com.fasterxml.jackson.module", name: "jackson-module-kotlin"
     compile group: "com.github.kittinunf.fuel", name: "fuel", version: fuelVersion // for JVM

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiver.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiver.kt
@@ -3,7 +3,7 @@ package org.cafejojo.schaapi.validationpipeline.githubtestreporter
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import org.cafejojo.schaapi.validationpipeline.events.ValidateRequestReceivedEvent
+import org.cafejojo.schaapi.validationpipeline.events.ValidationRequestReceivedEvent
 import org.cafejojo.schaapi.validationpipeline.githubtestreporter.events.CheckSuiteEvent
 import org.cafejojo.schaapi.validationpipeline.githubtestreporter.events.InstallationEvent
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -67,7 +67,7 @@ class WebHookReceiver(private val checkReporter: CheckReporter, private val publ
                         checkSuite.headSha
                     )
 
-                    publisher.publishEvent(ValidateRequestReceivedEvent(
+                    publisher.publishEvent(ValidationRequestReceivedEvent(
                         directory = File(Properties.testsStorageLocation, repository.fullName),
                         downloadUrl = "https://github.com/${repository.fullName}/archive/${checkSuite.headSha}.zip"
                     ))

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiverTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiverTest.kt
@@ -10,6 +10,7 @@ import org.cafejojo.schaapi.validationpipeline.events.ValidationRequestReceivedE
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
 import org.springframework.context.ApplicationEventPublisher
+import java.io.File
 
 object WebHookReceiverTest : Spek({
     it("can receive GitHub check suite requested web hooks") {
@@ -37,7 +38,7 @@ object WebHookReceiverTest : Spek({
 
         verify(checkReporter).reportStarted(12345, "cafejojo/schaapi", "patch01", "abc123")
         assertThat(event).isNotNull()
-        assertThat(event?.directory?.path).contains("cafejojo/schaapi")
+        assertThat(event?.directory?.path).contains("cafejojo${File.separator}schaapi")
     }
 
     it("cannot process general GitHub check suite web hooks") {

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiverTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiverTest.kt
@@ -6,7 +6,7 @@ import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.cafejojo.schaapi.validationpipeline.events.ValidateRequestReceivedEvent
+import org.cafejojo.schaapi.validationpipeline.events.ValidationRequestReceivedEvent
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
 import org.springframework.context.ApplicationEventPublisher
@@ -14,10 +14,10 @@ import org.springframework.context.ApplicationEventPublisher
 object WebHookReceiverTest : Spek({
     it("can receive GitHub check suite requested web hooks") {
         val checkReporter = mock<CheckReporter>()
-        var event: ValidateRequestReceivedEvent? = null
+        var event: ValidationRequestReceivedEvent? = null
         val webHookReceiver = WebHookReceiver(
             checkReporter,
-            ApplicationEventPublisher { event = it as? ValidateRequestReceivedEvent }
+            ApplicationEventPublisher { event = it as? ValidationRequestReceivedEvent }
         )
 
         webHookReceiver.processWebHook("check_suite", json {

--- a/modules/validation-pipeline/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/events/ValidateRequestReceivedEvent.kt
+++ b/modules/validation-pipeline/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/events/ValidateRequestReceivedEvent.kt
@@ -1,5 +1,0 @@
-package org.cafejojo.schaapi.validationpipeline.events
-
-import java.io.File
-
-data class ValidateRequestReceivedEvent(val directory: File, val downloadUrl: String)

--- a/modules/validation-pipeline/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/events/ValidateRequestReceivedEvent.kt
+++ b/modules/validation-pipeline/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/events/ValidateRequestReceivedEvent.kt
@@ -1,0 +1,5 @@
+package org.cafejojo.schaapi.validationpipeline.events
+
+import java.io.File
+
+data class ValidateRequestReceivedEvent(val directory: File, val downloadUrl: String)

--- a/modules/validation-pipeline/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/events/ValidationRequestReceivedEvent.kt
+++ b/modules/validation-pipeline/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/events/ValidationRequestReceivedEvent.kt
@@ -1,0 +1,8 @@
+package org.cafejojo.schaapi.validationpipeline.events
+
+import java.io.File
+
+/**
+ * Event that can be broadcast after receiving a request to start the validation process.
+ */
+data class ValidationRequestReceivedEvent(val directory: File, val downloadUrl: String)

--- a/modules/web/build.gradle
+++ b/modules/web/build.gradle
@@ -13,6 +13,7 @@ apply plugin: "io.spring.dependency-management"
 
 dependencies {
     compile project(":validation-pipeline:github-test-reporter")
+    compile project(":validation-pipeline:ci-job")
 
     compile group: "com.fasterxml.jackson.module", name: "jackson-module-kotlin"
     compile group: "org.springframework.boot", name: "spring-boot-starter-web"

--- a/modules/web/src/main/kotlin/org/cafejojo/schaapi/web/WebApplication.kt
+++ b/modules/web/src/main/kotlin/org/cafejojo/schaapi/web/WebApplication.kt
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.ComponentScan
 @SpringBootApplication
 @ComponentScan(basePackages = [
     "org.cafejojo.schaapi.web",
-    "org.cafejojo.schaapi.validationpipeline.githubtestreporter"
+    "org.cafejojo.schaapi.validationpipeline"
 ])
 open class WebApplication
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,6 +31,7 @@ includeModule "mining-pipeline", "ccspan-pattern-detector"
 includeModule "mining-pipeline", "spam-pattern-detector"
 
 includeModule "validation-pipeline"
+includeModule "validation-pipeline", "ci-job"
 includeModule "validation-pipeline", "github-test-reporter"
 includeModule "validation-pipeline", "junit-test-runner"
 


### PR DESCRIPTION
This PR fires an event when a web hook to start a check run is received.

It also adds a new `ci-job` module, in which the actual ci run will be executed. It will be responsible of creating a new thread for itself as well.