### PR TITLE
Make return type `Object` if `null` is returned

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -141,16 +141,16 @@ internal class ClassGenerator(className: String) {
 
     private fun addReturnStatement(jimpleBody: Body): Type {
         val lastStatement = jimpleBody.units.last()
-        val returnType = when (lastStatement) {
-            is JReturnStmt -> lastStatement.op.type
+        return when (lastStatement) {
+            is JReturnStmt ->
+                if (lastStatement.op.type == NullType.v()) RefType.v("java.lang.Object")
+                else lastStatement.op.type
             is JReturnVoidStmt -> VoidType.v()
             else -> {
                 jimpleBody.units.add(Jimple.v().newReturnVoidStmt())
                 VoidType.v()
             }
         }
-
-        return if (returnType == NullType.v()) RefType.v("java.lang.Object") else returnType
     }
 
     private fun findUnboundVariables(statements: List<Unit>): Set<Value> {

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -12,6 +12,8 @@ import soot.IntType
 import soot.Local
 import soot.LongType
 import soot.Modifier
+import soot.NullType
+import soot.RefType
 import soot.Scene
 import soot.ShortType
 import soot.SootClass
@@ -139,8 +141,7 @@ internal class ClassGenerator(className: String) {
 
     private fun addReturnStatement(jimpleBody: Body): Type {
         val lastStatement = jimpleBody.units.last()
-
-        return when (lastStatement) {
+        val returnType = when (lastStatement) {
             is JReturnStmt -> lastStatement.op.type
             is JReturnVoidStmt -> VoidType.v()
             else -> {
@@ -148,6 +149,8 @@ internal class ClassGenerator(className: String) {
                 VoidType.v()
             }
         }
+
+        return if (returnType == NullType.v()) RefType.v("java.lang.Object") else returnType
     }
 
     private fun findUnboundVariables(statements: List<Unit>): Set<Value> {

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGeneratorTest.kt
@@ -261,7 +261,7 @@ internal object ClassGeneratorTest : Spek({
         assertThat(jimpleMethod.returnType).isEqualTo(VoidType.v())
     }
 
-    it("should generate a method with return type boolean of last statement is return boolean") {
+    it("should generate a method with return type boolean if last statement is return boolean") {
         val c = Jimple.v().newLocal("c", BooleanType.v())
 
         val assignC = Jimple.v().newAssignStmt(c, IntConstant.v(10))
@@ -285,6 +285,16 @@ internal object ClassGeneratorTest : Spek({
         }.sootClass.methods.last()
 
         assertThat(jimpleMethod.returnType).isEqualTo(c.type)
+    }
+
+    it("should generate a method with Object as return type if last statement returns null") {
+        val returnStmt = Jimple.v().newReturnStmt(NullConstant.v())
+
+        val jimpleMethod = ClassGenerator("myClass").apply {
+            generateMethod("method", listOf(JimpleNode(returnStmt)))
+        }.sootClass.methods.last()
+
+        assertThat(jimpleMethod.returnType).isEqualTo(RefType.v("java.lang.Object"))
     }
 
     it("should generate a method with only statements before return") {


### PR DESCRIPTION
If a method returns `null`, the current `ClassGenerator` will set its return type to `null_type`. That's not good. This PR makes the `ClassGenerator` set the return type to `java.lang.Object` instead.