### PR TITLE
Filter separation

### DIFF
--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -23,11 +23,22 @@ import soot.jimple.StaticInvokeExpr
 import soot.jimple.toolkits.infoflow.AbstractDataSource
 import soot.jimple.toolkits.thread.synchronization.NewStaticLock
 
+/**
+ * Determines whether to keep individual [Value]s.
+ */
 internal class ValueFilter(libraryProject: JavaProject) {
     private val classFilter = ValueClassFilter()
     private val libraryUsageFilter = ValueLibraryUsageFilter(libraryProject)
     private val userUsageFilter = ValueUserUsageFilter(libraryProject)
 
+    /**
+     * Returns true iff [value] is of a useful class (as determined by [ValueClassFilter]), has a library usage, and
+     * does not have any user project usages.
+     *
+     * @param value a [Value]
+     * @return true iff [value] is of a useful class (as determined by [ValueClassFilter]), has a library usage, and
+     * does not have any user project usages
+     */
     fun retain(value: Value) =
         classFilter.retain(value) && libraryUsageFilter.retain(value) && userUsageFilter.retain(value)
 }

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -1,103 +1,163 @@
 package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
 
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleValueVisitor
 import org.cafejojo.schaapi.models.project.JavaProject
 import soot.EquivalentValue
-import soot.Immediate
-import soot.Local
+import soot.PrimType
+import soot.Scene
+import soot.SootClass
+import soot.Type
 import soot.Value
-import soot.jimple.AnyNewExpr
-import soot.jimple.ArrayRef
-import soot.jimple.BinopExpr
 import soot.jimple.CastExpr
-import soot.jimple.ConcreteRef
 import soot.jimple.Constant
 import soot.jimple.DynamicInvokeExpr
-import soot.jimple.Expr
-import soot.jimple.FieldRef
 import soot.jimple.IdentityRef
+import soot.jimple.InstanceFieldRef
+import soot.jimple.InstanceInvokeExpr
 import soot.jimple.InstanceOfExpr
-import soot.jimple.InvokeExpr
 import soot.jimple.NewArrayExpr
 import soot.jimple.NewExpr
 import soot.jimple.NewMultiArrayExpr
-import soot.jimple.Ref
-import soot.jimple.UnopExpr
-import soot.jimple.internal.AbstractBinopExpr
+import soot.jimple.StaticFieldRef
+import soot.jimple.StaticInvokeExpr
 import soot.jimple.toolkits.infoflow.AbstractDataSource
 import soot.jimple.toolkits.thread.synchronization.NewStaticLock
-import soot.shimple.PhiExpr
-import soot.shimple.ShimpleExpr
 
-/**
- * Performs filtering of library-using values.
- *
- * @property project library project
- */
-internal class ValueFilter(private val project: JavaProject) {
-    /**
-     * Filters out non library-using values.
-     *
-     * @param value a value.
-     * @return whether or not the value should be kept.
-     */
-    fun retain(value: Value): Boolean = when (value) {
-        is Expr -> retainExpr(value)
-        is Ref -> retainRef(value)
-        is Immediate -> retainImmediate(value)
-        is EquivalentValue -> retain(value.value)
-        is NewStaticLock -> false // can never involve library usage
-        is AbstractDataSource -> false // is only used for analysis purposes
-        else -> throwUnrecognizedValue(value)
-    }
+internal class ValueFilter(libraryProject: JavaProject) {
+    private val classFilter = ValueClassFilter()
+    private val libraryUsageFilter = ValueLibraryUsageFilter(libraryProject)
+    private val userUsageFilter = ValueUserUsageFilter(libraryProject)
 
-    private fun retainExpr(expr: Expr) = when (expr) {
-        is DynamicInvokeExpr -> false // todo add support for lambdas
-        is InvokeExpr -> isLibraryClass(expr.method.declaringClass.name)
-        is UnopExpr -> retain(expr.op)
-        is BinopExpr -> retain(expr.op1) || retain(expr.op2)
-        is AbstractBinopExpr -> retain(expr.op1) || retain(expr.op2)
-        is InstanceOfExpr -> retain(expr.op) && isLibraryClass(expr.checkType.toString())
-        is ShimpleExpr -> retainShimpleExpr(expr)
-        is AnyNewExpr -> retainAnyNewExpr(expr)
-        is CastExpr -> retain(expr.op)
-        else -> throwUnrecognizedValue(expr)
-    }
-
-    private fun retainShimpleExpr(expr: ShimpleExpr) = when (expr) {
-        is PhiExpr -> expr.values.filter { retain(it) }.any()
-        else -> throwUnrecognizedValue(expr)
-    }
-
-    private fun retainAnyNewExpr(expr: AnyNewExpr) = when (expr) {
-        is NewExpr -> isLibraryClass(expr.type.toString())
-        is NewArrayExpr -> false
-        is NewMultiArrayExpr -> false
-        else -> throwUnrecognizedValue(expr)
-    }
-
-    private fun retainRef(ref: Ref) = when (ref) {
-        is IdentityRef -> false
-        is ConcreteRef -> when (ref) {
-            is FieldRef -> isLibraryClass(ref.field.declaringClass.name)
-            is ArrayRef -> retain(ref.base)
-            else -> throwUnrecognizedValue(ref)
-        }
-        else -> throwUnrecognizedValue(ref)
-    }
-
-    private fun retainImmediate(immediate: Immediate) = when (immediate) {
-        is Local -> isLibraryClass(immediate.type.toString())
-        is Constant -> false
-        else -> throwUnrecognizedValue(immediate)
-    }
-
-    private fun isLibraryClass(className: String) = project.classNames.contains(className)
-
-    private fun throwUnrecognizedValue(value: Value): Nothing =
-        throw UnsupportedValueException("Value of type ${value.javaClass} is not supported by the value filter.")
+    fun retain(value: Value) =
+        classFilter.retain(value) && libraryUsageFilter.retain(value) && userUsageFilter.retain(value)
 }
 
 /**
- * Exception for encountered values that are not supported by the [ValueFilter].
+ * Filters [Value]s based on their class.
+ */
+@Suppress("MethodOverloading") // That is how JimpleValueVisitor works
+private class ValueClassFilter : JimpleValueVisitor<Boolean>() {
+    /**
+     * Returns true iff [value] should be retained.
+     *
+     * @param value a [Value]
+     * @return true iff [value] should be retained
+     */
+    fun retain(value: Value) = visit(value)
+
+    override fun applyDefault(value: Value) = true
+
+    override fun applyOther(value: Value) =
+        throw UnsupportedValueException("Value of type ${value.javaClass} is not supported by the value filter.")
+
+    override fun apply(value: NewArrayExpr) = false
+    override fun apply(value: NewMultiArrayExpr) = false
+    override fun apply(value: IdentityRef) = false
+    override fun apply(value: EquivalentValue) = false
+    override fun apply(value: NewStaticLock) = false
+    override fun apply(value: AbstractDataSource) = false
+
+    /**
+     * Returns true iff [result1] and [result2] are both true.
+     *
+     * @param result1 a boolean
+     * @param result2 a boolean
+     * @return true iff [result1] and [result2] are both true
+     */
+    override fun accumulate(result1: Boolean, result2: Boolean) = result1 && result2
+}
+
+/**
+ * Retains [Value]s that use the library somewhere.
+ *
+ * @property libraryProject a library project
+ */
+@Suppress("MethodOverloading", "TooManyFunctions") // That is how JimpleValueVisitor works
+private class ValueLibraryUsageFilter(private val libraryProject: JavaProject) : JimpleValueVisitor<Boolean>() {
+    /**
+     * Returns true iff [value] uses a class from [libraryProject] somewhere.
+     *
+     * @param value a [Value]
+     * @return true iff [value] uses a class from [libraryProject] somewhere
+     */
+    fun retain(value: Value) = visit(value)
+
+    override fun applyDefault(value: Value) = isLibraryClass(value.type)
+
+    override fun apply(value: NewExpr) = isLibraryClass(value.baseType)
+    override fun apply(value: NewArrayExpr) = isLibraryClass(value.baseType)
+    override fun apply(value: NewMultiArrayExpr) = isLibraryClass(value.baseType)
+
+    override fun apply(value: StaticInvokeExpr) = isLibraryClass(value.method.declaringClass)
+    override fun apply(value: InstanceInvokeExpr) = isLibraryClass(value.method.declaringClass)
+    override fun apply(value: DynamicInvokeExpr) = isLibraryClass(value.method.declaringClass)
+
+    override fun apply(value: InstanceFieldRef) = isLibraryClass(value.field.declaringClass)
+    override fun apply(value: StaticFieldRef) = isLibraryClass(value.field.declaringClass)
+
+    override fun apply(value: Constant) = false
+
+    override fun apply(value: InstanceOfExpr) = isLibraryClass(value.checkType)
+    override fun apply(value: CastExpr) = isLibraryClass(value.castType)
+
+    /**
+     * Returns true if either [result1] or [result2] is true.
+     *
+     * @param result1 a boolean
+     * @param result2 a boolean
+     * @return true if either [result1] or [result2] is true
+     */
+    override fun accumulate(result1: Boolean, result2: Boolean) = result1 || result2
+
+    private fun isLibraryClass(type: Type) = type !is PrimType && isLibraryClass(type.toString())
+    private fun isLibraryClass(clazz: SootClass) = isLibraryClass(clazz.name)
+    private fun isLibraryClass(className: String) = libraryProject.classNames.contains(className)
+}
+
+/**
+ * Retains [Value]s that do not use user projects.
+ *
+ * @property libraryProject a library project
+ */
+@Suppress("MethodOverloading", "TooManyFunctions") // That is how JimpleValueVisitor works
+private class ValueUserUsageFilter(private val libraryProject: JavaProject) : JimpleValueVisitor<Boolean>() {
+    fun retain(value: Value) = visit(value)
+
+    override fun applyDefault(value: Value) = isNotUserClass(value.type)
+
+    override fun apply(value: NewExpr) = isNotUserClass(value.baseType)
+    override fun apply(value: NewArrayExpr) = isNotUserClass(value.baseType)
+    override fun apply(value: NewMultiArrayExpr) = isNotUserClass(value.baseType)
+
+    override fun apply(value: StaticInvokeExpr) = isNotUserClass(value.method.declaringClass)
+    override fun apply(value: InstanceInvokeExpr) = isNotUserClass(value.method.declaringClass)
+    override fun apply(value: DynamicInvokeExpr) = isNotUserClass(value.method.declaringClass)
+
+    override fun apply(value: InstanceFieldRef) = isNotUserClass(value.field.declaringClass)
+    override fun apply(value: StaticFieldRef) = isNotUserClass(value.field.declaringClass)
+
+    override fun apply(value: Constant) = true
+
+    override fun apply(value: InstanceOfExpr) = isNotUserClass(value.checkType)
+    override fun apply(value: CastExpr) = isNotUserClass(value.castType)
+
+    /**
+     * Returns true iff [result1] and [result2] are true.
+     *
+     * @param result1 a boolean
+     * @param result2 a boolean
+     * @return true iff [result1] and [result2] are true
+     */
+    override fun accumulate(result1: Boolean, result2: Boolean) = result1 && result2
+
+    private fun isNotUserClass(type: Type) = type is PrimType || isNotUserClass(type.toString())
+    private fun isNotUserClass(clazz: SootClass) = isNotUserClass(clazz.name)
+    private fun isNotUserClass(className: String) =
+        libraryProject.classNames.contains(className)
+            || Scene.v().forceResolve(className, SootClass.BODIES).isJavaLibraryClass
+}
+
+/**
+ * Exception for encountered values that are not supported by the [ValueClassFilter].
  */
 internal class UnsupportedValueException(message: String) : Exception(message)

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -258,7 +258,9 @@ internal object IntegrationTest : Spek({
             assertThatStructureMatches(
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
-                        node<JReturnStmt>()
+                        node<JInvokeStmt>(
+                            node<JReturnStmt>()
+                        )
                     )
                 ),
                 libraryUsageGraph

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/Helpers.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/Helpers.kt
@@ -4,13 +4,13 @@ import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import soot.SootClass
 import soot.SootMethod
-import soot.jimple.InvokeExpr
+import soot.jimple.StaticInvokeExpr
 
 internal const val NON_LIBRARY_CLASS = "java.lang.String"
 internal const val LIBRARY_CLASS =
     "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.Object1"
 
-internal fun constructInvokeExprMock(declaringClassName: String): InvokeExpr {
+internal fun constructInvokeExprMock(declaringClassName: String): StaticInvokeExpr {
     val clazz = mock<SootClass> {
         on { name } doReturn declaringClassName
     }

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitor.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitor.kt
@@ -1,5 +1,6 @@
 package org.cafejojo.schaapi.models.libraryusagegraph.jimple
 
+import soot.EquivalentValue
 import soot.Immediate
 import soot.Local
 import soot.Value
@@ -23,6 +24,8 @@ import soot.jimple.Ref
 import soot.jimple.StaticFieldRef
 import soot.jimple.StaticInvokeExpr
 import soot.jimple.UnopExpr
+import soot.jimple.toolkits.infoflow.AbstractDataSource
+import soot.jimple.toolkits.thread.synchronization.NewStaticLock
 
 /**
  * Recursively visits the [Value]s contained within a [Value] and accumulates a result based on the implemented methods.
@@ -57,6 +60,9 @@ abstract class JimpleValueVisitor<R> {
             is Expr -> visitExpr(value)
             is Ref -> visitRef(value)
             is Immediate -> visitImmediate(value)
+            is EquivalentValue -> accumulate(apply(value), visit(value.value))
+            is NewStaticLock -> apply(value)
+            is AbstractDataSource -> apply(value)
             else -> applyOther(value)
         }
 
@@ -286,6 +292,27 @@ abstract class JimpleValueVisitor<R> {
      * @param value a [CastExpr]
      */
     open fun apply(value: CastExpr) = applyDefault(value)
+
+    /**
+     * This method is called when an [EquivalentValue] is visited by [visit].
+     *
+     * @param value an [EquivalentValue]
+     */
+    open fun apply(value: EquivalentValue) = applyDefault(value)
+
+    /**
+     * This method is called when an [NewStaticLock] is visited by [visit].
+     *
+     * @param value an [NewStaticLock]
+     */
+    open fun apply(value: NewStaticLock) = applyDefault(value)
+
+    /**
+     * This method is called when an [AbstractDataSource] is visited by [visit].
+     *
+     * @param value an [AbstractDataSource]
+     */
+    open fun apply(value: AbstractDataSource) = applyDefault(value)
 
     /**
      * This method is called by default if an [apply] method is not overridden.

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitorTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimpleValueVisitorTest.kt
@@ -6,6 +6,7 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.context
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
+import soot.EquivalentValue
 import soot.Immediate
 import soot.IntType
 import soot.Modifier
@@ -21,6 +22,8 @@ import soot.jimple.IntConstant
 import soot.jimple.InvokeExpr
 import soot.jimple.Jimple
 import soot.jimple.Ref
+import soot.jimple.toolkits.infoflow.AbstractDataSource
+import soot.jimple.toolkits.thread.synchronization.NewStaticLock
 
 /**
  * Unit tests for [JimpleValueVisitor].
@@ -216,6 +219,28 @@ internal object JimpleValueVisitorTest : Spek({
 
             it("returns the value of a Constant") {
                 val value = IntConstant.v(384)
+
+                assertThat(visitor.visit(value)).containsExactly(value)
+            }
+        }
+
+        context("miscellaneous") {
+            it("returns the value and equivalent value of an EquivalentValue") {
+                val value = Jimple.v().newLocal("local", IntType.v())
+                val eqValue = EquivalentValue(value)
+
+                assertThat(visitor.visit(eqValue)).containsExactly(eqValue, value)
+            }
+
+            it("returns the value of a NewStaticLock") {
+                val clazz = SootClass("SomeClass", Modifier.PUBLIC)
+                val value = NewStaticLock(clazz)
+
+                assertThat(visitor.visit(value)).containsExactly(value)
+            }
+
+            it("returns the value of an AbstractDataSource") {
+                val value = AbstractDataSource(Any())
 
                 assertThat(visitor.visit(value)).containsExactly(value)
             }


### PR DESCRIPTION
The `ValueFilter` should be doing three things:
1. Filtering _out_ particular classes of `Value`s
2. Filtering _out_ `Value`s that use something from a user's own code (because we cannot use these statements)
3. Filtering _out_ `Value`s that do not use the library.

Previously, the `ValueFilter` did 1 and 2, but I was unable to implement 3 because it is incompatible with 2. This is because 2 is a universal check of absence ("for all not"), while 3 is an existential check of presence ("any").

Therefore, I have split the `ValueFilter` into three separate filters, each filter performing one of these three steps. I thought it would be easiest to do this using the `JimpleValueVisitor`, so I did.
