### PR TITLE
Remove copy-dependencies step in Maven compiler

### DIFF
--- a/modules/application/src/module-integration-test/resources/user/a/pom.xml
+++ b/modules/application/src/module-integration-test/resources/user/a/pom.xml
@@ -23,5 +23,10 @@
             <version>1.0.0</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>25.1-jre</version>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/application/src/module-integration-test/resources/user/a/src/main/java/org/cafejojo/schaapi/test/user/a/UserClass.java
+++ b/modules/application/src/module-integration-test/resources/user/a/src/main/java/org/cafejojo/schaapi/test/user/a/UserClass.java
@@ -1,10 +1,14 @@
 package org.cafejojo.schaapi.test.user.a;
 
+import com.google.common.base.Charsets;
 import org.cafejojo.schaapi.test.library.LibraryClass;
+
+import java.nio.charset.Charset;
 
 public class UserClass {
     public int userFoo() {
         int x = new LibraryClass().libraryFoo();
+        Charset utf8 = Charsets.UTF_8;
         return x;
     }
 

--- a/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompiler.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompiler.kt
@@ -50,6 +50,7 @@ class JavaMavenProjectCompiler : ProjectCompiler<JavaMavenProject> {
             it.relativeTo(project.classDir).toString().dropLast(".class".length).replace(File.separatorChar, '.')
         }.toSet()
 
+        project.dependencies = emptySet()
         project.classpath = project.classDir.absolutePath
 
         if (project.classes.isEmpty()) {

--- a/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompiler.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompiler.kt
@@ -25,7 +25,7 @@ class JavaMavenProjectCompiler : ProjectCompiler<JavaMavenProject> {
     private fun runMaven(project: JavaMavenProject) {
         val request = DefaultInvocationRequest().apply {
             baseDirectory = project.projectDir
-            goals = listOf("clean", "install", "dependency:copy-dependencies")
+            goals = listOf("clean", "install")
             isBatchMode = true
             javaHome = File(System.getProperty("java.home"))
             mavenOpts = "-DskipTests=true"
@@ -49,10 +49,8 @@ class JavaMavenProjectCompiler : ProjectCompiler<JavaMavenProject> {
         project.classNames = project.classes.map {
             it.relativeTo(project.classDir).toString().dropLast(".class".length).replace(File.separatorChar, '.')
         }.toSet()
-        project.dependencies = project.dependencyDir.listFiles().orEmpty().toSet()
 
-        val classpathDirectories = project.dependencies + project.classDir
-        project.classpath = classpathDirectories.joinToString(File.pathSeparator) { it.absolutePath }
+        project.classpath = project.classDir.absolutePath
 
         if (project.classes.isEmpty()) {
             logger.warn { "Maven project at ${project.projectDir.path} does not contain any classes." }

--- a/modules/mining-pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompilerTest.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompilerTest.kt
@@ -93,12 +93,9 @@ internal object JavaMavenProjectCompilerTest : Spek({
             assertThat(project.classNames).containsExactlyInAnyOrder(
                 "org.cafejojo.schaapi.test.MyClass"
             )
-            assertThat(project.dependencies).containsExactlyInAnyOrder(
-                target.resolve("target/dependency/zip4j-1.3.2.jar")
-            )
+            assertThat(project.dependencies).isEmpty()
             assertThat(project.classpath.split(File.pathSeparator)).containsExactlyInAnyOrder(
-                target.resolve("target/classes").absolutePath,
-                target.resolve("target/dependency").resolve("zip4j-1.3.2.jar").absolutePath
+                target.resolve("target/classes").absolutePath
             )
         }
     }


### PR DESCRIPTION
This turned out not to be necessary for the pipeline (analyzing the compiled project for LUGs still works without it), and was quite time and space intensive. The smoke test has been modified to include an external dependency in one of the user projects, do demonstrate that the mining pipeline still works.