### PR TITLE
Upgrade `JimpleValueVisitor` to support more `Value`s

### DIFF
--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitor.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitor.kt
@@ -1,14 +1,26 @@
 package org.cafejojo.schaapi.models.libraryusagegraph.jimple
 
 import soot.Immediate
+import soot.Local
 import soot.Value
 import soot.jimple.AnyNewExpr
+import soot.jimple.ArrayRef
 import soot.jimple.BinopExpr
 import soot.jimple.CastExpr
+import soot.jimple.Constant
 import soot.jimple.DynamicInvokeExpr
+import soot.jimple.Expr
+import soot.jimple.FieldRef
+import soot.jimple.IdentityRef
+import soot.jimple.InstanceFieldRef
 import soot.jimple.InstanceInvokeExpr
 import soot.jimple.InstanceOfExpr
+import soot.jimple.InvokeExpr
+import soot.jimple.NewArrayExpr
+import soot.jimple.NewExpr
+import soot.jimple.NewMultiArrayExpr
 import soot.jimple.Ref
+import soot.jimple.StaticFieldRef
 import soot.jimple.StaticInvokeExpr
 import soot.jimple.UnopExpr
 
@@ -42,9 +54,59 @@ abstract class JimpleValueVisitor<R> {
         beforeVisit(value)
 
         val result = when (value) {
+            is Expr -> visitExpr(value)
+            is Ref -> visitRef(value)
+            is Immediate -> visitImmediate(value)
+            else -> applyOther(value)
+        }
+
+        afterVisit(value)
+        return result
+    }
+
+    /**
+     * This method is called when a [Value] is visited by [visit] and all other [apply] methods are not applicable.
+     *
+     * @param value a [Value]
+     */
+    open fun applyOther(value: Value) = applyDefault(value)
+
+    private fun visitExpr(value: Expr): R =
+        when (value) {
             is UnopExpr -> accumulate(apply(value), visit(value.op))
             is BinopExpr -> accumulate(apply(value), visit(value.op1), visit(value.op2))
-            is AnyNewExpr -> apply(value)
+            is AnyNewExpr -> visitAnyNewExpr(value)
+            is InvokeExpr -> visitInvokeExpr(value)
+            is InstanceOfExpr -> accumulate(apply(value), visit(value.op))
+            is CastExpr -> accumulate(apply(value), visit(value.op))
+            else -> applyOtherExpr(value)
+        }
+
+    /**
+     * This method is called when an [Expr] is visited by [visit] and all other [apply] methods are not applicable.
+     *
+     * @param value an [Expr]
+     */
+    open fun applyOtherExpr(value: Expr) = applyOther(value)
+
+    private fun visitAnyNewExpr(value: AnyNewExpr) =
+        when (value) {
+            is NewExpr -> apply(value)
+            is NewArrayExpr -> accumulate(apply(value), visit(value.size))
+            is NewMultiArrayExpr -> accumulate(apply(value), value.sizes.map { visit(it) })
+            else -> applyOtherAnyNewExpr(value)
+        }
+
+    /**
+     * This method is called when an [AnyNewExpr] is visited by [visit] and all other [apply] methods are not
+     * applicable.
+     *
+     * @param value an [AnyNewExpr]
+     */
+    open fun applyOtherAnyNewExpr(value: AnyNewExpr) = applyOtherExpr(value)
+
+    private fun visitInvokeExpr(value: InvokeExpr) =
+        when (value) {
             is InstanceInvokeExpr ->
                 accumulate(
                     accumulate(apply(value), visit(value.base)),
@@ -59,100 +121,178 @@ abstract class JimpleValueVisitor<R> {
                     ),
                     value.args.map { visit(it) }
                 )
-            is Ref -> apply(value)
-            is Immediate -> apply(value)
-            is InstanceOfExpr -> accumulate(apply(value), visit(value.op))
-            is CastExpr -> accumulate(apply(value), visit(value.op))
-            else -> applyOther(value)
+            else -> applyOtherInvokeExpr(value)
         }
 
-        afterVisit(value)
-        return result
-    }
+    /**
+     * This method is called when an [InvokeExpr] is visited by [visit] and all other [apply] methods are not
+     * applicable.
+     *
+     * @param value an [InvokeExpr]
+     */
+    open fun applyOtherInvokeExpr(value: InvokeExpr) = applyOtherExpr(value)
+
+    private fun visitRef(value: Ref) =
+        when (value) {
+            is IdentityRef -> apply(value)
+            is FieldRef -> visitFieldRef(value)
+            is ArrayRef -> accumulate(apply(value), visit(value.base), visit(value.index))
+            else -> applyOtherRef(value)
+        }
+
+    /**
+     * This method is called when a [Ref] is visited by [visit] and all other [apply] methods are not applicable.
+     *
+     * @param value a [Ref]
+     */
+    open fun applyOtherRef(value: Ref) = applyOther(value)
+
+    private fun visitFieldRef(value: FieldRef) =
+        when (value) {
+            is InstanceFieldRef -> accumulate(apply(value), visit(value.base))
+            is StaticFieldRef -> apply(value)
+            else -> applyOtherFieldRef(value)
+        }
+
+    /**
+     * This method is called when a [FieldRef] is visited by [visit] and all other [apply] methods are not applicable.
+     *
+     * @param value a [FieldRef]
+     */
+    open fun applyOtherFieldRef(value: FieldRef) = applyOtherRef(value)
+
+    private fun visitImmediate(value: Immediate) =
+        when (value) {
+            is Local -> apply(value)
+            is Constant -> apply(value)
+            else -> applyOtherImmediate(value)
+        }
+
+    /**
+     * This method is called when an [Immediate] is visited by [visit] and all other [apply] methods are not applicable.
+     *
+     * @param value an [Immediate]
+     */
+    open fun applyOtherImmediate(value: Immediate) = applyOther(value)
 
     /**
      * This method is called when a [UnopExpr] is visited by [visit].
      *
      * @param value a [UnopExpr]
      */
-    open fun apply(value: UnopExpr) = defaultApply(value)
+    open fun apply(value: UnopExpr) = applyDefault(value)
 
     /**
      * This method is called when a [BinopExpr] is visited by [visit].
      *
      * @param value a [BinopExpr]
      */
-    open fun apply(value: BinopExpr) = defaultApply(value)
+    open fun apply(value: BinopExpr) = applyDefault(value)
 
     /**
-     * This method is called when an [AnyNewExpr] is visited by [visit].
+     * This method is called when a [NewExpr] is visited by [visit].
      *
-     * @param value an [AnyNewExpr]
+     * @param value a [NewExpr]
      */
-    open fun apply(value: AnyNewExpr) = defaultApply(value)
+    open fun apply(value: NewExpr) = applyDefault(value)
+
+    /**
+     * This method is called when a [NewArrayExpr] is visited by [visit].
+     *
+     * @param value a [NewArrayExpr]
+     */
+    open fun apply(value: NewArrayExpr) = applyDefault(value)
+
+    /**
+     * This method is called when a [NewMultiArrayExpr] is visited by [visit].
+     *
+     * @param value a [NewMultiArrayExpr]
+     */
+    open fun apply(value: NewMultiArrayExpr) = applyDefault(value)
 
     /**
      * This method is called when a [StaticInvokeExpr] is visited by [visit].
      *
      * @param value a [StaticInvokeExpr]
      */
-    open fun apply(value: StaticInvokeExpr) = defaultApply(value)
+    open fun apply(value: StaticInvokeExpr) = applyDefault(value)
 
     /**
      * This method is called when an [InstanceInvokeExpr] is visited by [visit].
      *
      * @param value an [InstanceInvokeExpr]
      */
-    open fun apply(value: InstanceInvokeExpr) = defaultApply(value)
+    open fun apply(value: InstanceInvokeExpr) = applyDefault(value)
 
     /**
      * This method is called when a [DynamicInvokeExpr] is visited by [visit].
      *
      * @param value a [DynamicInvokeExpr]
      */
-    open fun apply(value: DynamicInvokeExpr) = defaultApply(value)
+    open fun apply(value: DynamicInvokeExpr) = applyDefault(value)
 
     /**
-     * This method is called when a [Ref] is visited by [visit].
+     * This method is called when an [IdentityRef] is visited by [visit].
      *
-     * @param value a [Ref]
+     * @param value an [IdentityRef]
      */
-    open fun apply(value: Ref) = defaultApply(value)
+    open fun apply(value: IdentityRef) = applyDefault(value)
 
     /**
-     * This method is called when an [Immediate] is visited by [visit].
+     * This method is called when an [InstanceFieldRef] is visited by [visit].
      *
-     * @param value an [Immediate]
+     * @param value an [InstanceFieldRef]
      */
-    open fun apply(value: Immediate) = defaultApply(value)
+    open fun apply(value: InstanceFieldRef) = applyDefault(value)
+
+    /**
+     * This method is called when a [StaticFieldRef] is visited by [visit].
+     *
+     * @param value a [StaticFieldRef]
+     */
+    open fun apply(value: StaticFieldRef) = applyDefault(value)
+
+    /**
+     * This method is called when an [ArrayRef] is visited by [visit].
+     *
+     * @param value an [ArrayRef]
+     */
+    open fun apply(value: ArrayRef) = applyDefault(value)
+
+    /**
+     * This method is called when a [Local] is visited by [visit].
+     *
+     * @param value a [Local]
+     */
+    open fun apply(value: Local) = applyDefault(value)
+
+    /**
+     * This method is called when a [Constant] is visited by [visit].
+     *
+     * @param value a [Constant]
+     */
+    open fun apply(value: Constant) = applyDefault(value)
 
     /**
      * This method is called when an [InstanceOfExpr] is visited by [visit].
      *
      * @param value an [InstanceOfExpr]
      */
-    open fun apply(value: InstanceOfExpr) = defaultApply(value)
+    open fun apply(value: InstanceOfExpr) = applyDefault(value)
 
     /**
      * This method is called when a [CastExpr] is visited by [visit].
      *
      * @param value a [CastExpr]
      */
-    open fun apply(value: CastExpr) = defaultApply(value)
+    open fun apply(value: CastExpr) = applyDefault(value)
 
     /**
-     * This method is called when a [Value] is visited by [visit] and the other [apply] methods are not applicable.
+     * This method is called by default if an [apply] method is not overridden.
      *
      * @param value a [Value]
      */
-    open fun applyOther(value: Value) = defaultApply(value)
-
-    /**
-     * This method is called by default is an [apply] method is not implemented.
-     *
-     * @param value a [Value]
-     */
-    abstract fun defaultApply(value: Value): R
+    abstract fun applyDefault(value: Value): R
 
     /**
      * Combines two values of type [R].
@@ -163,7 +303,7 @@ abstract class JimpleValueVisitor<R> {
      */
     abstract fun accumulate(result1: R, result2: R): R
 
-    private fun accumulate(result1: R, results: List<R>) = results.fold(result1, { acc, cur -> accumulate(acc, cur) })
+    private fun accumulate(result1: R, results: List<R>) = results.fold(result1) { acc, cur -> accumulate(acc, cur) }
 
     private fun accumulate(result1: R, vararg results: R) = accumulate(result1, results.toList())
 }
@@ -178,7 +318,7 @@ class JimpleValueAccumulator : JimpleValueVisitor<List<Value>>() {
      * @param value the [Value] to return in a singleton list
      * @return a singleton list containing [value]
      */
-    override fun defaultApply(value: Value) = listOf(value)
+    override fun applyDefault(value: Value) = listOf(value)
 
     /**
      * Returns the union of the given lists.

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitorTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitorTest.kt
@@ -3,16 +3,24 @@ package org.cafejojo.schaapi.models.libraryusagegraph.jimple
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import soot.Immediate
 import soot.IntType
 import soot.Modifier
 import soot.RefType
 import soot.SootClass
+import soot.SootField
 import soot.SootMethod
 import soot.Value
+import soot.jimple.AnyNewExpr
+import soot.jimple.Expr
+import soot.jimple.FieldRef
 import soot.jimple.IntConstant
+import soot.jimple.InvokeExpr
 import soot.jimple.Jimple
+import soot.jimple.Ref
 
 /**
  * Unit tests for [JimpleValueVisitor].
@@ -31,91 +39,186 @@ internal object JimpleValueVisitorTest : Spek({
             assertThat(visitor.visit(value)).containsExactly(value)
         }
 
-        it("returns the only value in an UnopExpr") {
-            val const = IntConstant.v(1)
-            val value = Jimple.v().newNegExpr(const)
+        context("Expr") {
+            it("returns the value in an unknown Expr") {
+                val value = mock<Expr> {}
 
-            assertThat(visitor.visit(value)).containsExactly(value, const)
+                assertThat(visitor.visit(value)).containsExactly(value)
+            }
+
+            it("returns the only value of an UnopExpr") {
+                val const = IntConstant.v(1)
+                val value = Jimple.v().newNegExpr(const)
+
+                assertThat(visitor.visit(value)).containsExactly(value, const)
+            }
+
+            it("returns both values of a BinopExpr") {
+                val constA = IntConstant.v(49)
+                val constB = IntConstant.v(53)
+                val value = Jimple.v().newSubExpr(constA, constB)
+
+                assertThat(visitor.visit(value)).containsExactly(value, constA, constB)
+            }
+
+            it("returns the value of an InstanceOfExpr") {
+                val local = Jimple.v().newLocal("local", RefType.v("SomeClass"))
+                val value = Jimple.v().newInstanceOfExpr(local, RefType.v("SomeOtherClass"))
+
+                assertThat(visitor.visit(value)).containsExactly(value, local)
+            }
+
+            it("returns the value of a CastExpr") {
+                val local = Jimple.v().newLocal("local", RefType.v("SomeClass"))
+                val value = Jimple.v().newCastExpr(local, RefType.v("SomeOtherClass"))
+
+                assertThat(visitor.visit(value)).containsExactly(value, local)
+            }
+
+            context("AnyNewExpr") {
+                it("returns the value of an unknown AnyNewExpr") {
+                    val value = mock<AnyNewExpr> { }
+
+                    assertThat(visitor.visit(value)).containsExactly(value)
+                }
+
+                it("returns the value of a NewExpr") {
+                    val value = Jimple.v().newNewExpr(RefType.v("SomeClass"))
+
+                    assertThat(visitor.visit(value)).containsExactly(value)
+                }
+
+                it("returns the value and size of a NewArrayExpr") {
+                    val sizeValue = Jimple.v().newLocal("size", IntType.v())
+                    val value = Jimple.v().newNewArrayExpr(RefType.v("SomeClass"), sizeValue)
+
+                    assertThat(visitor.visit(value)).containsExactly(value, sizeValue)
+                }
+
+                it("returns the value and sizes of a NewMultiArrayExpr") {
+                    val sizeValues = Array(3) { i -> Jimple.v().newLocal("size$i", IntType.v()) }
+                    val value =
+                        Jimple.v().newNewMultiArrayExpr(RefType.v("SomeClass").arrayType, sizeValues.toMutableList())
+
+                    @Suppress("SpreadOperator") // Easier to write
+                    assertThat(visitor.visit(value)).containsExactly(value, *sizeValues)
+                }
+            }
+
+            context("InvokeExpr") {
+                it("returns the value of an unknown InvokeExpr") {
+                    val value = mock<InvokeExpr> {}
+
+                    assertThat(visitor.visit(value)).containsExactly(value)
+                }
+
+                it("returns the value, base, and arguments of an InstanceInvokeExpr") {
+                    val base = Jimple.v().newLocal("base", RefType.v("BaseClass"))
+                    val method = SootMethod("method", listOf(RefType.v("ArgTypeA"), RefType.v("ArgTypeB")), IntType.v())
+                        .also { SootClass("SomeClass").addMethod(it) }
+                    val argA = Jimple.v().newLocal("argA", RefType.v("ArgTypeA"))
+                    val argB = Jimple.v().newLocal("argB", RefType.v("ArgTypeB"))
+                    val value = Jimple.v().newSpecialInvokeExpr(base, method.makeRef(), listOf(argA, argB))
+
+                    assertThat(visitor.visit(value)).containsExactly(value, base, argA, argB)
+                }
+
+                it("returns the arguments of a StaticInvokeExpr") {
+                    val method = SootMethod(
+                        "method",
+                        listOf(RefType.v("ArgTypeA"), RefType.v("ArgTypeB")),
+                        IntType.v(),
+                        Modifier.STATIC
+                    ).also { SootClass("SomeClass").addMethod(it) }
+                    val argA = Jimple.v().newLocal("argA", RefType.v("ArgTypeA"))
+                    val argB = Jimple.v().newLocal("argB", RefType.v("ArgTypeB"))
+                    val value = Jimple.v().newStaticInvokeExpr(method.makeRef(), listOf(argA, argB))
+
+                    assertThat(visitor.visit(value)).containsExactly(value, argA, argB)
+                }
+
+                it("returns the arguments of a DynamicInvokeExpr") {
+                    val method = SootMethod("method", listOf(RefType.v("ArgTypeA"), RefType.v("ArgTypeB")), IntType.v())
+                        .also { SootClass(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME).addMethod(it) }
+                    val bsArgA = Jimple.v().newLocal("bsArgA", RefType.v("ArgTypeA"))
+                    val bsArgB = Jimple.v().newLocal("bsArgB", RefType.v("ArgTypeB"))
+                    val argA = Jimple.v().newLocal("argA", RefType.v("ArgTypeA"))
+                    val argB = Jimple.v().newLocal("argB", RefType.v("ArgTypeB"))
+                    val value = Jimple.v().newDynamicInvokeExpr(
+                        method.makeRef(), listOf(bsArgA, bsArgB),
+                        method.makeRef(), listOf(argA, argB)
+                    )
+
+                    assertThat(visitor.visit(value)).containsExactly(value, bsArgA, bsArgB, argA, argB)
+                }
+            }
         }
 
-        it("returns both values in a BinopExpr") {
-            val constA = IntConstant.v(49)
-            val constB = IntConstant.v(53)
-            val value = Jimple.v().newSubExpr(constA, constB)
+        context("Ref") {
+            it("returns the value of an unknown Ref") {
+                val value = mock<Ref> {}
 
-            assertThat(visitor.visit(value)).containsExactly(value, constA, constB)
+                assertThat(visitor.visit(value)).containsExactly(value)
+            }
+
+            it("returns the value of an IdentityRef") {
+                val value = Jimple.v().newThisRef(RefType.v("SomeClass"))
+
+                assertThat(visitor.visit(value)).containsExactly(value)
+            }
+
+            context("FieldRef") {
+                it("returns the value of an unknown FieldRef") {
+                    val value = mock<FieldRef> {}
+
+                    assertThat(visitor.visit(value)).containsExactly(value)
+                }
+
+                it("returns the value and base of an InstanceFieldRef") {
+                    val base = Jimple.v().newLocal("base", RefType.v("SomeClass"))
+                    val field = SootField("field", IntType.v(), Modifier.PUBLIC)
+                        .also { it.declaringClass = mock {} }
+                    val value = Jimple.v().newInstanceFieldRef(base, field.makeRef())
+
+                    assertThat(visitor.visit(value)).containsExactly(value, base)
+                }
+
+                it("returns the value of a StaticFieldRef") {
+                    val field = SootField("field", IntType.v(), Modifier.PUBLIC + Modifier.STATIC)
+                        .also { it.declaringClass = mock {} }
+                    val value = Jimple.v().newStaticFieldRef(field.makeRef())
+
+                    assertThat(visitor.visit(value)).containsExactly(value)
+                }
+            }
+
+            it("returns the value, base, and index of an ArrayRef") {
+                val base = Jimple.v().newLocal("base", RefType.v("SomeClass").arrayType)
+                val index = Jimple.v().newLocal("offset", IntType.v())
+                val value = Jimple.v().newArrayRef(base, index)
+
+                assertThat(visitor.visit(value)).containsExactly(value, base, index)
+            }
         }
 
-        it("returns the value of an AnyNewExpr") {
-            val value = Jimple.v().newNewExpr(RefType.v("SomeClass"))
+        context("Immediate") {
+            it("returns the value of an unknown Immediate") {
+                val value = mock<Immediate> {}
 
-            assertThat(visitor.visit(value)).containsExactly(value)
-        }
+                assertThat(visitor.visit(value)).containsExactly(value)
+            }
 
-        it("returns the base and arguments of an InstanceInvokeExpr") {
-            val base = Jimple.v().newLocal("base", RefType.v("BaseClass"))
-            val method = SootMethod("method", listOf(RefType.v("ArgTypeA"), RefType.v("ArgTypeB")), IntType.v())
-                .also { SootClass("SomeClass").addMethod(it) }
-            val argA = Jimple.v().newLocal("argA", RefType.v("ArgTypeA"))
-            val argB = Jimple.v().newLocal("argB", RefType.v("ArgTypeB"))
-            val value = Jimple.v().newSpecialInvokeExpr(base, method.makeRef(), listOf(argA, argB))
+            it("returns the value of a Local") {
+                val value = Jimple.v().newLocal("local", RefType.v("SomeClass"))
 
-            assertThat(visitor.visit(value)).containsExactly(value, base, argA, argB)
-        }
+                assertThat(visitor.visit(value)).containsExactly(value)
+            }
 
-        it("returns the arguments of a StaticInvokeExpr") {
-            val method = SootMethod(
-                "method",
-                listOf(RefType.v("ArgTypeA"), RefType.v("ArgTypeB")),
-                IntType.v(),
-                Modifier.STATIC
-            ).also { SootClass("SomeClass").addMethod(it) }
-            val argA = Jimple.v().newLocal("argA", RefType.v("ArgTypeA"))
-            val argB = Jimple.v().newLocal("argB", RefType.v("ArgTypeB"))
-            val value = Jimple.v().newStaticInvokeExpr(method.makeRef(), listOf(argA, argB))
+            it("returns the value of a Constant") {
+                val value = IntConstant.v(384)
 
-            assertThat(visitor.visit(value)).containsExactly(value, argA, argB)
-        }
-
-        it("returns the arguments of a DynamicInvokeExpr") {
-            val method = SootMethod("method", listOf(RefType.v("ArgTypeA"), RefType.v("ArgTypeB")), IntType.v())
-                .also { SootClass(SootClass.INVOKEDYNAMIC_DUMMY_CLASS_NAME).addMethod(it) }
-            val bsArgA = Jimple.v().newLocal("bsArgA", RefType.v("ArgTypeA"))
-            val bsArgB = Jimple.v().newLocal("bsArgB", RefType.v("ArgTypeB"))
-            val argA = Jimple.v().newLocal("argA", RefType.v("ArgTypeA"))
-            val argB = Jimple.v().newLocal("argB", RefType.v("ArgTypeB"))
-            val value = Jimple.v().newDynamicInvokeExpr(
-                method.makeRef(), listOf(bsArgA, bsArgB),
-                method.makeRef(), listOf(argA, argB)
-            )
-
-            assertThat(visitor.visit(value)).containsExactly(value, bsArgA, bsArgB, argA, argB)
-        }
-
-        it("returns the value of a Ref") {
-            val value = Jimple.v().newThisRef(RefType.v("SomeClass"))
-
-            assertThat(visitor.visit(value)).containsExactly(value)
-        }
-
-        it("returns the value of an Immediate") {
-            val value = Jimple.v().newLocal("local", RefType.v("SomeClass"))
-
-            assertThat(visitor.visit(value)).containsExactly(value)
-        }
-
-        it("returns the value of an InstanceOf") {
-            val local = Jimple.v().newLocal("local", RefType.v("SomeClass"))
-            val value = Jimple.v().newInstanceOfExpr(local, RefType.v("SomeOtherClass"))
-
-            assertThat(visitor.visit(value)).containsExactly(value, local)
-        }
-
-        it("returns the value of a CastExpr") {
-            val local = Jimple.v().newLocal("local", RefType.v("SomeClass"))
-            val value = Jimple.v().newCastExpr(local, RefType.v("SomeOtherClass"))
-
-            assertThat(visitor.visit(value)).containsExactly(value, local)
+                assertThat(visitor.visit(value)).containsExactly(value)
+            }
         }
     }
 })


### PR DESCRIPTION
Upgrades the `JimpleValueVisitor` to
* allow different overrides for the different `Ref` classes
* allow different overrides for the different `Immediate` classes
* allow different overrides for the different `AnyNewExpr` classes
* allow overrides for unrecognised classes at different levels (e.g. one override for an unrecognised `Value`, another for an unrecognised `Ref`, and yet another for an unrecognised `FieldRef`)

This is the first step towards fixing the annoying bugs with excessive filtering in the `StatementFilter`.