### PR TITLE
Switch single equiv fix

### DIFF
--- a/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumerator.kt
+++ b/modules/models/jimple-library-usage-graph/src/main/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumerator.kt
@@ -91,9 +91,9 @@ class JimplePathEnumerator(entryNode: JimpleNode, maximumPathLength: Int) :
             ?: throw IllegalStateException("SwitchStmt changed class after copy.")
         val defaultTargetNode = node.successors
             .filterIsInstance<JimpleNode>()
-            .singleEquiv { it.statement === statementCopy.defaultTarget }
+            .first { it.statement === statementCopy.defaultTarget }
 
-        val currentBranchNode = node.successors.singleEquiv { it in path }
+        val currentBranchNode = node.successors.first { it in path }
         (0 until node.successors.size)
             .filterNot { node.successors[it] === currentBranchNode }
             .filterNot { node.successors[it] === defaultTargetNode }
@@ -151,21 +151,3 @@ private fun MutableList<JimpleNode>.replaceAndUpdateTargets(old: JimpleNode, new
 }
 
 private fun Node.findNextCommonNodeWithOrNull(node: Node) = this.toList().intersect(node.toList()).firstOrNull()
-
-/**
- * Returns the first element for which [predicate] is true iff all elements for which [predicate] is true are
- * equivalent; otherwise an [IllegalArgumentException] is thrown.
- *
- * @param N the type of [Node] contained in this [Iterable]
- * @param predicate the predicate to check for
- * @return the first element for which [predicate] is true iff all elements for which [predicate] is true are
- * equivalent
- */
-private fun <N : Node> Iterable<N>.singleEquiv(predicate: (N) -> Boolean): N {
-    val candidates = this.toList().filter(predicate)
-    require(candidates.isNotEmpty()) { "No elements match the predicate." }
-    require(candidates.all { it.equivTo(candidates.first()) }) {
-        "Not all elements matching the predicate are equivalent."
-    }
-    return candidates.first()
-}

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumeratorTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumeratorTest.kt
@@ -414,6 +414,38 @@ internal object JimplePathEnumeratorTest : Spek({
                 )
             }
 
+            it("correctly identifies the current branch when a branch is empty") {
+                val endNode = createReturnNode(local)
+                val switchDefaultTargetGoto = createGotoNode(endNode)
+                val switchDefaultTargetNode = createAssignNode(local, 3, switchDefaultTargetGoto)
+                val switchTargetAGoto = createGotoNode(endNode)
+                val switchTargetANode = createAssignNode(local, 1, switchTargetAGoto)
+                val switchNode = createSwitchNode(local, switchDefaultTargetNode, switchTargetANode, endNode)
+                val localInitNode = createAssignNode(local, 0, switchNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, switchDefaultTargetNode, endNode, endNode),
+                        switchDefaultTargetNode,
+                        switchDefaultTargetGoto,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, switchTargetANode, endNode),
+                        switchTargetANode,
+                        switchTargetAGoto,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, endNode, endNode),
+                        endNode
+                    )
+                )
+            }
+
             it("correctly identifies the current branch when the default is empty") {
                 val endNode = createReturnNode(local)
                 val switchTargetBGoto = createGotoNode(endNode)

--- a/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumeratorTest.kt
+++ b/modules/models/jimple-library-usage-graph/src/test/kotlin/org/cafejojo/schaapi/models/libraryusagegraph/jimple/JimplePathEnumeratorTest.kt
@@ -413,6 +413,38 @@ internal object JimplePathEnumeratorTest : Spek({
                     )
                 )
             }
+
+            it("correctly identifies the current branch when the default is empty") {
+                val endNode = createReturnNode(local)
+                val switchTargetBGoto = createGotoNode(endNode)
+                val switchTargetBNode = createAssignNode(local, 2, switchTargetBGoto)
+                val switchTargetAGoto = createGotoNode(endNode)
+                val switchTargetANode = createAssignNode(local, 1, switchTargetAGoto)
+                val switchNode = createSwitchNode(local, endNode, switchTargetANode, switchTargetBNode)
+                val localInitNode = createAssignNode(local, 0, switchNode)
+
+                assertThatEnumeratorCreatesPaths(localInitNode,
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, endNode, endNode),
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, switchTargetANode, endNode),
+                        switchTargetANode,
+                        switchTargetAGoto,
+                        endNode
+                    ),
+                    listOf(
+                        localInitNode,
+                        createSwitchNode(local, endNode, endNode, switchTargetBNode),
+                        switchTargetBNode,
+                        switchTargetBGoto,
+                        endNode
+                    )
+                )
+            }
         }
     }
 })


### PR DESCRIPTION
In the the `JimplePathEnumerator` from #275 I assumed that, after enumerating the paths, there would only be one branch intact in a switch. That is, I assumed that a switch could be generalised to the following:
```
switch (x) {
    case 1: a(); break;
    case 2: b(); break;
    default: c();
}
d();
```
Where `a()`, `b()`, and `d()` could be empty and the breaks are optional. The code explicitly asserted that this was the case by checking that all successors of the `SwitchStmt` that are still in the current enumerated path are equivalent. However, if `c()` is empty and we are currently looking at the enumerated path that retains `case 1`, there will be two successors: `a()` and `d()`.

This PR simply removes the check that all successors in the current enumerated path are equivalent.