### PR TITLE
Jimple-aware enumerator

### DIFF
--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -5,8 +5,8 @@ import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
 import org.cafejojo.schaapi.miningpipeline.MiningPipeline
 import org.cafejojo.schaapi.miningpipeline.PatternFilter
-import org.cafejojo.schaapi.miningpipeline.miner.directory.DirectorySearchOptions
 import org.cafejojo.schaapi.miningpipeline.miner.directory.DirectoryProjectMiner
+import org.cafejojo.schaapi.miningpipeline.miner.directory.DirectorySearchOptions
 import org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan.CCSpanPatternDetector
 import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.EmptyLoopPatternFilterRule
 import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.IncompleteInitPatternFilterRule
@@ -15,6 +15,7 @@ import org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.JavaMavenPr
 import org.cafejojo.schaapi.miningpipeline.testgenerator.jimpleevosuite.TestGenerator
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.JimpleLibraryUsageGraphGenerator
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimplePathEnumerator
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import java.io.File
 
@@ -61,7 +62,7 @@ internal class DirectoryMiningCommandLineInterface {
             libraryUsageGraphGenerator = JimpleLibraryUsageGraphGenerator,
             patternDetector = CCSpanPatternDetector(
                 patternDetectorMinCount,
-                maxSequenceLength,
+                { node -> JimplePathEnumerator(node, maxSequenceLength) },
                 GeneralizedNodeComparator()
             ),
             patternFilter = PatternFilter(

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -6,8 +6,8 @@ import org.apache.commons.cli.Option
 import org.apache.commons.cli.Options
 import org.cafejojo.schaapi.miningpipeline.MiningPipeline
 import org.cafejojo.schaapi.miningpipeline.PatternFilter
-import org.cafejojo.schaapi.miningpipeline.miner.github.MavenProjectSearchOptions
 import org.cafejojo.schaapi.miningpipeline.miner.github.GitHubProjectMiner
+import org.cafejojo.schaapi.miningpipeline.miner.github.MavenProjectSearchOptions
 import org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan.CCSpanPatternDetector
 import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.EmptyLoopPatternFilterRule
 import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.IncompleteInitPatternFilterRule
@@ -17,6 +17,7 @@ import org.cafejojo.schaapi.miningpipeline.projectcompiler.javamaven.JavaMavenPr
 import org.cafejojo.schaapi.miningpipeline.testgenerator.jimpleevosuite.TestGenerator
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.JimpleLibraryUsageGraphGenerator
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimplePathEnumerator
 import org.cafejojo.schaapi.models.project.JavaJarProject
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import java.io.File
@@ -114,7 +115,7 @@ internal class GitHubMiningCommandLineInterface {
             libraryUsageGraphGenerator = JimpleLibraryUsageGraphGenerator,
             patternDetector = CCSpanPatternDetector(
                 patternDetectorMinCount,
-                maxSequenceLength,
+                { node -> JimplePathEnumerator(node, maxSequenceLength) },
                 GeneralizedNodeComparator()
             ),
             patternFilter = PatternFilter(

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanPatternDetector.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanPatternDetector.kt
@@ -11,11 +11,11 @@ import org.cafejojo.schaapi.models.PathEnumerator
  */
 class CCSpanPatternDetector<N : Node>(
     private val minimumCount: Int,
-    private val maximumSequenceLength: Int,
+    private val enumerator: (N) -> PathEnumerator<N>,
     private val comparator: GeneralizedNodeComparator<N>
 ) : PatternDetector<N> {
     override fun findPatterns(graphs: List<N>): List<Pattern<N>> {
-        val sequences = graphs.flatMap { PathEnumerator(it, maximumSequenceLength).enumerate() }
+        val sequences = graphs.flatMap { enumerator(it).enumerate() }
         return CCSpan(sequences, minimumCount, comparator).findFrequentPatterns()
     }
 }

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/module-integration-test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanIntegrationTest.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/module-integration-test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanIntegrationTest.kt
@@ -3,6 +3,7 @@ package org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan
 import org.assertj.core.api.Assertions.assertThat
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimplePathEnumerator
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.SootNameEquivalenceChanger
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
@@ -24,7 +25,7 @@ internal object CCSpanIntegrationTest : Spek({
 
         beforeEachTest {
             val nodeComparator = GeneralizedNodeComparator()
-            patternDetector = CCSpanPatternDetector(0, 10, nodeComparator)
+            patternDetector = CCSpanPatternDetector(0, { node -> JimplePathEnumerator(node, 10) }, nodeComparator)
         }
 
         it("can detect very simple patterns") {

--- a/modules/mining-pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpanPatternDetector.kt
+++ b/modules/mining-pipeline/prefix-span-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpanPatternDetector.kt
@@ -12,7 +12,7 @@ import org.cafejojo.schaapi.models.PathEnumerator
  */
 class PrefixSpanPatternDetector<N : Node>(
     private val minimumCount: Int,
-    private val maximumSequenceLength: Int,
+    private val enumerator: (N) -> PathEnumerator<N>,
     private val comparator: GeneralizedNodeComparator<N>
 ) : PatternDetector<N> {
     private companion object : KLogging()
@@ -20,7 +20,7 @@ class PrefixSpanPatternDetector<N : Node>(
     override fun findPatterns(graphs: List<N>): List<Pattern<N>> {
         logger.info { "Detecting patterns in ${graphs.size} graphs." }
 
-        val sequences = graphs.flatMap { PathEnumerator(it, maximumSequenceLength).enumerate() }
+        val sequences = graphs.flatMap { enumerator(it).enumerate() }
         logger.info { "Found ${sequences.size} sequences in ${graphs.size} graphs." }
 
         return PrefixSpan(sequences, minimumCount, comparator).findFrequentPatterns()

--- a/modules/mining-pipeline/prefix-span-pattern-detector/src/module-integration-test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/CCSpanJimpleNodeIntegrationTest.kt
+++ b/modules/mining-pipeline/prefix-span-pattern-detector/src/module-integration-test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/CCSpanJimpleNodeIntegrationTest.kt
@@ -3,6 +3,7 @@ package org.cafejojo.schaapi.miningpipeline.patterndetector.prefixspan
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
+import org.cafejojo.schaapi.models.SimplePathEnumerator
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import org.jetbrains.spek.api.Spek
@@ -70,7 +71,7 @@ internal object CCSpanJimpleNodeIntegrationTest : Spek({
                 makeGraph(node7, node8, node9, node10, node4, node5, node6)
             )
 
-            val frequent = PrefixSpanPatternDetector(2, 100, GeneralizedNodeComparator())
+            val frequent = PrefixSpanPatternDetector(2, { SimplePathEnumerator(it, 100) }, GeneralizedNodeComparator())
                 .findPatterns(graphs)
 
             assertThat(frequent).contains(listOf(node1, node2, node3))
@@ -98,7 +99,7 @@ internal object CCSpanJimpleNodeIntegrationTest : Spek({
                 makeGraph(node11, node12, node6, node7, node8, node9, node10)
             )
 
-            val frequent = PrefixSpanPatternDetector(2, 100, GeneralizedNodeComparator())
+            val frequent = PrefixSpanPatternDetector(2, { SimplePathEnumerator(it, 100) }, GeneralizedNodeComparator())
                 .findPatterns(graphs)
 
             assertThat(frequent).hasSize(amountOfPossibleSubSequences(5))
@@ -123,7 +124,7 @@ internal object CCSpanJimpleNodeIntegrationTest : Spek({
                 makeGraph(node9, node10, node5, node6, node7, node8)
             )
 
-            val frequent = PrefixSpanPatternDetector(2, 100, GeneralizedNodeComparator())
+            val frequent = PrefixSpanPatternDetector(2, { SimplePathEnumerator(it, 100) }, GeneralizedNodeComparator())
                 .findPatterns(graphs)
 
             assertThat(frequent).contains(listOf(node1, node2, node3, node4))
@@ -143,7 +144,7 @@ internal object CCSpanJimpleNodeIntegrationTest : Spek({
                 makeGraph(node7, node8, node9, node10, node1, node2, node3)
             )
 
-            val frequent = PrefixSpanPatternDetector(2, 100, GeneralizedNodeComparator())
+            val frequent = PrefixSpanPatternDetector(2, { SimplePathEnumerator(it, 100) }, GeneralizedNodeComparator())
                 .findPatterns(graphs)
 
             assertThat(frequent).contains(listOf(node1, node2, node3))
@@ -166,7 +167,7 @@ internal object CCSpanJimpleNodeIntegrationTest : Spek({
                 makeGraph(node7, node8, node9, node10, node4, node5, node6)
             )
 
-            val frequent = PrefixSpanPatternDetector(2, 100, GeneralizedNodeComparator())
+            val frequent = PrefixSpanPatternDetector(2, { SimplePathEnumerator(it, 100) }, GeneralizedNodeComparator())
                 .findPatterns(graps)
 
             assertThat(frequent).isEmpty()
@@ -192,7 +193,7 @@ internal object CCSpanJimpleNodeIntegrationTest : Spek({
                 makeGraph(node9, node10, node5, node6, node7, node8)
             )
 
-            val frequent = PrefixSpanPatternDetector(2, 100, GeneralizedNodeComparator())
+            val frequent = PrefixSpanPatternDetector(2, { SimplePathEnumerator(it, 100) }, GeneralizedNodeComparator())
                 .findPatterns(graphs)
 
             assertThat(frequent).hasSize(4)

--- a/modules/mining-pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/spam/SpamPatternDetector.kt
+++ b/modules/mining-pipeline/spam-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/spam/SpamPatternDetector.kt
@@ -11,11 +11,11 @@ import org.cafejojo.schaapi.miningpipeline.PatternDetector
  */
 class SpamPatternDetector<N : Node>(
     private val minimumCount: Int,
-    private val maximumSequenceLength: Int,
+    private val enumerator: (N) -> PathEnumerator<N>,
     private val comparator: GeneralizedNodeComparator<N>
 ) : PatternDetector<N> {
     override fun findPatterns(graphs: List<N>): List<Pattern<N>> {
-        val sequences = graphs.flatMap { PathEnumerator(it, maximumSequenceLength).enumerate() }
+        val sequences = graphs.flatMap { enumerator(it).enumerate() }
         return Spam(sequences, minimumCount, comparator).findFrequentPatterns()
     }
 }

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumerator.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumerator.kt
@@ -51,7 +51,7 @@ class JimplePathEnumerator(entryNode: JimpleNode, maximumPathLength: Int) :
     PathEnumerator<JimpleNode>(entryNode, maximumPathLength) {
     override fun postProcess(paths: List<List<JimpleNode>>) =
         paths.map { it.toMutableList() }
-            .also { it.forEach(this::processPath) }
+            .also { it.forEach(::processPath) }
 
     private fun processPath(path: MutableList<JimpleNode>) {
         path.toList()
@@ -101,17 +101,17 @@ class JimplePathEnumerator(entryNode: JimpleNode, maximumPathLength: Int) :
     }
 
     /**
-     * Returns the first common node in the (recursive) successors of [base] and [target], or the last element of [path]
+     * Returns the first common node in the (recursive) successors of [nodeA] and [nodeB], or the last element of [path]
      * if there is no such element.
      *
-     * @param base // TODO
-     * @param target // TODO
-     * @param path // TODO
-     * @return the first common node in the (recursive) successors of [base] and [target], or the last element of [path]
+     * @param nodeA a node
+     * @param nodeB a node
+     * @param path the path from which to return the last node if there is no common node
+     * @return the first common node in the (recursive) successors of [nodeA] and [nodeB], or the last element of [path]
      * if there is no such element
      */
-    private fun findCoercionTargetFor(base: Node, target: Node, path: List<Node>) =
-        ((base.findNextCommonNodeWithOrNull(target) ?: path.last()) as? JimpleNode
+    private fun findCoercionTargetFor(nodeA: Node, nodeB: Node, path: List<Node>) =
+        ((nodeA.findNextCommonNodeWithOrNull(nodeB) ?: path.last()) as? JimpleNode
             ?: throw IllegalStateException("JimpleNode should not have non-Jimple successor during path enumeration."))
             .statement
 }

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumerator.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumerator.kt
@@ -1,0 +1,166 @@
+package org.cafejojo.schaapi.models.libraryusagegraph.jimple
+
+import org.cafejojo.schaapi.models.Node
+import org.cafejojo.schaapi.models.PathEnumerator
+import soot.jimple.EqExpr
+import soot.jimple.GeExpr
+import soot.jimple.GtExpr
+import soot.jimple.IfStmt
+import soot.jimple.Jimple
+import soot.jimple.LeExpr
+import soot.jimple.LtExpr
+import soot.jimple.NeExpr
+import soot.jimple.SwitchStmt
+
+/**
+ * A [PathEnumerator] that performs some post-processing to ensure that branches are correct.
+ *
+ * Given the following Jimple pseudo-code:
+ * ```
+ * a()
+ * IF condition GOTO c()
+ * b()
+ * GOTO d()
+ * c()
+ * d()
+ * ```
+ *
+ * the default behaviour of the path enumerator will result in the following two paths:
+ * ```
+ * a()
+ * IF condition GOTO c()
+ * b()
+ * GOTO d()
+ * d()
+ * ```
+ * ```
+ * a()
+ * IF condition GOTO c()
+ * c()
+ * d()
+ * ```
+ * The first path contains a GOTO to a statement that is not in the path, which is not valid. The solution is to make
+ * the IF jump to `d()` instead.
+ * The second path contains a GOTO to the next statement, which means that the next statement will always be `c()`
+ * regardless of the condition. The solution is to make the IF jump to `d()` instead. Additionally, the condition should
+ * be flipped because it would execute what was the else branch in the original code.
+ *
+ * Similarly, the targets of a switch statement should be redirected to point to after the branch.
+ */
+class JimplePathEnumerator(entryNode: JimpleNode, maximumPathLength: Int) :
+    PathEnumerator<JimpleNode>(entryNode, maximumPathLength) {
+    override fun postProcess(paths: List<List<JimpleNode>>) =
+        paths.map { it.toMutableList() }
+            .also { it.forEach(this::processPath) }
+
+    private fun processPath(path: MutableList<JimpleNode>) {
+        path.toList()
+            .filter { it.statement.branches() }
+            .forEach { node ->
+                val statement = node.statement
+                when (statement) {
+                    is IfStmt -> handleIf(path, node, statement)
+                    is SwitchStmt -> handleSwitch(path, node)
+                }
+            }
+    }
+
+    private fun handleIf(path: MutableList<JimpleNode>, node: JimpleNode, statement: IfStmt) {
+        val pathStatements = path.map { it.statement }
+
+        val nodeCopy = node.copy()
+        path.replaceAndUpdateTargets(node, nodeCopy)
+
+        val statementCopy = nodeCopy.statement as? IfStmt
+            ?: throw IllegalStateException("IfStmt changed class after copy.")
+        statementCopy.setTarget(findCoercionTargetFor(node.successors[0], node.successors[1], path))
+
+        if (statement.target in pathStatements) statementCopy.flipCondition()
+    }
+
+    private fun handleSwitch(path: MutableList<JimpleNode>, node: JimpleNode) {
+        val nodeCopy = node.copy()
+        path.replaceAndUpdateTargets(node, nodeCopy)
+
+        val statementCopy = nodeCopy.statement as? SwitchStmt
+            ?: throw IllegalStateException("SwitchStmt changed class after copy.")
+        val defaultTargetNode = node.successors
+            .filterIsInstance<JimpleNode>()
+            .singleEquiv { it.statement === statementCopy.defaultTarget }
+
+        val currentBranchNode = node.successors.singleEquiv { it in path }
+        (0 until node.successors.size)
+            .filterNot { node.successors[it] === currentBranchNode }
+            .filterNot { node.successors[it] === defaultTargetNode }
+            .forEach {
+                statementCopy.setTarget(it,
+                    findCoercionTargetFor(currentBranchNode, node.successors[it], path))
+            }
+
+        statementCopy.defaultTarget = findCoercionTargetFor(currentBranchNode, defaultTargetNode, path)
+    }
+
+    /**
+     * Returns the first common node in the (recursive) successors of [base] and [target], or the last element of [path]
+     * if there is no such element.
+     *
+     * @param base // TODO
+     * @param target // TODO
+     * @param path // TODO
+     * @return the first common node in the (recursive) successors of [base] and [target], or the last element of [path]
+     * if there is no such element
+     */
+    private fun findCoercionTargetFor(base: Node, target: Node, path: List<Node>) =
+        ((base.findNextCommonNodeWithOrNull(target) ?: path.last()) as? JimpleNode
+            ?: throw IllegalStateException("JimpleNode should not have non-Jimple successor during path enumeration."))
+            .statement
+}
+
+/**
+ * Flips the statement's condition.
+ */
+private fun IfStmt.flipCondition() =
+    this.condition.let { condition ->
+        this.condition = when (condition) {
+            is EqExpr -> Jimple.v().newNeExpr(condition.op1, condition.op2)
+            is NeExpr -> Jimple.v().newEqExpr(condition.op1, condition.op2)
+            is GeExpr -> Jimple.v().newLtExpr(condition.op1, condition.op2)
+            is LtExpr -> Jimple.v().newGeExpr(condition.op1, condition.op2)
+            is GtExpr -> Jimple.v().newLeExpr(condition.op1, condition.op2)
+            is LeExpr -> Jimple.v().newGtExpr(condition.op1, condition.op2)
+            else -> throw IllegalStateException("Cannot invert a condition of an unknown type.")
+        }
+    }
+
+/**
+ * Replaces [old] with [new] and replaces all jumps to [old] in this path with jumps to [new].
+ *
+ * @param old the node to be replaced by [new]
+ * @param new the node to replace [old] with
+ */
+private fun MutableList<JimpleNode>.replaceAndUpdateTargets(old: JimpleNode, new: JimpleNode) {
+    set(indexOf(old), new)
+    this.map { it.statement.unitBoxes }
+        .mapNotNull { it.firstOrNull { it.unit == old.statement } }
+        .forEach { it.unit = new.statement }
+}
+
+private fun Node.findNextCommonNodeWithOrNull(node: Node) = this.toList().intersect(node.toList()).firstOrNull()
+
+/**
+ * Returns the first element for which [predicate] is true iff all elements for which [predicate] is true are
+ * equivalent; otherwise an [IllegalArgumentException] is thrown.
+ *
+ * @param N the type of [Node] contained in this [Iterable]
+ * @param predicate the predicate to check for
+ * @return the first element for which [predicate] is true iff all elements for which [predicate] is true are
+ * equivalent
+ */
+private fun <N : Node> Iterable<N>.singleEquiv(predicate: (N) -> Boolean): N {
+    val candidates = this.toList().filter(predicate)
+    require(candidates.isNotEmpty()) { "No elements match the predicate." }
+    require(candidates.all { it.equivTo(candidates.first()) }) {
+        "Not all elements matching the predicate are equivalent."
+    }
+    return candidates.first()
+}

--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumerator.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumerator.kt
@@ -4,6 +4,7 @@ import org.cafejojo.schaapi.models.Node
 import org.cafejojo.schaapi.models.PathEnumerator
 import soot.jimple.EqExpr
 import soot.jimple.GeExpr
+import soot.jimple.GotoStmt
 import soot.jimple.GtExpr
 import soot.jimple.IfStmt
 import soot.jimple.Jimple
@@ -61,6 +62,10 @@ class JimplePathEnumerator(entryNode: JimpleNode, maximumPathLength: Int) :
                 when (statement) {
                     is IfStmt -> handleIf(path, node, statement)
                     is SwitchStmt -> handleSwitch(path, node)
+                    is GotoStmt -> {
+                        // Do nothing
+                    }
+                    else -> throw IllegalArgumentException("Unrecognized branching statement.")
                 }
             }
     }

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumeratorTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumeratorTest.kt
@@ -256,7 +256,7 @@ internal object JimplePathEnumeratorTest : Spek({
                 )
             }
 
-            it("") {
+            it("creates two different paths if switch targets go to the same location") {
                 val endNode = createReturnNode(local)
                 val switchDefaultTargetNode = createAssignNode(local, 3, endNode)
                 val switchTargetCGoto = createGotoNode(endNode)

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumeratorTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumeratorTest.kt
@@ -302,6 +302,51 @@ internal object JimplePathEnumeratorTest : Spek({
                 )
             }
 
+            it("creates two different paths if a switch target is the same as the default target") {
+                val endNode = createReturnNode(local)
+                val switchTargetCDefaultNode = createAssignNode(local, 2, endNode)
+                val switchTargetBGoto = createGotoNode(endNode)
+                val switchTargetBNode = createAssignNode(local, 1, switchTargetBGoto)
+                val switchTargetAGoto = createGotoNode(endNode)
+                val switchTargetANode = createAssignNode(local, 1, switchTargetAGoto)
+                val switchNode = createSwitchNode(local,
+                    switchTargetCDefaultNode,
+                    switchTargetANode,
+                    switchTargetBNode,
+                    switchTargetCDefaultNode
+                )
+                val localInitNode = createAssignNode(local, 0, switchNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, switchTargetCDefaultNode, endNode, endNode, endNode),
+                        switchTargetCDefaultNode,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, switchTargetANode, endNode, endNode),
+                        switchTargetANode,
+                        switchTargetAGoto,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, endNode, switchTargetBNode, endNode),
+                        switchTargetBNode,
+                        switchTargetBGoto,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, endNode, switchTargetCDefaultNode),
+                        switchTargetCDefaultNode,
+                        endNode
+                    )
+                )
+            }
+
             it("jumps past the inner switch statement of another branch") {
                 val endNode = createReturnNode(local)
                 val switchDefault = createGotoNode(endNode)

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumeratorTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumeratorTest.kt
@@ -1,0 +1,413 @@
+package org.cafejojo.schaapi.models.libraryusagegraph.jimple
+
+import org.assertj.core.api.Assertions.assertThat
+import org.cafejojo.schaapi.models.Node
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.context
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import soot.IntType
+import soot.Local
+import soot.Value
+import soot.jimple.IntConstant
+import soot.jimple.Jimple
+
+internal object JimplePathEnumeratorTest : Spek({
+    describe("Jimple-aware path enumerator") {
+        context("if-statements") {
+            val local = Jimple.v().newLocal("local", IntType.v())
+            val condition = Jimple.v().newEqExpr(local, IntConstant.v(3))
+            val invertedCondition = Jimple.v().newNeExpr(local, IntConstant.v(3))
+
+            it("constructs two converging paths for a regular if-statement") {
+                val endNode = createReturnNode(local)
+                val elseBranchNode = createAssignNode(local, 2, endNode)
+                val ifBranchGotoNode = createGotoNode(endNode)
+                val ifBranchNode = createAssignNode(local, 1, ifBranchGotoNode)
+                val ifNode = createIfNode(condition, ifBranchNode, elseBranchNode)
+                val localInitNode = createAssignNode(local, 0, ifNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createIfNode(condition, ifBranchNode, endNode),
+                        ifBranchNode,
+                        ifBranchGotoNode,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createIfNode(invertedCondition, elseBranchNode, endNode),
+                        elseBranchNode,
+                        endNode
+                    )
+                )
+            }
+
+            it("makes the else-branch jump to the end if it contains a return") {
+                val endNode = createReturnNode(local)
+                val elseBranchNode = createReturnNode(local)
+                val ifBranchGotoNode = createGotoNode(endNode)
+                val ifBranchNode = createAssignNode(local, 1, ifBranchGotoNode)
+                val ifNode = createIfNode(condition, ifBranchNode, elseBranchNode)
+                val localInitNode = createAssignNode(local, 0, ifNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createIfNode(condition, ifBranchNode, endNode),
+                        ifBranchNode,
+                        ifBranchGotoNode,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createIfNode(invertedCondition, endNode, endNode),
+                        endNode
+                    )
+                )
+            }
+
+            it("makes the if-branch jump to the end if it contains a return") {
+                val endNode = createReturnNode(local)
+                val elseBranchNode = createAssignNode(local, 2, endNode)
+                val ifBranchNode = createReturnNode(local)
+                val ifNode = createIfNode(condition, ifBranchNode, elseBranchNode)
+                val localInitNode = createAssignNode(local, 0, ifNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createIfNode(condition, ifBranchNode, endNode),
+                        ifBranchNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createIfNode(invertedCondition, elseBranchNode, endNode),
+                        elseBranchNode,
+                        endNode
+                    )
+                )
+            }
+
+            it("makes both branches jump to the end if they both contain a return") {
+                val elseBranchNode = createReturnNode(local)
+                val ifBranchNode = createReturnNode(local)
+                val ifNode = createIfNode(condition, ifBranchNode, elseBranchNode)
+                val localInitNode = createAssignNode(local, 0, ifNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createIfNode(condition, ifBranchNode, ifBranchNode),
+                        ifBranchNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createIfNode(invertedCondition, elseBranchNode, elseBranchNode),
+                        elseBranchNode
+                    )
+                )
+            }
+
+            it("makes the else-branch jump past the if-branch's internal if-statement") {
+                val endNode = createReturnNode(local)
+                val elseBranchNode = createAssignNode(local, 4, endNode)
+                val ifBranchGotoNode = createGotoNode(endNode)
+                val ifBranchElseBranchNode = createAssignNode(local, 3, ifBranchGotoNode)
+                val ifBranchIfBranchGotoNode = createGotoNode(ifBranchGotoNode)
+                val ifBranchIfBranchNode = createAssignNode(local, 2, ifBranchIfBranchGotoNode)
+                val ifBranchIfNode = createIfNode(condition, ifBranchIfBranchNode, ifBranchElseBranchNode)
+                val ifBranchNode = createAssignNode(local, 1, ifBranchIfNode)
+                val ifNode = createIfNode(condition, ifBranchNode, elseBranchNode)
+                val localInitNode = createAssignNode(local, 0, ifNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createIfNode(condition, ifBranchNode, endNode),
+                        ifBranchNode,
+                        createIfNode(condition, ifBranchIfNode, ifBranchGotoNode),
+                        ifBranchIfBranchNode,
+                        ifBranchIfBranchGotoNode,
+                        ifBranchGotoNode,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createIfNode(condition, ifBranchNode, endNode),
+                        ifBranchNode,
+                        createIfNode(invertedCondition, ifBranchGotoNode, ifBranchElseBranchNode),
+                        ifBranchElseBranchNode,
+                        ifBranchGotoNode,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createIfNode(invertedCondition, endNode, elseBranchNode),
+                        elseBranchNode,
+                        endNode
+                    )
+                )
+            }
+        }
+
+        context("switch-statements") {
+            val local = Jimple.v().newLocal("local", IntType.v())
+
+            it("jumps over unused switch branches") {
+                val endNode = createReturnNode(local)
+                val switchDefaultTargetNode = createAssignNode(local, 3, endNode)
+                val switchTargetBGoto = createGotoNode(endNode)
+                val switchTargetBNode = createAssignNode(local, 2, switchTargetBGoto)
+                val switchTargetAGoto = createGotoNode(endNode)
+                val switchTargetANode = createAssignNode(local, 1, switchTargetAGoto)
+                val switchNode = createSwitchNode(local, switchDefaultTargetNode, switchTargetANode, switchTargetBNode)
+                val localInitNode = createAssignNode(local, 0, switchNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, switchDefaultTargetNode, endNode, endNode),
+                        switchDefaultTargetNode,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, switchTargetANode, endNode),
+                        switchTargetANode,
+                        switchTargetAGoto,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, endNode, switchTargetBNode),
+                        switchTargetBNode,
+                        switchTargetBGoto,
+                        endNode
+                    )
+                )
+            }
+
+            it("jumps to the end if a branch does not converge with the path's active branch") {
+                val endNode = createReturnNode(local)
+                val switchDefaultTargetNode = createAssignNode(local, 3, endNode)
+                val switchTargetBGoto = createGotoNode(endNode)
+                val switchTargetBNode = createAssignNode(local, 2, switchTargetBGoto)
+                val switchTargetANode = createReturnNode(local)
+                val switchNode = createSwitchNode(local, switchDefaultTargetNode, switchTargetANode, switchTargetBNode)
+                val localInitNode = createAssignNode(local, 0, switchNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, switchDefaultTargetNode, endNode, endNode),
+                        switchDefaultTargetNode,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, switchTargetANode, switchTargetANode, switchTargetANode),
+                        switchTargetANode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, endNode, switchTargetBNode),
+                        switchTargetBNode,
+                        switchTargetBGoto,
+                        endNode
+                    )
+                )
+            }
+
+            it("jumps to the end if the default branch does not converge with the path's active branch") {
+                val endNode = createReturnNode(local)
+                val switchDefaultTargetNode = createReturnNode(local)
+                val switchTargetBGoto = createGotoNode(endNode)
+                val switchTargetBNode = createAssignNode(local, 2, switchTargetBGoto)
+                val switchTargetAGoto = createGotoNode(endNode)
+                val switchTargetANode = createAssignNode(local, 1, switchTargetAGoto)
+                val switchNode = createSwitchNode(local, switchDefaultTargetNode, switchTargetANode, switchTargetBNode)
+                val localInitNode = createAssignNode(local, 0, switchNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local,
+                            switchDefaultTargetNode,
+                            switchDefaultTargetNode,
+                            switchDefaultTargetNode),
+                        switchDefaultTargetNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, switchTargetANode, endNode, endNode),
+                        switchTargetANode,
+                        switchTargetAGoto,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, switchTargetBNode, endNode),
+                        switchTargetBNode,
+                        switchTargetBGoto,
+                        endNode
+                    )
+                )
+            }
+
+            it("") {
+                val endNode = createReturnNode(local)
+                val switchDefaultTargetNode = createAssignNode(local, 3, endNode)
+                val switchTargetCGoto = createGotoNode(endNode)
+                val switchTargetCNode = createAssignNode(local, 2, switchTargetCGoto)
+                val switchTargetABGoto = createGotoNode(endNode)
+                val switchTargetABNode = createAssignNode(local, 1, switchTargetABGoto)
+                val switchNode = createSwitchNode(local,
+                    switchDefaultTargetNode,
+                    switchTargetABNode,
+                    switchTargetABNode,
+                    switchTargetCNode
+                )
+                val localInitNode = createAssignNode(local, 0, switchNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, switchDefaultTargetNode, endNode, endNode, endNode),
+                        switchDefaultTargetNode,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, switchTargetABNode, endNode, endNode),
+                        switchTargetABNode,
+                        switchTargetABGoto,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, endNode, switchTargetABNode, endNode),
+                        switchTargetABNode,
+                        switchTargetABGoto,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, endNode, switchTargetCNode),
+                        switchTargetCNode,
+                        switchTargetCGoto,
+                        endNode
+                    )
+                )
+            }
+
+            it("jumps past the inner switch statement of another branch") {
+                val endNode = createReturnNode(local)
+                val switchDefault = createGotoNode(endNode)
+                val switchGotoB = createGotoNode(endNode)
+                val switchTargetB = createAssignNode(local, 5, switchGotoB)
+                val switchGotoA = createGotoNode(endNode)
+                val switchTargetASwitchDefault = createAssignNode(local, 4, switchGotoA)
+                val switchTargetASwitchGotoB = createGotoNode(switchGotoA)
+                val switchTargetASwitchTargetB = createAssignNode(local, 3, switchTargetASwitchGotoB)
+                val switchTargetASwitchGotoA = createGotoNode(switchGotoA)
+                val switchTargetASwitchTargetA = createAssignNode(local, 2, switchTargetASwitchGotoA)
+                val switchTargetASwitch = createSwitchNode(
+                    local,
+                    switchTargetASwitchDefault,
+                    switchTargetASwitchTargetA,
+                    switchTargetASwitchTargetB
+                )
+                val switchTargetA = createAssignNode(local, 1, switchTargetASwitch)
+                val switchNode = createSwitchNode(local, switchDefault, switchTargetA, switchTargetB)
+                val localInitNode = createAssignNode(local, 0, switchNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, switchDefault, endNode, endNode),
+                        switchDefault,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, switchTargetA, endNode),
+                        switchTargetA,
+                        createSwitchNode(local, switchTargetASwitchDefault, switchGotoA, switchGotoA),
+                        switchTargetASwitchDefault,
+                        switchGotoA,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, switchTargetA, endNode),
+                        switchTargetA,
+                        createSwitchNode(local, switchGotoA, switchTargetASwitchTargetA, switchGotoA),
+                        switchTargetASwitchTargetA,
+                        switchTargetASwitchGotoA,
+                        switchGotoA,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, switchTargetA, endNode),
+                        switchTargetA,
+                        createSwitchNode(local, switchGotoA, switchGotoA, switchTargetASwitchTargetB),
+                        switchTargetASwitchTargetB,
+                        switchTargetASwitchGotoB,
+                        switchGotoA,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, endNode, switchTargetB),
+                        switchTargetB,
+                        switchGotoB,
+                        endNode
+                    )
+                )
+            }
+        }
+    }
+})
+
+fun createIfNode(condition: Value, ifBranch: JimpleNode, elseBranch: JimpleNode) =
+    JimpleNode(
+        Jimple.v().newIfStmt(condition, elseBranch.statement),
+        mutableListOf(ifBranch, elseBranch)
+    )
+
+fun createSwitchNode(switch: Value, defaultTarget: JimpleNode, vararg targets: JimpleNode) =
+    JimpleNode(
+        Jimple.v().newTableSwitchStmt(
+            switch,
+            0, targets.size - 1,
+            targets.map { it.statement },
+            defaultTarget.statement
+        ),
+        targets.toMutableList<Node>().also { it.add(defaultTarget) }
+    )
+
+fun createAssignNode(target: Local, value: Int, vararg successors: JimpleNode) =
+    JimpleNode(Jimple.v().newAssignStmt(target, IntConstant.v(value)), successors.toMutableList())
+
+fun createGotoNode(target: JimpleNode) =
+    JimpleNode(Jimple.v().newGotoStmt(target.statement), mutableListOf(target))
+
+fun createReturnNode(value: Value) =
+    JimpleNode(Jimple.v().newReturnStmt(value))
+
+fun assertThatEnumeratorCreatesPaths(entryNode: JimpleNode, vararg paths: List<JimpleNode>) {
+    assertThat(JimplePathEnumerator(entryNode, 999).enumerate())
+        .usingElementComparator(NodeComparator())
+        .containsExactlyInAnyOrderElementsOf(paths.toList())
+}
+
+private class NodeComparator : Comparator<List<JimpleNode>> {
+    override fun compare(o1: List<JimpleNode>, o2: List<JimpleNode>): Int {
+        if (o1 === o2) return 0
+        if (o1.size != o2.size) return -1
+        return if ((0 until o1.size).all { o1[it].equivTo(o2[it]) }) 0 else -1
+    }
+}

--- a/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathEnumerator.kt
+++ b/modules/models/src/main/kotlin/org/cafejojo/schaapi/models/PathEnumerator.kt
@@ -12,7 +12,7 @@ import java.util.Stack
  * @property entryNode the entry node of the method graph
  * @property maximumPathLength the maximum length a path output by this enumerator should have
  */
-class PathEnumerator<N : Node>(
+abstract class PathEnumerator<N : Node>(
     private val entryNode: N,
     private val maximumPathLength: Int
 ) {
@@ -35,8 +35,16 @@ class PathEnumerator<N : Node>(
         recursivelyEnumerate(entryNode)
         cleanUp()
 
-        return allPaths.filterIsInstance<List<N>>()
+        return postProcess(allPaths.filterIsInstance<List<N>>())
     }
+
+    /**
+     * Applies processing to the paths before they are returned by [enumerate].
+     *
+     * @param paths the paths to process
+     * @return the processed paths
+     */
+    protected abstract fun postProcess(paths: List<List<N>>): List<List<N>>
 
     private fun recursivelyEnumerate(node: Node) {
         if (exitNode in node.successors) allPaths.add(currentPath.toList())
@@ -52,6 +60,14 @@ class PathEnumerator<N : Node>(
     }
 
     private fun cleanUp() = entryNode.removeExitNodes()
+}
+
+/**
+ * A simple [PathEnumerator] that does not perform post-processing.
+ */
+class SimplePathEnumerator<N : Node>(entryNode: N, maximumPathLength: Int) :
+    PathEnumerator<N>(entryNode, maximumPathLength) {
+    override fun postProcess(paths: List<List<N>>) = paths
 }
 
 /**

--- a/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/PathEnumeratorTest.kt
+++ b/modules/models/src/test/kotlin/org/cafejojo/schaapi/models/PathEnumeratorTest.kt
@@ -15,7 +15,7 @@ internal class PathEnumeratorTest : Spek({
             node1.successors.addAll(listOf(node2))
             node2.successors.addAll(listOf(node3))
 
-            val paths = PathEnumerator(node1, 100).enumerate()
+            val paths = SimplePathEnumerator(node1, 100).enumerate()
             assertThat(paths)
                 .isEqualTo(
                     listOf(
@@ -36,7 +36,7 @@ internal class PathEnumeratorTest : Spek({
             node3.successors.addAll(listOf(node5))
             node4.successors.addAll(listOf(node5))
 
-            val paths = PathEnumerator(node1, 100).enumerate()
+            val paths = SimplePathEnumerator(node1, 100).enumerate()
 
             assertThat(paths)
                 .isEqualTo(
@@ -65,7 +65,7 @@ internal class PathEnumeratorTest : Spek({
             node6.successors.addAll(listOf(node7))
             node7.successors.addAll(listOf(node8))
 
-            val paths = PathEnumerator(node1, 100).enumerate()
+            val paths = SimplePathEnumerator(node1, 100).enumerate()
 
             assertThat(paths)
                 .isEqualTo(
@@ -87,7 +87,7 @@ internal class PathEnumeratorTest : Spek({
             node2.successors.addAll(listOf(node3))
             node3.successors.addAll(listOf(node4, node2))
 
-            val paths = PathEnumerator(node1, 100).enumerate()
+            val paths = SimplePathEnumerator(node1, 100).enumerate()
 
             assertThat(paths)
                 .isEqualTo(
@@ -111,7 +111,7 @@ internal class PathEnumeratorTest : Spek({
             node4.successors.addAll(listOf(node5, node3))
             node5.successors.addAll(listOf(node6, node2))
 
-            val paths = PathEnumerator(node1, 100).enumerate()
+            val paths = SimplePathEnumerator(node1, 100).enumerate()
 
             assertThat(paths)
                 .isEqualTo(
@@ -197,7 +197,7 @@ internal class PathEnumeratorTest : Spek({
             node2.successors.addAll(listOf(node3, node4))
             node3.successors.addAll(listOf(node5))
 
-            val paths = PathEnumerator(node1, 3).enumerate()
+            val paths = SimplePathEnumerator(node1, 3).enumerate()
 
             assertThat(paths)
                 .isEqualTo(


### PR DESCRIPTION
Given the following pseudo-Jimple code:
```
a()
IF condition GOTO c()
    b()
    GOTO d()
    c()
d()
```
the current implementation of the path enumerator will produce the following paths:
```
a()
IF condition GOTO c()
    b()
    GOTO d()
d()
```
```
a()
IF condition GOTO c()
    c()
d()
```
The former pattern is incorrect because it has a `GOTO` to an instruction that is not in the path, and the latter pattern is incorrect because the `IF` does not actually branch because it always goes to `c()`.

This PR introduces a Jimple-aware pattern detector that performs post-processing on the paths produced by the `PathEnumerator` to produce the following paths instead:
```
a()
IF condition GOTO d()
    b()
    GOTO d()
d()
```
```
a()
IF !condition GOTO d()
    c()
d()
```
