### PR TITLE
Consistently use `@Suppress`

### DIFF
--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/RecursiveGotoFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/RecursiveGotoFilterTest.kt
@@ -20,7 +20,7 @@ internal object RecursiveGotoFilterTest : Spek({
         }
 
         it("does not retain a recursive goto statement") {
-            @SuppressWarnings("UnsafeCast") // Unavoidable
+            @Suppress("UnsafeCast") // Unavoidable
             val goto = mock<GotoStmt> { on { it.target } doAnswer { it.mock as GotoStmt } }
 
             assertThat(filter.retain(goto)).isFalse()
@@ -44,7 +44,7 @@ internal object RecursiveGotoFilterTest : Spek({
         }
 
         it("retains a goto that goes to a recursive goto") {
-            @SuppressWarnings("UnsafeCast") // Unavoidable
+            @Suppress("UnsafeCast") // Unavoidable
             val gotoA = mock<GotoStmt> { on { it.target } doAnswer { it.mock as GotoStmt } }
             val gotoB = mock<GotoStmt> { on { it.target } doReturn gotoA }
 

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaJarProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaJarProject.kt
@@ -5,7 +5,7 @@ import java.io.File
 /**
  * A Java project contained in a JAR file.
  */
-@SuppressWarnings("LateinitUsage") // Refer to PR #23
+@Suppress("LateinitUsage") // Refer to PR #23
 class JavaJarProject(private val jar: File) : JavaProject {
     override val classDir: File
         get() = jar

--- a/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaMavenProject.kt
+++ b/modules/models/java-project/src/main/kotlin/org/cafejojo/schaapi/models/project/JavaMavenProject.kt
@@ -5,7 +5,7 @@ import java.io.File
 /**
  * A Java project using Maven.
  */
-@SuppressWarnings("LateinitUsage") // Refer to PR #23
+@Suppress("LateinitUsage") // Refer to PR #23
 class JavaMavenProject(
     override val projectDir: File,
     override val mavenDir: File = DEFAULT_MAVEN_HOME

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparator.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparator.kt
@@ -51,7 +51,7 @@ class GeneralizedNodeComparator : GeneralizedNodeComparator<JimpleNode> {
      * @param instance the instance [Node]
      * @return true iff [template] and [instance] have the same generalized values
      */
-    @SuppressWarnings("UnsafeCallOnNullableType") // The !! is implicitly avoided by checking `templateHasTag`
+    @Suppress("UnsafeCallOnNullableType") // The !! is implicitly avoided by checking `templateHasTag`
     override fun generalizedValuesAreEqual(template: JimpleNode, instance: JimpleNode): Boolean {
         val templateValues = template.getValues()
         val instanceValues = instance.getValues()

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitor.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitor.kt
@@ -15,7 +15,7 @@ import soot.jimple.UnopExpr
 /**
  * Recursively visits the [Value]s contained within a [Value] and accumulates a result based on the implemented methods.
  */
-@SuppressWarnings("MethodOverloading", "TooManyFunctions") // Result of the inverted implementation of Visitor
+@Suppress("MethodOverloading", "TooManyFunctions") // Result of the inverted implementation of Visitor
 abstract class JimpleValueVisitor<R> {
     /**
      * This method is called at the start of [visit].

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleNodeTest.kt
@@ -166,7 +166,7 @@ internal object JimpleNodeTest : Spek({
                 it("finds the values in an invocation without arguments") {
                     val method = SimpleSootMethod("method", emptyList(), "output")
                     val base = mockValue("base")
-                    @SuppressWarnings("SpreadOperator") // Cannot be avoided because of generic
+                    @Suppress("SpreadOperator") // Cannot be avoided because of generic
                     val expr = SimpleInvokeExpr(base, method, *emptyArray<String>())
                     val node = JimpleNode(mockIfStmt(expr))
 

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/SimpleSoot.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/SimpleSoot.kt
@@ -87,7 +87,7 @@ internal class SimpleBinopExpr(leftValue: Value, rightValue: Value) : AbstractBi
 /**
  * A simple implementation of [soot.jimple.internal.AbstractInvokeExpr].
  */
-@SuppressWarnings("SpreadOperator") // No clean alternative
+@Suppress("SpreadOperator") // No clean alternative
 internal class SimpleInvokeExpr(base: Value, sootMethod: SootMethod, vararg arguments: Value) :
     AbstractSpecialInvokeExpr(
         mockValueBox(base),

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollections.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollections.kt
@@ -100,7 +100,7 @@ class CustomEqualsHashSet<K>(
 /**
  * A [MutableList] that allows one to use custom [equals] and [hashCode] functions.
  */
-@SuppressWarnings("TooManyFunctions") // All methods are overrides
+@Suppress("TooManyFunctions") // All methods are overrides
 class CustomEqualsList<K>(
     private val customEquals: (K, Any?) -> Boolean,
     private val customHash: (K) -> Int

--- a/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollectionsTest.kt
+++ b/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollectionsTest.kt
@@ -15,9 +15,9 @@ internal object EqualsWrapperTest : Spek({
         }
 
         it("uses the wrapped type's equals implementation by default") {
-            @SuppressWarnings("EqualsWithHashCodeExist")
+            @Suppress("EqualsWithHashCodeExist")
             val key = object : Any() {
-                @SuppressWarnings("EqualsAlwaysReturnsTrueOrFalse")
+                @Suppress("EqualsAlwaysReturnsTrueOrFalse")
                 override fun equals(other: Any?) = false
             }
             val wrapper = EqualsWrapper(
@@ -36,7 +36,7 @@ internal object EqualsWrapperTest : Spek({
         }
 
         it("uses the wrapped type's hash code implementation by default") {
-            @SuppressWarnings("EqualsWithHashCodeExist")
+            @Suppress("EqualsWithHashCodeExist")
             val key = object : Any() {
                 override fun hashCode() = 31749
             }


### PR DESCRIPTION
Consistently use `@Suppress` instead of using `@SuppressWarnings` in some places and `@Suppress` in others.