### PR TITLE
Custom equals sub-list

### DIFF
--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
@@ -57,7 +57,7 @@ internal class CCSpan<N : Node>(
             subSequenceLength++
         }
 
-        return frequentClosedContiguousSequences
+        return frequentClosedContiguousSequences.map { it.toList() }
     }
 
     private fun findFrequentSingletonSequences() {

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
@@ -20,9 +20,7 @@ internal class CCSpan<N : Node>(
     private val minimumSupport: Int,
     private val nodeComparator: GeneralizedNodeComparator<N>
 ) {
-    private val equalsSequences = sequences.map { sequence ->
-        CustomEqualsList<N>(Node.Companion::equiv, Node::equivHashCode).also { it.addAll(sequence) }
-    }
+    private val equalsSequences = sequences.map { CustomEqualsList(it, Node.Companion::equiv, Node::equivHashCode) }
     private val nodeSequenceUtil = NodeSequenceUtil<N>()
 
     private val sequencesOfPreviousLength = mutableSetOf<SequenceTriple<N>>()

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollections.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollections.kt
@@ -186,6 +186,16 @@ class CustomEqualsList<K>(
             customHash
         )
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is CustomEqualsList<*>) return false
+        if (this.size != other.size) return false
+
+        return (0 until innerList.size).all { this.innerList[it] == other.innerList[it] }
+    }
+
+    override fun hashCode() = innerList.hashCode()
+
     private fun wrapElement(key: K) = EqualsWrapper(key, customEquals, customHash)
 }
 

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollections.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollections.kt
@@ -110,6 +110,17 @@ class CustomEqualsList<K>(
     override val size: Int
         get() = innerList.size
 
+    /**
+     * Constructs a new [CustomEqualsList] that contains [elements].
+     */
+    constructor(
+        elements: Collection<K>,
+        customEquals: (K, Any?) -> Boolean,
+        customHash: (K) -> Int
+    ) : this(customEquals, customHash) {
+        addAll(elements)
+    }
+
     override fun contains(element: K) = innerList.contains(wrapElement(element))
 
     override fun containsAll(elements: Collection<K>) = innerList.containsAll(elements.map { wrapElement(it) })
@@ -169,7 +180,11 @@ class CustomEqualsList<K>(
     override fun set(index: Int, element: K) = innerList.set(index, wrapElement(element)).value
 
     override fun subList(fromIndex: Int, toIndex: Int) =
-        innerList.subList(fromIndex, toIndex).map { it.value }.toMutableList()
+        CustomEqualsList(
+            innerList.subList(fromIndex, toIndex).map { it.value }.toMutableList(),
+            customEquals,
+            customHash
+        )
 
     private fun wrapElement(key: K) = EqualsWrapper(key, customEquals, customHash)
 }

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollections.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollections.kt
@@ -181,7 +181,7 @@ class CustomEqualsList<K>(
 
     override fun subList(fromIndex: Int, toIndex: Int) =
         CustomEqualsList(
-            innerList.subList(fromIndex, toIndex).map { it.value }.toMutableList(),
+            innerList.subList(fromIndex, toIndex).map { it.value },
             customEquals,
             customHash
         )

--- a/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollectionsTest.kt
+++ b/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/CustomEqualsCollectionsTest.kt
@@ -458,7 +458,9 @@ internal object CustomEqualsListTest : Spek({
 
             list.addAll(elements)
 
-            assertThat(list.subList(1, 3)).containsExactly(elements[1], elements[2])
+            assertThat(list.subList(1, 3))
+                .isInstanceOf(CustomEqualsList::class.java)
+                .containsExactly(elements[1], elements[2])
         }
 
         it("can be iterated over forwards") {


### PR DESCRIPTION
When `subList` is called on a `CustomEqualsList`, the sub-list should also be a `CustomEqualsList`.