### PR TITLE
Always initialize local variables in the ClassGenerator

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -128,12 +128,10 @@ internal class ClassGenerator(className: String) {
         val defaultValue = getDefaultValueForType(local.type)
         val assignStatement = Jimple.v().newAssignStmt(local, defaultValue)
 
-        val identityStatements = jimpleBody.units.takeWhile { it is IdentityStmt }
-        if (identityStatements.isEmpty()) {
+        if (jimpleBody.units.first is IdentityStmt)
+            jimpleBody.units.insertAfter(assignStatement, jimpleBody.units.last { it is IdentityStmt })
+        else
             jimpleBody.units.addFirst(assignStatement)
-        } else {
-            jimpleBody.units.insertAfter(assignStatement, identityStatements.last())
-        }
     }
 
     private fun addReturnStatement(jimpleBody: Body): Type {

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -128,7 +128,7 @@ internal class ClassGenerator(className: String) {
         val defaultValue = getDefaultValueForType(local.type)
         val assignStatement = Jimple.v().newAssignStmt(local, defaultValue)
 
-        if (jimpleBody.units.first is IdentityStmt)
+        if (jimpleBody.units.size > 0 && jimpleBody.units.first is IdentityStmt)
             jimpleBody.units.insertAfter(assignStatement, jimpleBody.units.last { it is IdentityStmt })
         else
             jimpleBody.units.addFirst(assignStatement)

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -481,23 +481,21 @@ internal object ClassGeneratorTest : Spek({
             }.sootClass.methods.last()
             val methodStatements = method.retrieveActiveBody().units
 
-            assertThat(methodStatements.count { it is AssignStmt && it.leftOp.type is IntType }).isEqualTo(10)
-            assertThat(methodStatements.count { it is AssignStmt && it.leftOp.type is DoubleType }).isEqualTo(2)
-            assertThat(methodStatements.count { it is AssignStmt && it.leftOp.type is FloatType }).isEqualTo(2)
-            assertThat(methodStatements.count { it is AssignStmt && it.leftOp.type is LongType }).isEqualTo(2)
+            assertThat(methodStatements).filteredOn { it is AssignStmt && it.leftOp.type is IntType }.hasSize(10)
+            assertThat(methodStatements).filteredOn { it is AssignStmt && it.leftOp.type is DoubleType }.hasSize(2)
+            assertThat(methodStatements).filteredOn { it is AssignStmt && it.leftOp.type is FloatType }.hasSize(2)
+            assertThat(methodStatements).filteredOn { it is AssignStmt && it.leftOp.type is LongType }.hasSize(2)
         }
 
         it("should add an initialization statement for an object type") {
             val local = Jimple.v().newLocal("local", NullType.v())
 
             val method = ClassGenerator("test").apply {
-                generateMethod("method", listOf(
-                    Jimple.v().newAssignStmt(local, NullConstant.v())
-                ).map { JimpleNode(it) })
+                generateMethod("method", listOf(JimpleNode(Jimple.v().newAssignStmt(local, NullConstant.v()))))
             }.sootClass.methods.last()
             val methodStatements = method.retrieveActiveBody().units
 
-            assertThat(methodStatements.count { it is AssignStmt && it.leftOp.type is NullType }).isEqualTo(2)
+            assertThat(methodStatements).filteredOn { it is AssignStmt && it.leftOp.type is NullType }.hasSize(2)
         }
     }
 })

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -9,17 +9,26 @@ import org.jetbrains.spek.api.dsl.it
 import soot.AbstractSootFieldRef
 import soot.BooleanType
 import soot.CharType
+import soot.DoubleType
+import soot.FloatType
 import soot.IntType
+import soot.LongType
 import soot.Modifier
+import soot.NullType
 import soot.RefType
 import soot.Scene
 import soot.SootClass
 import soot.SootField
 import soot.VoidType
+import soot.jimple.AssignStmt
+import soot.jimple.DoubleConstant
+import soot.jimple.FloatConstant
 import soot.jimple.GotoStmt
 import soot.jimple.IfStmt
 import soot.jimple.IntConstant
 import soot.jimple.Jimple
+import soot.jimple.LongConstant
+import soot.jimple.NullConstant
 import soot.jimple.Stmt
 import soot.jimple.StringConstant
 import soot.jimple.SwitchStmt
@@ -289,7 +298,7 @@ internal object ClassGeneratorTest : Spek({
             generateMethod("method", listOf(assignC, returnC, assignCAgain).map { JimpleNode(it) })
         }.sootClass.methods.last()
 
-        assertThat(jimpleMethod.activeBody.units).hasSize(2)
+        assertThat(jimpleMethod.activeBody.units).hasSize(3)
     }
 
     describe("replacing missing targets") {
@@ -445,5 +454,50 @@ internal object ClassGeneratorTest : Spek({
         }.sootClass.methods.last()
 
         assertThat(method.retrieveActiveBody().locals).containsExactly(local)
+    }
+
+    describe("initialization of locals") {
+        it("should add an initialization statement for all primitive types") {
+            val booleanLocal = Jimple.v().newLocal("booleanLocal", IntType.v())
+            val byteLocal = Jimple.v().newLocal("byteLocal", IntType.v())
+            val charLocal = Jimple.v().newLocal("charLocal", IntType.v())
+            val doubleLocal = Jimple.v().newLocal("doubleLocal", DoubleType.v())
+            val floatLocal = Jimple.v().newLocal("floatLocal", FloatType.v())
+            val intLocal = Jimple.v().newLocal("intLocal", IntType.v())
+            val longLocal = Jimple.v().newLocal("longLocal", LongType.v())
+            val shortLocal = Jimple.v().newLocal("shortLocal", IntType.v())
+
+            val method = ClassGenerator("test").apply {
+                generateMethod("method", listOf(
+                    Jimple.v().newAssignStmt(booleanLocal, IntConstant.v(0)),
+                    Jimple.v().newAssignStmt(byteLocal, IntConstant.v(0)),
+                    Jimple.v().newAssignStmt(charLocal, IntConstant.v(0)),
+                    Jimple.v().newAssignStmt(doubleLocal, DoubleConstant.v(0.0)),
+                    Jimple.v().newAssignStmt(floatLocal, FloatConstant.v(0f)),
+                    Jimple.v().newAssignStmt(intLocal, IntConstant.v(0)),
+                    Jimple.v().newAssignStmt(longLocal, LongConstant.v(0)),
+                    Jimple.v().newAssignStmt(shortLocal, IntConstant.v(0))
+                ).map { JimpleNode(it) })
+            }.sootClass.methods.last()
+            val methodStatements = method.retrieveActiveBody().units
+
+            assertThat(methodStatements.count { it is AssignStmt && it.leftOp.type is IntType }).isEqualTo(10)
+            assertThat(methodStatements.count { it is AssignStmt && it.leftOp.type is DoubleType }).isEqualTo(2)
+            assertThat(methodStatements.count { it is AssignStmt && it.leftOp.type is FloatType }).isEqualTo(2)
+            assertThat(methodStatements.count { it is AssignStmt && it.leftOp.type is LongType }).isEqualTo(2)
+        }
+
+        it("should add an initialization statement for an object type") {
+            val local = Jimple.v().newLocal("local", NullType.v())
+
+            val method = ClassGenerator("test").apply {
+                generateMethod("method", listOf(
+                    Jimple.v().newAssignStmt(local, NullConstant.v())
+                ).map { JimpleNode(it) })
+            }.sootClass.methods.last()
+            val methodStatements = method.retrieveActiveBody().units
+
+            assertThat(methodStatements.count { it is AssignStmt && it.leftOp.type is NullType }).isEqualTo(2)
+        }
     }
 })


### PR DESCRIPTION
Because values may be initialized only in one branch of a method CFG, they may be uninitialised when called upon. This change initializes all locals that are not parameters, at the beginning of the method (after all identity statements).

Fixes #272 