### PR TITLE
Filter out all dynamic invoke expressions

### DIFF
--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -90,6 +90,7 @@ private class ClassValueFilterRule : ValueFilterRule() {
     override fun applyOther(value: Value) =
         throw UnsupportedValueException("Value of type ${value.javaClass} is not supported by the value filter.")
 
+    override fun apply(value: DynamicInvokeExpr) = false
     override fun apply(value: NewArrayExpr) = false
     override fun apply(value: NewMultiArrayExpr) = false
     override fun apply(value: IdentityRef) = false

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/users/LambdaTest.java
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/users/LambdaTest.java
@@ -1,0 +1,18 @@
+package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.users;
+
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.Object1;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class LambdaTest {
+    public void test() {
+        List<Object1> o1s = new ArrayList<>();
+        o1s.add(new Object1());
+
+        o1s.forEach(o1 -> {
+            o1.m1();
+            o1.m3();
+        });
+    }
+}

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -485,6 +485,28 @@ internal object IntegrationTest : Spek({
             assertThat(libraryUsageGraphs).isEmpty()
         }
     }
+
+    describe("lambdas") {
+        it("filters out lambdas") {
+            val libraryUsageGraph = JimpleLibraryUsageGraphGenerator().generate(
+                libraryProject,
+                TestProject(testClassesClassPath, setOf(
+                    "$TEST_CLASSES_PACKAGE.users.LambdaTest"
+                ))
+            )[0]
+
+            assertThatStructureMatches(
+                node<JAssignStmt>(
+                    node<JInvokeStmt>(
+                        node<JInvokeStmt>(
+                            node<JReturnVoidStmt>()
+                        )
+                    )
+                ),
+                libraryUsageGraph
+            )
+        }
+    }
 })
 
 private fun assertThatStructureMatches(structure: Node, libraryUsageGraph: Node) {


### PR DESCRIPTION
## Superseded by #299.

Soot does not fully support dynamic invokes (e.g. lambdas), which sometimes causes problems when `ClassConstant`s are used inside them (see also Sable/soot#379). This caused crashes when checking whether a type inside a lambda is a library type. @casperboone and I could not find an easy workaround and instead decided that it would be best to change Schaapi such that dynamic invokes (and thus lambdas) are ignored _completely_.
