### PR TITLE
Use snapshot release of Jacoco

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ allprojects {
     repositories {
         mavenCentral()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url = "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 
     dependencies {
@@ -79,6 +80,10 @@ allprojects {
             append = true
             destinationFile = file("$buildDir/jacoco/test.exec")
         }
+    }
+
+    jacoco {
+        toolVersion = '0.8.2-SNAPSHOT'
     }
 
     jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -83,7 +83,7 @@ allprojects {
     }
 
     jacoco {
-        toolVersion = '0.8.2-SNAPSHOT'
+        toolVersion = jacocoVersion
     }
 
     jacocoTestReport {

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ targetCompatibility = 1.8
 assertjVersion       = 3.9.0
 detektVersion        = 1.0.0.RC6-4
 dokkaVersion         = 0.9.17
+jacocoVersion        = 0.8.2-SNAPSHOT
 junitVersion         = 5.2.0
 kotlinVersion        = 1.2.50
 kotlinLoggingVersion = 1.5.4


### PR DESCRIPTION
~Hopefully~ fixes issues with Jacoco's calculation of coverage in Kotlin.

| Before | After |
|---|---|
| ![Low coverage](https://user-images.githubusercontent.com/13442533/41849939-18e5d726-7883-11e8-80e3-e69487bdf33e.png) | ![High coverage](https://user-images.githubusercontent.com/13442533/41849943-1c86b116-7883-11e8-9d17-5c5e80358b11.png) |


