### PR TITLE
Bump version number to 1.0.0-RC1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group               = org.cafejojo
-version             = 0.0.1
+version             = 1.0.0-RC1
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 


### PR DESCRIPTION
Bumps the version number of Schaapi to 1.0.0-RC1. The plan is to create a (pre-)release after this PR has been merged.