### PR TITLE
Rename incorrectly renamed class

### DIFF
--- a/modules/mining-pipeline/prefix-span-pattern-detector/src/module-integration-test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpanJimpleNodeIntegrationTest.kt
+++ b/modules/mining-pipeline/prefix-span-pattern-detector/src/module-integration-test/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/prefixspan/PrefixSpanJimpleNodeIntegrationTest.kt
@@ -13,7 +13,7 @@ import org.jetbrains.spek.api.dsl.xit
 import soot.jimple.DefinitionStmt
 import soot.jimple.IfStmt
 
-internal object CCSpanJimpleNodeIntegrationTest : Spek({
+internal object PrefixSpanJimpleNodeIntegrationTest : Spek({
     /**
      * Calculates how many sub-sequences a given sequence may have.
      */


### PR DESCRIPTION
In #263 I accidentally named a PrefixSpan-related integration test class to `CCSpanJimpleIntegrationTest`, so this PR fixes that.