### PR TITLE
Singleton custom list

### DIFF
--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpan.kt
@@ -60,7 +60,12 @@ internal class CCSpan<N : Node>(
 
     private fun findFrequentSingletonSequences() {
         sequencesOfPreviousLength += nodeSequenceUtil.findFrequentNodesInSequences(equalsSequences, minimumSupport)
-            .map { (node, support) -> SequenceTriple(listOf(node), support) }
+            .map { (node, support) ->
+                SequenceTriple(
+                    CustomEqualsList(listOf(node), Node.Companion::equiv, Node::equivHashCode),
+                    support
+                )
+            }
     }
 
     private fun findAllContiguousSequencesOfLength(

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/module-integration-test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanIntegrationTest.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/module-integration-test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanIntegrationTest.kt
@@ -29,20 +29,32 @@ internal object CCSpanIntegrationTest : Spek({
 
         it("can detect very simple patterns") {
             val localA = Jimple.v().newLocal("local", IntType.v())
-            val stmtA2 = Jimple.v().newAssignStmt(localA, IntConstant.v(504))
-            val nodeA2 = JimpleNode(stmtA2)
-            val stmtA1 = Jimple.v().newAssignStmt(localA, IntConstant.v(591))
-            val nodeA1 = JimpleNode(stmtA1, mutableListOf(nodeA2))
+            val nodeA2 = JimpleNode(Jimple.v().newAssignStmt(localA, IntConstant.v(504)))
+            val nodeA1 = JimpleNode(Jimple.v().newAssignStmt(localA, IntConstant.v(591)), mutableListOf(nodeA2))
 
             val localB = Jimple.v().newLocal("local", IntType.v())
-            val stmtB2 = Jimple.v().newAssignStmt(localB, IntConstant.v(504))
-            val nodeB2 = JimpleNode(stmtB2)
-            val stmtB1 = Jimple.v().newAssignStmt(localB, IntConstant.v(591))
-            val nodeB1 = JimpleNode(stmtB1, mutableListOf(nodeB2))
+            val nodeB2 = JimpleNode(Jimple.v().newAssignStmt(localB, IntConstant.v(504)))
+            val nodeB1 = JimpleNode(Jimple.v().newAssignStmt(localB, IntConstant.v(591)), mutableListOf(nodeB2))
 
             val patterns = patternDetector.findPatterns(listOf(nodeA1, nodeB1))
 
             assertThat(patterns).containsExactly(listOf(nodeA1, nodeA2))
+        }
+
+        it("correctly uses the custom equivalence method to compare singleton lists") {
+            val localA = Jimple.v().newLocal("local", IntType.v())
+            val nodeA1 = JimpleNode(Jimple.v().newAssignStmt(localA, IntConstant.v(107)))
+
+            val localB = Jimple.v().newLocal("local", IntType.v())
+            val nodeB2 = JimpleNode(Jimple.v().newAssignStmt(localB, IntConstant.v(944)))
+            val nodeB1 = JimpleNode(Jimple.v().newAssignStmt(localB, IntConstant.v(107)), mutableListOf(nodeB2))
+
+            val patterns = patternDetector.findPatterns(listOf(nodeA1, nodeB1))
+
+            assertThat(patterns).containsExactlyInAnyOrder(
+                listOf(nodeA1),
+                listOf(nodeB1, nodeB2)
+            )
         }
     }
 })


### PR DESCRIPTION
When CCSpan find frequent singleton sequences, it should put the singleton sequence into a `CustomEqualsList` to ensure that comparisons are done using structural equivalence.