### PR TITLE
Ensure that clone of custom `JimpleLocal` is custom `JimpleLocal`

### DIFF
--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/SootNameEquivalenceChanger.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/SootNameEquivalenceChanger.kt
@@ -79,4 +79,6 @@ private class NameIgnoringJimpleLocal(name: String?, type: Type?) : JimpleLocal(
 
     @Suppress("MagicNumber") // Necessary for compatibility with Soot
     override fun equivHashCode() = 31 + (type?.hashCode() ?: 0)
+
+    override fun clone() = NameIgnoringJimpleLocal(name, type)
 }


### PR DESCRIPTION
When the `clone` method is called on a `NameIgnoringJimpleLocal` it should return a `NameIgnoringJimpleLocal` instead of a `JimpleLocal`.