### PR TITLE
Specify that pom file has to be in root of project

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
@@ -99,6 +99,7 @@ class MavenProjectSearchOptions(
             `in`("file")
             filename("pom")
             extension("xml")
+            path("/")
         }
     }
 }


### PR DESCRIPTION
Ensure the pom is in the correct location before downloading projects.

With this change, no project we download gives a warning as the pom file is now always in the correct location. (Before we downloaded a lot of projects which had pom files but not in the desired location).