### PR TITLE
Filter out user-project usages from all kinds of statements

### DIFF
--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
@@ -92,15 +92,15 @@ class JimpleLibraryUsageGraphGenerator : LibraryUsageGraphGenerator<JavaProject,
         val methodBody = method.retrieveActiveBody()
         lugStatistics.allStatements += methodBody.units.size
 
-        val filters = listOf(
+        listOf(
             StatementFilter(libraryProject),
             BranchStatementFilter(libraryProject),
             RecursiveGotoFilter()
-        )
-        filters.forEach { it.apply(methodBody) }
+        ).forEach { it.apply(methodBody) }
 
-        val processors = listOf(UserUsageProcessor(libraryProject))
-        processors.forEach { it.process(methodBody) }
+        listOf(
+            UserUsageProcessor(libraryProject)
+        ).forEach { it.process(methodBody) }
 
         lugStatistics.validStatements += methodBody.units.size
         if (methodBody.units.isEmpty()) methodBody.units.add(Jimple.v().newReturnVoidStmt())

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
@@ -4,6 +4,7 @@ import org.cafejojo.schaapi.miningpipeline.LibraryUsageGraphGenerator
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.BranchStatementFilter
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.RecursiveGotoFilter
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.StatementFilter
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.processors.UserUsageProcessor
 import org.cafejojo.schaapi.models.DfsIterator
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.SootNameEquivalenceChanger
@@ -97,6 +98,9 @@ class JimpleLibraryUsageGraphGenerator : LibraryUsageGraphGenerator<JavaProject,
             RecursiveGotoFilter()
         )
         filters.forEach { it.apply(methodBody) }
+
+        val processors = listOf(UserUsageProcessor(libraryProject))
+        processors.forEach { it.process(methodBody) }
 
         lugStatistics.validStatements += methodBody.units.size
         if (methodBody.units.isEmpty()) methodBody.units.add(Jimple.v().newReturnVoidStmt())

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
@@ -33,7 +33,7 @@ internal class StatementFilter(project: JavaProject) : Filter {
         is ThrowStmt -> valueFilter.retain(unit.op)
         is DefinitionStmt -> valueFilter.retain(unit.leftOp, unit.rightOp)
         is IfStmt -> true // defer to BranchStatementFilter
-        is SwitchStmt -> userUsageFilter.retain(unit.key) // defer to BranchStatementFilter
+        is SwitchStmt -> true // defer to BranchStatementFilter
         is InvokeStmt -> valueFilter.retain(unit.invokeExpr)
         is ReturnStmt -> userUsageFilter.retain(unit.op)
         is GotoStmt -> true

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilter.kt
@@ -32,7 +32,7 @@ internal class StatementFilter(project: JavaProject) : Filter {
     fun retain(unit: Unit) = when (unit) {
         is ThrowStmt -> valueFilter.retain(unit.op)
         is DefinitionStmt -> valueFilter.retain(unit.leftOp, unit.rightOp)
-        is IfStmt -> userUsageFilter.retain(unit.condition) // defer to BranchStatementFilter
+        is IfStmt -> true // defer to BranchStatementFilter
         is SwitchStmt -> userUsageFilter.retain(unit.key) // defer to BranchStatementFilter
         is InvokeStmt -> valueFilter.retain(unit.invokeExpr)
         is ReturnStmt -> userUsageFilter.retain(unit.op)

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -5,7 +5,6 @@ import org.cafejojo.schaapi.models.project.JavaProject
 import soot.EquivalentValue
 import soot.Modifier
 import soot.PrimType
-import soot.Scene
 import soot.SootClass
 import soot.Type
 import soot.Value

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -172,7 +172,7 @@ private class UserUsageValueFilterRule(private val libraryProject: JavaProject) 
     private fun isNotUserClass(clazz: SootClass) = isNotUserClass(clazz.name)
     private fun isNotUserClass(className: String) =
         libraryProject.classNames.contains(className)
-            || Scene.v().forceResolve(className, SootClass.BODIES).isJavaLibraryClass
+            || SootClass(className, Modifier.PUBLIC).isJavaLibraryClass
 }
 
 /**

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -2,9 +2,11 @@ package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
 
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleValueVisitor
 import org.cafejojo.schaapi.models.project.JavaProject
+import soot.AnySubType
+import soot.ArrayType
 import soot.EquivalentValue
-import soot.Modifier
 import soot.PrimType
+import soot.RefType
 import soot.SootClass
 import soot.Type
 import soot.Value
@@ -178,11 +180,16 @@ private class UserUsageValueFilterRule(private val libraryProject: JavaProject) 
      */
     override fun accumulate(result1: Boolean, result2: Boolean) = result1 && result2
 
-    private fun isNotUserClass(type: Type) = type is PrimType || isNotUserClass(type.toString())
-    private fun isNotUserClass(clazz: SootClass) = isNotUserClass(clazz.name)
-    private fun isNotUserClass(className: String) =
-        libraryProject.classNames.contains(className)
-            || SootClass(className, Modifier.PUBLIC).isJavaLibraryClass
+    private fun isNotUserClass(type: Type): Boolean =
+        when (type) {
+            is ArrayType -> isNotUserClass(type.baseType)
+            is AnySubType -> isNotUserClass(type.base)
+            is RefType -> isNotUserClass(type.sootClass)
+            else -> true
+        }
+
+    private fun isNotUserClass(clazz: SootClass) =
+        libraryProject.classNames.contains(clazz.name) || clazz.isJavaLibraryClass
 }
 
 /**

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -3,6 +3,7 @@ package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleValueVisitor
 import org.cafejojo.schaapi.models.project.JavaProject
 import soot.EquivalentValue
+import soot.Modifier
 import soot.PrimType
 import soot.Scene
 import soot.SootClass
@@ -25,12 +26,16 @@ import soot.jimple.toolkits.thread.synchronization.NewStaticLock
 
 /**
  * Determines whether to keep individual [Value]s.
+ *
+ * @property filterRules the rules to apply to the values
  */
-internal class ValueFilter(libraryProject: JavaProject) {
-    private val filterRules = listOf(
-        ClassValueFilterRule(),
-        LibraryUsageValueFilterRule(libraryProject),
-        UserUsageValueFilterRule(libraryProject)
+internal open class ValueFilter(private val filterRules: List<ValueFilterRule>) {
+    constructor(libraryProject: JavaProject) : this(
+        listOf(
+            ClassValueFilterRule(),
+            LibraryUsageValueFilterRule(libraryProject),
+            UserUsageValueFilterRule(libraryProject)
+        )
     )
 
     /**
@@ -47,9 +52,15 @@ internal class ValueFilter(libraryProject: JavaProject) {
 }
 
 /**
+ * Filters [Value]s based only on their usage of classes from user projects.
+ */
+internal class UserUsageValueFilter(libraryProject: JavaProject) :
+    ValueFilter(listOf(UserUsageValueFilterRule(libraryProject)))
+
+/**
  * Describes how a [Value] should be filtered.
  */
-private abstract class ValueFilterRule : JimpleValueVisitor<Boolean>() {
+internal abstract class ValueFilterRule : JimpleValueVisitor<Boolean>() {
     /**
      * Returns true iff [value] should be retained.
      *

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/Processor.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/Processor.kt
@@ -1,0 +1,15 @@
+package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.processors
+
+import soot.Body
+
+/**
+ * (Potentially) modifies a given method body.
+ */
+interface Processor {
+    /**
+     * (Potentially) modifies a [body].
+     *
+     * @param body the body to process
+     */
+    fun process(body: Body)
+}

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessor.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessor.kt
@@ -1,0 +1,36 @@
+package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.processors
+
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.UserUsageValueFilter
+import org.cafejojo.schaapi.models.project.JavaProject
+import soot.Body
+import soot.BooleanType
+import soot.jimple.IfStmt
+import soot.jimple.IntConstant
+import soot.jimple.Jimple
+
+/**
+ * Processes Jimple bodies such that they no longer contain usages of user projects.
+ */
+internal class UserUsageProcessor(project: JavaProject) : Processor {
+    private val userUsageValueFilter = UserUsageValueFilter(project)
+
+    /**
+     * Removes usages of user projects from if-statements.
+     *
+     * @param body the body to process
+     */
+    override fun process(body: Body) =
+        body.units
+            .filterIsInstance<IfStmt>()
+            .filterNot { userUsageValueFilter.retain(it.condition) }
+            .forEach {
+                val userUsageLocal = Jimple.v().newLocal("userUsageLocal$localsInserted", BooleanType.v())
+                localsInserted++
+
+                it.condition = Jimple.v().newEqExpr(userUsageLocal, IntConstant.v(1))
+            }
+
+    companion object {
+        private var localsInserted = 0
+    }
+}

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessor.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessor.kt
@@ -41,7 +41,7 @@ internal class UserUsageProcessor(project: JavaProject) : Processor {
                 }
             }
 
-    companion object {
+    private companion object {
         private var localsInserted = 0
     }
 }

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/Helpers.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/Helpers.kt
@@ -2,6 +2,7 @@ package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
+import soot.Modifier
 import soot.SootClass
 import soot.SootMethod
 import soot.jimple.StaticInvokeExpr
@@ -13,9 +14,7 @@ internal const val LIBRARY_CLASS =
     "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.Object1"
 
 internal fun constructInvokeExprMock(declaringClassName: String): StaticInvokeExpr {
-    val clazz = mock<SootClass> {
-        on { name } doReturn declaringClassName
-    }
+    val clazz = SootClass(declaringClassName, Modifier.PUBLIC)
     val method = mock<SootMethod> {
         on { declaringClass } doReturn clazz
     }

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/Helpers.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/Helpers.kt
@@ -7,6 +7,8 @@ import soot.SootMethod
 import soot.jimple.StaticInvokeExpr
 
 internal const val NON_LIBRARY_CLASS = "java.lang.String"
+internal const val USER_CLASS =
+    "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.users.SimpleTest"
 internal const val LIBRARY_CLASS =
     "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.Object1"
 

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
@@ -20,6 +20,7 @@ import soot.jimple.ThrowStmt
 internal object StatementFilterTest : Spek({
     describe("filters statements based on library usage") {
         val libraryValue = constructInvokeExprMock(LIBRARY_CLASS)
+        val userValue = constructInvokeExprMock(USER_CLASS)
         val nonLibraryValue = constructInvokeExprMock(NON_LIBRARY_CLASS)
 
         it("filters throw statements") {
@@ -51,11 +52,27 @@ internal object StatementFilterTest : Spek({
         }
 
         it("filters if statements") {
-            assertThatItRetains(mock<IfStmt>())
+            assertThatItRetains(mock<IfStmt> {
+                on { it.condition } doReturn libraryValue
+            })
+            assertThatItRetains(mock<IfStmt> {
+                on { it.condition } doReturn nonLibraryValue
+            })
+            assertThatItDoesNotRetain(mock<IfStmt> {
+                on { it.condition } doReturn userValue
+            })
         }
 
         it("filters switch statements") {
-            assertThatItRetains(mock<SwitchStmt>())
+            assertThatItRetains(mock<SwitchStmt> {
+                on { it.key } doReturn libraryValue
+            })
+            assertThatItRetains(mock<SwitchStmt> {
+                on { it.key } doReturn nonLibraryValue
+            })
+            assertThatItDoesNotRetain(mock<SwitchStmt> {
+                on { it.key } doReturn userValue
+            })
         }
 
         it("filters invoke statements") {
@@ -68,7 +85,15 @@ internal object StatementFilterTest : Spek({
         }
 
         it("filters return statements") {
-            assertThatItRetains(mock<ReturnStmt>())
+            assertThatItRetains(mock<ReturnStmt> {
+                on { op } doReturn libraryValue
+            })
+            assertThatItRetains(mock<ReturnStmt> {
+                on { op } doReturn nonLibraryValue
+            })
+            assertThatItDoesNotRetain(mock<ReturnStmt> {
+                on { op } doReturn userValue
+            })
         }
 
         it("filters goto statements") {

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
@@ -58,7 +58,7 @@ internal object StatementFilterTest : Spek({
             assertThatItRetains(mock<IfStmt> {
                 on { it.condition } doReturn nonLibraryValue
             })
-            assertThatItDoesNotRetain(mock<IfStmt> {
+            assertThatItRetains(mock<IfStmt> {
                 on { it.condition } doReturn userValue
             })
         }

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/StatementFilterTest.kt
@@ -70,7 +70,7 @@ internal object StatementFilterTest : Spek({
             assertThatItRetains(mock<SwitchStmt> {
                 on { it.key } doReturn nonLibraryValue
             })
-            assertThatItDoesNotRetain(mock<SwitchStmt> {
+            assertThatItRetains(mock<SwitchStmt> {
                 on { it.key } doReturn userValue
             })
         }

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilterTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.assertThrows
 import soot.Immediate
 import soot.IntType
 import soot.Local
+import soot.Modifier
 import soot.RefType
 import soot.SootClass
 import soot.SootField
@@ -38,9 +39,11 @@ internal object ValueFilterTest : Spek({
 
     val libraryType = mock<RefType> {
         on { toString() } doReturn LIBRARY_CLASS
+        on { sootClass } doReturn SootClass(LIBRARY_CLASS, Modifier.PUBLIC)
     }
     val nonLibraryType = mock<RefType> {
         on { toString() } doReturn NON_LIBRARY_CLASS
+        on { sootClass } doReturn SootClass(NON_LIBRARY_CLASS, Modifier.PUBLIC)
     }
 
     describe("filtering of expression values based on library usage") {

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessorTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessorTest.kt
@@ -8,7 +8,6 @@ import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.LIBRARY_CLASS
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.NON_LIBRARY_CLASS
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.USER_CLASS
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.constructInvokeExprMock
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.libraryProject
@@ -16,12 +15,15 @@ import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
 import soot.Body
+import soot.BooleanType
+import soot.IntType
 import soot.Local
 import soot.PatchingChain
 import soot.Unit
 import soot.Value
 import soot.jimple.Constant
 import soot.jimple.IfStmt
+import soot.jimple.SwitchStmt
 import soot.jimple.internal.JEqExpr
 import soot.util.IterableSet
 
@@ -31,13 +33,12 @@ import soot.util.IterableSet
 internal object UserUsageProcessorTest : Spek({
     fun createBody(units: Collection<Unit>) =
         mock<Body> {
-            on { it.units } doReturn  PatchingChain(IterableSet(units))
+            on { it.units } doReturn PatchingChain(IterableSet(units))
         }
 
     describe("user usage processor") {
         val libraryValue = constructInvokeExprMock(LIBRARY_CLASS)
         val userValue = constructInvokeExprMock(USER_CLASS)
-        val nonLibraryValue = constructInvokeExprMock(NON_LIBRARY_CLASS)
 
         lateinit var userUsageProcessor: UserUsageProcessor
 
@@ -47,6 +48,7 @@ internal object UserUsageProcessorTest : Spek({
 
         it("removes user usages from if-statements") {
             val ifStmt = mock<IfStmt> {
+                on { branches() } doReturn true
                 on { condition } doReturn userValue
             }
 
@@ -57,17 +59,45 @@ internal object UserUsageProcessorTest : Spek({
 
             val newCondition = captor.firstValue as? JEqExpr ?: throw AssertionError("Captured value is not a JEqExpr.")
             assertThat(newCondition.op1).isInstanceOf(Local::class.java)
+            assertThat(newCondition.op1.type).isEqualTo(BooleanType.v())
             assertThat(newCondition.op2).isInstanceOf(Constant::class.java)
         }
 
         it("does not touch if-statements using the library") {
             val ifStmt = mock<IfStmt> {
+                on { branches() } doReturn true
                 on { condition } doReturn libraryValue
             }
 
             userUsageProcessor.process(createBody(listOf(ifStmt)))
 
             verify(ifStmt, never()).condition = any()
+        }
+
+        it("removes user usages from switch-statements") {
+            val switchStmt = mock<SwitchStmt> {
+                on { branches() } doReturn true
+                on { key } doReturn userValue
+            }
+
+            userUsageProcessor.process(createBody(listOf(switchStmt)))
+
+            val captor = argumentCaptor<Value>()
+            verify(switchStmt).key = captor.capture()
+
+            val newCondition = captor.firstValue as? Local ?: throw AssertionError("Captured value is not a Local.")
+            assertThat(newCondition.type).isEqualTo(IntType.v())
+        }
+
+        it("does not touch switch-statements using the library") {
+            val switchStmt = mock<SwitchStmt> {
+                on { branches() } doReturn true
+                on { key } doReturn libraryValue
+            }
+
+            userUsageProcessor.process(createBody(listOf(switchStmt)))
+
+            verify(switchStmt, never()).key = any()
         }
     }
 })

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessorTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessorTest.kt
@@ -1,0 +1,73 @@
+package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.processors
+
+import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argumentCaptor
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.never
+import com.nhaarman.mockito_kotlin.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.LIBRARY_CLASS
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.NON_LIBRARY_CLASS
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.USER_CLASS
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.constructInvokeExprMock
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.libraryProject
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import soot.Body
+import soot.Local
+import soot.PatchingChain
+import soot.Unit
+import soot.Value
+import soot.jimple.Constant
+import soot.jimple.IfStmt
+import soot.jimple.internal.JEqExpr
+import soot.util.IterableSet
+
+/**
+ * Unit tests for [UserUsageProcessor].
+ */
+internal object UserUsageProcessorTest : Spek({
+    fun createBody(units: Collection<Unit>) =
+        mock<Body> {
+            on { it.units } doReturn  PatchingChain(IterableSet(units))
+        }
+
+    describe("user usage processor") {
+        val libraryValue = constructInvokeExprMock(LIBRARY_CLASS)
+        val userValue = constructInvokeExprMock(USER_CLASS)
+        val nonLibraryValue = constructInvokeExprMock(NON_LIBRARY_CLASS)
+
+        lateinit var userUsageProcessor: UserUsageProcessor
+
+        beforeEachTest {
+            userUsageProcessor = UserUsageProcessor(libraryProject)
+        }
+
+        it("removes user usages from if-statements") {
+            val ifStmt = mock<IfStmt> {
+                on { condition } doReturn userValue
+            }
+
+            userUsageProcessor.process(createBody(listOf(ifStmt)))
+
+            val captor = argumentCaptor<Value>()
+            verify(ifStmt).condition = captor.capture()
+
+            val newCondition = captor.firstValue as? JEqExpr ?: throw AssertionError("Captured value is not a JEqExpr.")
+            assertThat(newCondition.op1).isInstanceOf(Local::class.java)
+            assertThat(newCondition.op2).isInstanceOf(Constant::class.java)
+        }
+
+        it("does not touch if-statements using the library") {
+            val ifStmt = mock<IfStmt> {
+                on { condition } doReturn libraryValue
+            }
+
+            userUsageProcessor.process(createBody(listOf(ifStmt)))
+
+            verify(ifStmt, never()).condition = any()
+        }
+    }
+})


### PR DESCRIPTION
If a `ReturnStmt` returns a type from a user project, it should be filtered out.

Additionally, `IfStmt`s should be filtered out if they use the user project, except that this would significantly reduce the amount of paths accessible, so instead these conditions are changed with a random one. Something similar happens to `SwitchStmt`s.