### PR TITLE
Set default log level to 'info'

### DIFF
--- a/modules/application/src/main/resources/logback.xml
+++ b/modules/application/src/main/resources/logback.xml
@@ -5,7 +5,7 @@
         </encoder>
     </appender>
 
-    <root level="warn">
+    <root level="info">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
I believe that the default choice should provide the user with enough output to get an understanding of what's going on in the tool at the moment, which the `info` level provides. I suggest we make this level the default.