### PR TITLE
Restructure GitHub test reporter

### DIFF
--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/CheckReporter.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/CheckReporter.kt
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.jackson.mapper
 import com.github.kittinunf.fuel.jackson.responseObject
+import org.cafejojo.schaapi.validationpipeline.githubtestreporter.githubapi.GitHubApi
+import org.cafejojo.schaapi.validationpipeline.githubtestreporter.githubapi.getResultOrThrowException
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiver.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiver.kt
@@ -4,8 +4,8 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import org.cafejojo.schaapi.validationpipeline.events.ValidationRequestReceivedEvent
-import org.cafejojo.schaapi.validationpipeline.githubtestreporter.events.CheckSuiteEvent
-import org.cafejojo.schaapi.validationpipeline.githubtestreporter.events.InstallationEvent
+import org.cafejojo.schaapi.validationpipeline.githubtestreporter.webhookevents.CheckSuiteEvent
+import org.cafejojo.schaapi.validationpipeline.githubtestreporter.webhookevents.InstallationEvent
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Controller

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/githubapi/CustomHttpClient.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/githubapi/CustomHttpClient.kt
@@ -17,7 +17,7 @@
  * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package org.cafejojo.schaapi.validationpipeline.githubtestreporter
+package org.cafejojo.schaapi.validationpipeline.githubtestreporter.githubapi
 
 import com.github.kittinunf.fuel.core.Client
 import com.github.kittinunf.fuel.core.FuelError

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/githubapi/FuelConfiguration.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/githubapi/FuelConfiguration.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.validationpipeline.githubtestreporter
+package org.cafejojo.schaapi.validationpipeline.githubtestreporter.githubapi
 
 import com.github.kittinunf.fuel.core.Client
 import com.github.kittinunf.fuel.core.FuelManager

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/githubapi/GitHubApi.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/githubapi/GitHubApi.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.validationpipeline.githubtestreporter
+package org.cafejojo.schaapi.validationpipeline.githubtestreporter.githubapi
 
 import com.github.kittinunf.fuel.core.FuelError
 import com.github.kittinunf.fuel.core.Method

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/githubapi/JsonObjectBuilder.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/githubapi/JsonObjectBuilder.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.validationpipeline.githubtestreporter
+package org.cafejojo.schaapi.validationpipeline.githubtestreporter.githubapi
 
 import java.util.ArrayDeque
 import java.util.Deque

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/webhookevents/CheckSuiteEvent.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/webhookevents/CheckSuiteEvent.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.validationpipeline.githubtestreporter.events
+package org.cafejojo.schaapi.validationpipeline.githubtestreporter.webhookevents
 
 internal data class CheckSuiteEvent(
     val installation: Installation,

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/webhookevents/InstallationEvent.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/webhookevents/InstallationEvent.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.validationpipeline.githubtestreporter.events
+package org.cafejojo.schaapi.validationpipeline.githubtestreporter.webhookevents
 
 internal data class InstallationEvent(
     val installation: Installation,

--- a/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/webhookevents/Shared.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/webhookevents/Shared.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.validationpipeline.githubtestreporter.events
+package org.cafejojo.schaapi.validationpipeline.githubtestreporter.webhookevents
 
 internal data class Installation(val id: Int = 0, val account: Account? = null)
 

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/CheckReporterTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/CheckReporterTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.mock
 import net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
+import org.cafejojo.schaapi.validationpipeline.githubtestreporter.githubapi.json
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
 import java.util.concurrent.TimeUnit

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/Helpers.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/Helpers.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
+import org.cafejojo.schaapi.validationpipeline.githubtestreporter.githubapi.FuelConfiguration
 import org.json.JSONObject
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/IntegrationTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/IntegrationTest.kt
@@ -5,6 +5,7 @@ import com.nhaarman.mockito_kotlin.mock
 import net.javacrumbs.jsonunit.fluent.JsonFluentAssert.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.entry
+import org.cafejojo.schaapi.validationpipeline.githubtestreporter.githubapi.json
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test

--- a/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiverTest.kt
+++ b/modules/validation-pipeline/github-test-reporter/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubtestreporter/WebHookReceiverTest.kt
@@ -7,6 +7,7 @@ import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.cafejojo.schaapi.validationpipeline.events.ValidationRequestReceivedEvent
+import org.cafejojo.schaapi.validationpipeline.githubtestreporter.githubapi.json
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.it
 import org.springframework.context.ApplicationEventPublisher


### PR DESCRIPTION
Improves the structure of the GitHub test reporter a bit.

It now looks as follows:
![image](https://user-images.githubusercontent.com/15815208/41651760-9e916990-7481-11e8-98b9-519cb7269e47.png)
