### PR TITLE
Pattern detector fix

### DIFF
--- a/modules/mining-pipeline/ccspan-pattern-detector/build.gradle
+++ b/modules/mining-pipeline/ccspan-pattern-detector/build.gradle
@@ -1,5 +1,13 @@
+apply from: "$rootDir/gradle/tests/module-integration.gradle"
+
+repositories {
+    maven { url "https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/" }
+}
+
 dependencies {
     compile project(":mining-pipeline")
 
     testCompile group: "com.nhaarman", name: "mockito-kotlin", version: mockitoKotlinVersion
+
+    moduleIntegrationTestCompile project(":models:jimple-library-usage-graph")
 }

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
@@ -84,7 +84,7 @@ internal class CCSpan<N : Node>(
 
     private fun identifyNonClosedSequences() {
         sequencesOfCurrentLength.forEach { (sequence, sequenceSupport, _) ->
-            sequencesOfPreviousLength.parallelStream()
+            sequencesOfPreviousLength.stream()
                 .filter {
                     it.isClosedSequence
                         && (it.sequence == sequence.pre() || it.sequence == sequence.post())
@@ -95,7 +95,7 @@ internal class CCSpan<N : Node>(
     }
 
     private fun calculateSupport(sequence: List<N>) =
-        sequenceSupportMap[sequence] ?: equalsSequences.parallelStream()
+        sequenceSupportMap[sequence] ?: equalsSequences.stream()
             .filter {
                 it.size >= sequence.size && nodeSequenceUtil.sequenceContainsSubSequence(it,
                     sequence,

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
@@ -84,7 +84,7 @@ internal class CCSpan<N : Node>(
 
     private fun identifyNonClosedSequences() {
         sequencesOfCurrentLength.forEach { (sequence, sequenceSupport, _) ->
-            sequencesOfPreviousLength.stream()
+            sequencesOfPreviousLength.parallelStream()
                 .filter {
                     it.isClosedSequence
                         && (it.sequence == sequence.pre() || it.sequence == sequence.post())

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
@@ -28,7 +28,7 @@ internal class CCSpan<N : Node>(
     private val sequencesOfPreviousLength = mutableSetOf<SequenceTriple<N>>()
     private val sequencesOfCurrentLength = mutableSetOf<SequenceTriple<N>>()
 
-    private val sequenceSupportMap = CustomEqualsHashMap<List<N>, Long>(List<N>::equals, List<N>::hashCode)
+    private val sequenceSupportMap = CustomEqualsHashMap<List<N>, Int>(List<N>::equals, List<N>::hashCode)
 
     private fun List<N>.pre() = this.subList(0, this.size - 1)
     private fun List<N>.post() = this.subList(1, this.size)
@@ -95,13 +95,9 @@ internal class CCSpan<N : Node>(
     }
 
     private fun calculateSupport(sequence: List<N>) =
-        sequenceSupportMap[sequence] ?: equalsSequences.stream()
-            .filter {
-                it.size >= sequence.size && nodeSequenceUtil.sequenceContainsSubSequence(it,
-                    sequence,
-                    nodeComparator)
-            }
-            .count()
+        sequenceSupportMap[sequence] ?: equalsSequences
+            .filter { it.size >= sequence.size }
+            .count { nodeSequenceUtil.sequenceContainsSubSequence(it, sequence, nodeComparator) }
             .also { sequenceSupportMap[sequence] = it }
 
     private fun shiftCurrent() {
@@ -111,4 +107,4 @@ internal class CCSpan<N : Node>(
     }
 }
 
-private data class SequenceTriple<N>(val sequence: List<N>, val support: Long, var isClosedSequence: Boolean = true)
+private data class SequenceTriple<N>(val sequence: List<N>, val support: Int, var isClosedSequence: Boolean = true)

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/module-integration-test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanIntegrationTest.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/module-integration-test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanIntegrationTest.kt
@@ -1,0 +1,48 @@
+package org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan
+
+import org.assertj.core.api.Assertions.assertThat
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.SootNameEquivalenceChanger
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import soot.IntType
+import soot.jimple.IntConstant
+import soot.jimple.Jimple
+
+/**
+ * Integration tests for the integration between [PatternDetector] and [GeneralizedNodeComparator].
+ */
+internal object CCSpanIntegrationTest : Spek({
+    describe("integration of CCSpan with GeneralizedNodeComparator") {
+        lateinit var patternDetector: PatternDetector<JimpleNode>
+
+        beforeGroup {
+            SootNameEquivalenceChanger.activate()
+        }
+
+        beforeEachTest {
+            val nodeComparator = GeneralizedNodeComparator()
+            patternDetector = PatternDetector(0, 10, nodeComparator)
+        }
+
+        it("can detect very simple patterns") {
+            val localA = Jimple.v().newLocal("local", IntType.v())
+            val stmtA2 = Jimple.v().newAssignStmt(localA, IntConstant.v(504))
+            val nodeA2 = JimpleNode(stmtA2)
+            val stmtA1 = Jimple.v().newAssignStmt(localA, IntConstant.v(591))
+            val nodeA1 = JimpleNode(stmtA1, mutableListOf(nodeA2))
+
+            val localB = Jimple.v().newLocal("local", IntType.v())
+            val stmtB2 = Jimple.v().newAssignStmt(localB, IntConstant.v(504))
+            val nodeB2 = JimpleNode(stmtB2)
+            val stmtB1 = Jimple.v().newAssignStmt(localB, IntConstant.v(591))
+            val nodeB1 = JimpleNode(stmtB1, mutableListOf(nodeB2))
+
+            val patterns = patternDetector.findPatterns(listOf(nodeA1, nodeB1))
+
+            assertThat(patterns).containsExactly(listOf(nodeA1, nodeA2))
+        }
+    }
+})

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparator.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/GeneralizedNodeComparator.kt
@@ -21,6 +21,7 @@ class GeneralizedNodeComparator : GeneralizedNodeComparator<JimpleNode> {
      */
     private val tagOrigins = HashMap<Int, Stmt>()
 
+    @Synchronized
     override fun satisfies(template: JimpleNode, instance: JimpleNode) =
         structuresAreEqual(template, instance) && generalizedValuesAreEqual(template, instance)
 

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/NodeSequenceUtil.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/NodeSequenceUtil.kt
@@ -15,7 +15,7 @@ class NodeSequenceUtil<N : Node> {
         sequence.indices.any { sequenceIndex ->
             subSequence.indices.all { subSequenceIndex ->
                 sequenceIndex + subSequenceIndex < sequence.size &&
-                    comparator.satisfies(sequence[sequenceIndex + subSequenceIndex], subSequence[subSequenceIndex])
+                    comparator.satisfies(subSequence[subSequenceIndex], sequence[sequenceIndex + subSequenceIndex])
             }
         }
 

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/NodeSequenceUtil.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/NodeSequenceUtil.kt
@@ -26,8 +26,8 @@ class NodeSequenceUtil<N : Node> {
      * @param minimumCount the minimum number of times a node needs to occur
      * @return the set of nodes occurring at least [minimumCount] times
      */
-    fun findFrequentNodesInSequences(sequences: Collection<List<N>>, minimumCount: Int): Map<N, Long> {
-        val nodeCounts = CustomEqualsHashMap<N, Long>(Node.Companion::equiv, Node::equivHashCode)
+    fun findFrequentNodesInSequences(sequences: Collection<List<N>>, minimumCount: Int): Map<N, Int> {
+        val nodeCounts = CustomEqualsHashMap<N, Int>(Node.Companion::equiv, Node::equivHashCode)
         val sequenceSets = sequences.map { sequence ->
             CustomEqualsHashSet<N>(Node.Companion::equiv, Node::equivHashCode).also { it.addAll(sequence) }
         }


### PR DESCRIPTION
This PR fixes two bugs:
1. It makes the pattern detector deterministic again by removing a `parallelStream()` where the order of execution was important (because the `GeneralizedNodeComparator` ~is~ was not thread-safe).
2. It makes sure that the `NodeSequenceUtil`'s `sequenceContainsSubSequence` uses the correct order of arguments when calling `GeneralizedNodeComparator`'s `satisfies` method.

The second bug is also explicitly covered by a regression test.