### PR TITLE
Retain `DefinitionStmt` if either uses library

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -389,7 +389,7 @@ internal object ClassGeneratorTest : Spek({
                 generateMethod("method", listOf(ifStmt, gotoStmt).map { JimpleNode(it) })
             }.sootClass.methods.last()
 
-            val newIfStmt = method.activeBody.units.elementAt(0) as IfStmt
+            val newIfStmt = method.activeBody.units.first() as IfStmt
             assertThat(newIfStmt.target).isEqualTo(newIfStmt)
         }
 

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
@@ -30,7 +30,7 @@ internal class StatementFilter(project: JavaProject) : Filter {
      */
     fun retain(unit: Unit) = when (unit) {
         is ThrowStmt -> valueFilter.retain(unit.op)
-        is DefinitionStmt -> valueFilter.retain(listOf(unit.leftOp, unit.rightOp))
+        is DefinitionStmt -> valueFilter.retain(unit.leftOp, unit.rightOp)
         is IfStmt -> true // defer to BranchStatementFilter
         is SwitchStmt -> true // defer to BranchStatementFilter
         is InvokeStmt -> valueFilter.retain(unit.invokeExpr)

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
@@ -30,7 +30,7 @@ internal class StatementFilter(project: JavaProject) : Filter {
      */
     fun retain(unit: Unit) = when (unit) {
         is ThrowStmt -> valueFilter.retain(unit.op)
-        is DefinitionStmt -> valueFilter.retain(unit.leftOp) && valueFilter.retain(unit.rightOp)
+        is DefinitionStmt -> valueFilter.retain(listOf(unit.leftOp, unit.rightOp))
         is IfStmt -> true // defer to BranchStatementFilter
         is SwitchStmt -> true // defer to BranchStatementFilter
         is InvokeStmt -> valueFilter.retain(unit.invokeExpr)

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -34,24 +34,16 @@ internal class ValueFilter(libraryProject: JavaProject) {
     )
 
     /**
-     * Returns true iff [value] is of a useful class (as determined by [ClassValueFilterRule]), has a library usage, and
-     * does not have any user project usages.
-     *
-     * @param value a [Value]
-     * @return true iff [value] is of a useful class (as determined by [ClassValueFilterRule]), has a library usage, and
-     * does not have any user project usages
-     */
-    fun retain(value: Value) = filterRules.all { it.retain(value) }
-
-    /**
      * Returns true iff all [values] are of a useful class (as determined by [ClassValueFilterRule]), at least one of
      * them has a library usage, and none of them has a user project usage.
+     *
+     * If [values] is empty, true is returned.
      *
      * @param values a collection of [Value]s
      * @return true iff all [values] are of a useful class (as determined by [ClassValueFilterRule]), at least one of
      * them has a library usage, and none of them has a user project usage
      */
-    fun retain(values: Iterable<Value>) = filterRules.all { it.retain(values) }
+    fun retain(vararg values: Value) = filterRules.all { it.retain(values.toList()) }
 }
 
 /**
@@ -67,13 +59,13 @@ private abstract class ValueFilterRule : JimpleValueVisitor<Boolean>() {
     fun retain(value: Value) = visit(value)
 
     /**
-     * Returns true iff all [values] should be retained.
+     * Returns true iff all [values] should be retained or [values] is empty.
      *
      * @param values a collection of [Value]s
-     * @return true iff all [values] should be retained
+     * @return true iff all [values] should be retained or [values] is empty
      */
-    fun retain(values: Iterable<Value>) =
-        values.fold(retain(values.first())) { acc, value -> accumulate(acc, retain(value)) }
+    fun retain(values: List<Value>) =
+        values.isEmpty() || values.fold(retain(values.first())) { acc, value -> accumulate(acc, retain(value)) }
 }
 
 /**

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -73,7 +73,7 @@ private abstract class ValueFilterRule : JimpleValueVisitor<Boolean>() {
      * @return true iff all [values] should be retained
      */
     fun retain(values: Iterable<Value>) =
-        values.fold(retain(values.elementAt(0))) { acc, value -> accumulate(acc, retain(value)) }
+        values.fold(retain(values.first())) { acc, value -> accumulate(acc, retain(value)) }
 }
 
 /**

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -44,12 +44,12 @@ internal class ValueFilter(libraryProject: JavaProject) {
     fun retain(value: Value) = filterRules.all { it.retain(value) }
 
     /**
-     * Returns true iff all [values] are of a useful class (as determined by [ClassValueFilterRule]), at least one of them
-     * has a library usage, and none of them has a user project usage.
+     * Returns true iff all [values] are of a useful class (as determined by [ClassValueFilterRule]), at least one of
+     * them has a library usage, and none of them has a user project usage.
      *
      * @param values a collection of [Value]s
-     * @return true iff all [values] are of a useful class (as determined by [ClassValueFilterRule]), at least one of them
-     * has a library usage, and none of them has a user project usage
+     * @return true iff all [values] are of a useful class (as determined by [ClassValueFilterRule]), at least one of
+     * them has a library usage, and none of them has a user project usage
      */
     fun retain(values: Iterable<Value>) = filterRules.all { it.retain(values) }
 }

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -179,16 +179,18 @@ internal object IntegrationTest : Spek({
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
                         node<JAssignStmt>(
-                            node<JTableSwitchStmt>(
-                                node<JGotoStmt>(
-                                    node<JReturnVoidStmt>()
-                                ),
-                                node<JInvokeStmt>(
+                            node<JAssignStmt>(
+                                node<JTableSwitchStmt>(
                                     node<JGotoStmt>(
                                         node<JReturnVoidStmt>()
-                                    )
-                                ),
-                                node<JReturnVoidStmt>()
+                                    ),
+                                    node<JInvokeStmt>(
+                                        node<JGotoStmt>(
+                                            node<JReturnVoidStmt>()
+                                        )
+                                    ),
+                                    node<JReturnVoidStmt>()
+                                )
                             )
                         )
                     )
@@ -209,15 +211,17 @@ internal object IntegrationTest : Spek({
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
                         node<JAssignStmt>(
-                            node<JLookupSwitchStmt>(
-                                node<JGotoStmt>(
-                                    node<JReturnStmt>()
-                                ),
-                                node<JGotoStmt>(
-                                    node<JReturnStmt>()
-                                ),
-                                node<JInvokeStmt>(
-                                    node<JReturnStmt>()
+                            node<JAssignStmt>(
+                                node<JLookupSwitchStmt>(
+                                    node<JGotoStmt>(
+                                        node<JReturnStmt>()
+                                    ),
+                                    node<JGotoStmt>(
+                                        node<JReturnStmt>()
+                                    ),
+                                    node<JInvokeStmt>(
+                                        node<JReturnStmt>()
+                                    )
                                 )
                             )
                         )
@@ -239,7 +243,9 @@ internal object IntegrationTest : Spek({
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
                         node<JAssignStmt>(
-                            node<JReturnStmt>()
+                            node<JAssignStmt>(
+                                node<JReturnStmt>()
+                            )
                         )
                     )
                 ),
@@ -276,7 +282,9 @@ internal object IntegrationTest : Spek({
             assertThatStructureMatches(
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
-                        node<JReturnStmt>()
+                        node<JAssignStmt>(
+                            node<JReturnStmt>()
+                        )
                     )
                 ),
                 libraryUsageGraph
@@ -291,7 +299,9 @@ internal object IntegrationTest : Spek({
 
             assertThatStructureMatches(
                 node<JAssignStmt>(
-                    node<JInvokeStmt>()
+                    node<JInvokeStmt>(
+                        node<JAssignStmt>()
+                    )
                 ),
                 libraryUsageGraph
             )
@@ -360,22 +370,26 @@ internal object IntegrationTest : Spek({
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
                         node<JAssignStmt>(
-                            node<JIfStmt>(
-                                node<JInvokeStmt>(
-                                    node<JIfStmt>(
-                                        node<JInvokeStmt>(
-                                            node<JGotoStmt>(
-                                                PreviousBranchNode()
-                                            )
-                                        ),
-                                        node<JInvokeStmt>(
-                                            node<JGotoStmt>(
-                                                PreviousBranchNode()
+                            node<JAssignStmt>(
+                                node<JIfStmt>(
+                                    node<JInvokeStmt>(
+                                        node<JAssignStmt>(
+                                            node<JIfStmt>(
+                                                node<JInvokeStmt>(
+                                                    node<JGotoStmt>(
+                                                        PreviousBranchNode()
+                                                    )
+                                                ),
+                                                node<JInvokeStmt>(
+                                                    node<JGotoStmt>(
+                                                        PreviousBranchNode()
+                                                    )
+                                                )
                                             )
                                         )
-                                    )
-                                ),
-                                node<JReturnVoidStmt>()
+                                    ),
+                                    node<JReturnVoidStmt>()
+                                )
                             )
                         )
                     )
@@ -394,22 +408,26 @@ internal object IntegrationTest : Spek({
                 node<JAssignStmt>(
                     node<JInvokeStmt>(
                         node<JAssignStmt>(
-                            node<JIfStmt>(
-                                node<JInvokeStmt>(
-                                    node<JIfStmt>(
-                                        node<JGotoStmt>(
-                                            node<JGotoStmt>(
-                                                PreviousBranchNode()
-                                            )
-                                        ),
-                                        node<JInvokeStmt>(
-                                            node<JGotoStmt>(
-                                                PreviousBranchNode()
+                            node<JAssignStmt>(
+                                node<JIfStmt>(
+                                    node<JInvokeStmt>(
+                                        node<JAssignStmt>(
+                                            node<JIfStmt>(
+                                                node<JGotoStmt>(
+                                                    node<JGotoStmt>(
+                                                        PreviousBranchNode()
+                                                    )
+                                                ),
+                                                node<JInvokeStmt>(
+                                                    node<JGotoStmt>(
+                                                        PreviousBranchNode()
+                                                    )
+                                                )
                                             )
                                         )
-                                    )
-                                ),
-                                node<JReturnVoidStmt>()
+                                    ),
+                                    node<JReturnVoidStmt>()
+                                )
                             )
                         )
                     )

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
@@ -36,11 +36,11 @@ internal object StatementFilterTest : Spek({
                 on { leftOp } doReturn libraryValue
                 on { rightOp } doReturn libraryValue
             })
-            assertThatItDoesNotRetain(mock<DefinitionStmt> {
+            assertThatItRetains(mock<DefinitionStmt> {
                 on { leftOp } doReturn nonLibraryValue
                 on { rightOp } doReturn libraryValue
             })
-            assertThatItDoesNotRetain(mock<DefinitionStmt> {
+            assertThatItRetains(mock<DefinitionStmt> {
                 on { leftOp } doReturn libraryValue
                 on { rightOp } doReturn nonLibraryValue
             })

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilterTest.kt
@@ -252,8 +252,12 @@ internal object ValueFilterTest : Spek({
     }
 
     describe("filtering multiple values at once") {
+        it("retains if no values are given") {
+            assertThatItRetains()
+        }
+
         it("retains both values if they are both valid") {
-            assertThatItRetains(listOf<Value>(
+            assertThatItRetains(
                 mock<UnopExpr> {
                     on { type } doReturn libraryType
                     on { op } doReturn libraryInvokeExpr
@@ -262,11 +266,11 @@ internal object ValueFilterTest : Spek({
                     on { type } doReturn libraryType
                     on { op } doReturn libraryInvokeExpr
                 }
-            ))
+            )
         }
 
         it("filters out both values if either has an undesired class") {
-            assertThatItDoesNotRetain(listOf(
+            assertThatItDoesNotRetain(
                 mock<UnopExpr> {
                     on { type } doReturn libraryType
                     on { op } doReturn libraryInvokeExpr
@@ -274,8 +278,8 @@ internal object ValueFilterTest : Spek({
                 mock<NewStaticLock> {
                     on { type } doReturn libraryType
                 }
-            ))
-            assertThatItDoesNotRetain(listOf(
+            )
+            assertThatItDoesNotRetain(
                 mock<NewStaticLock> {
                     on { type } doReturn libraryType
                 },
@@ -283,19 +287,19 @@ internal object ValueFilterTest : Spek({
                     on { type } doReturn libraryType
                     on { op } doReturn libraryInvokeExpr
                 }
-            ))
-            assertThatItDoesNotRetain(listOf<Value>(
+            )
+            assertThatItDoesNotRetain(
                 mock<NewStaticLock> {
                     on { type } doReturn libraryType
                 },
                 mock<NewStaticLock> {
                     on { type } doReturn libraryType
                 }
-            ))
+            )
         }
 
         it("filters out both values if neither has a library usage") {
-            assertThatItRetains(listOf<Value>(
+            assertThatItRetains(
                 mock<UnopExpr> {
                     on { type } doReturn libraryType
                     on { op } doReturn libraryInvokeExpr
@@ -304,8 +308,8 @@ internal object ValueFilterTest : Spek({
                     on { type } doReturn nonLibraryType
                     on { op } doReturn nonLibraryInvokeExpr
                 }
-            ))
-            assertThatItRetains(listOf<Value>(
+            )
+            assertThatItRetains(
                 mock<UnopExpr> {
                     on { type } doReturn nonLibraryType
                     on { op } doReturn nonLibraryInvokeExpr
@@ -314,8 +318,8 @@ internal object ValueFilterTest : Spek({
                     on { type } doReturn libraryType
                     on { op } doReturn libraryInvokeExpr
                 }
-            ))
-            assertThatItDoesNotRetain(listOf<Value>(
+            )
+            assertThatItDoesNotRetain(
                 mock<UnopExpr> {
                     on { type } doReturn nonLibraryType
                     on { op } doReturn nonLibraryInvokeExpr
@@ -324,7 +328,7 @@ internal object ValueFilterTest : Spek({
                     on { type } doReturn nonLibraryType
                     on { op } doReturn nonLibraryInvokeExpr
                 }
-            ))
+            )
         }
     }
 })
@@ -336,14 +340,10 @@ private fun constructDeclaringClass(declaringClassName: String) = mock<SootClass
 private fun assertThatItDoesNotRecognize(value: Value) =
     assertThrows<UnsupportedValueException> { ValueFilter(libraryProject).retain(value) }
 
-private fun assertThatItRetains(value: Value) =
-    assertThat(ValueFilter(libraryProject).retain(value)).isTrue()
+@Suppress("SpreadOperator") // Inputs are small
+private fun assertThatItRetains(vararg values: Value) =
+    assertThat(ValueFilter(libraryProject).retain(*values)).isTrue()
 
-private fun assertThatItRetains(values: Iterable<Value>) =
-    assertThat(ValueFilter(libraryProject).retain(values)).isTrue()
-
-private fun assertThatItDoesNotRetain(value: Value) =
-    assertThat(ValueFilter(libraryProject).retain(value)).isFalse()
-
-private fun assertThatItDoesNotRetain(values: Iterable<Value>) =
-    assertThat(ValueFilter(libraryProject).retain(values)).isFalse()
+@Suppress("SpreadOperator") // Inputs are small
+private fun assertThatItDoesNotRetain(vararg values: Value) =
+    assertThat(ValueFilter(libraryProject).retain(*values)).isFalse()


### PR DESCRIPTION
While #255 separated the `ValueFilter` into three parts, this should also be done in the `StatementFilter` because it should retain a `DefinitionStmt` even if only one of the two uses the library.
