### PR TITLE
Filter lambdas

### DIFF
--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/library/LibrarySupplier.java
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/library/LibrarySupplier.java
@@ -1,0 +1,9 @@
+package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library;
+
+import java.util.function.Supplier;
+
+/**
+ * Exactly the same as {@link Supplier}, except that it counts as a library usage.
+ */
+public interface LibrarySupplier<T> extends Supplier<T> {
+}

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/library/Object1.java
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/library/Object1.java
@@ -7,6 +7,10 @@ public class Object1 {
 
     }
 
+    public static Object1 staticMethod2() {
+        return new Object1();
+    }
+
     public double m1() {
         return Math.random();
     }

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/users/LambdaClassConstantTest.java
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/users/LambdaClassConstantTest.java
@@ -1,0 +1,10 @@
+package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.users;
+
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.LibrarySupplier;
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.Object1;
+
+public class LambdaClassConstantTest {
+    public void test() {
+        LibrarySupplier<Object1> supplier = Object1::staticMethod2;
+    }
+}

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/users/LambdaTest.java
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/users/LambdaTest.java
@@ -1,0 +1,11 @@
+package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.users;
+
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.Object1;
+
+import java.util.function.Supplier;
+
+public class LambdaTest {
+    public void test() {
+        Supplier<Object1> supplier = Object1::staticMethod2;
+    }
+}

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/users/LambdaUsageTest.java
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/java/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/testclasses/users/LambdaUsageTest.java
@@ -4,7 +4,7 @@ import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasse
 
 import java.util.function.Supplier;
 
-public class LambdaTest {
+public class LambdaUsageTest {
     public void test() {
         Supplier<Object1> supplier = Object1::staticMethod2;
     }

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -485,6 +485,26 @@ internal object IntegrationTest : Spek({
             assertThat(libraryUsageGraphs).isEmpty()
         }
     }
+
+    describe("filtering of dynamic invokes") {
+        it("filters out lambdas that also have a library usage outside the lambda") {
+            val libraryUsageGraphs = JimpleLibraryUsageGraphGenerator().generate(
+                libraryProject,
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.LambdaClassConstantTest"))
+            )
+
+            assertThat(libraryUsageGraphs).isEmpty()
+        }
+
+        it("filters out lambdas that do not have a library usage outside the lambda") {
+            val libraryUsageGraphs = JimpleLibraryUsageGraphGenerator().generate(
+                libraryProject,
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.LambdaClassConstantTest"))
+            )
+
+            assertThat(libraryUsageGraphs).isEmpty()
+        }
+    }
 })
 
 private fun assertThatStructureMatches(structure: Node, libraryUsageGraph: Node) {

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/IntegrationTest.kt
@@ -499,7 +499,7 @@ internal object IntegrationTest : Spek({
         it("filters out lambdas that do not have a library usage outside the lambda") {
             val libraryUsageGraphs = JimpleLibraryUsageGraphGenerator().generate(
                 libraryProject,
-                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.LambdaClassConstantTest"))
+                TestProject(testClassesClassPath, setOf("$TEST_CLASSES_PACKAGE.users.LambdaUsageTest"))
             )
 
             assertThat(libraryUsageGraphs).isEmpty()

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilterTest.kt
@@ -3,7 +3,6 @@ package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.libraryClasses
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.libraryProject
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilterTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilterTest.kt
@@ -3,6 +3,7 @@ package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.libraryClasses
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.libraryProject
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
@@ -20,6 +21,7 @@ import soot.jimple.AnyNewExpr
 import soot.jimple.ArrayRef
 import soot.jimple.BinopExpr
 import soot.jimple.CastExpr
+import soot.jimple.ClassConstant
 import soot.jimple.ConcreteRef
 import soot.jimple.Constant
 import soot.jimple.Expr
@@ -229,6 +231,11 @@ internal object ValueFilterTest : Spek({
 
         it("filters constant immediates") {
             assertThatItDoesNotRetain(mock<Constant>())
+        }
+
+        it("filters class constants") {
+            assertThatItRetains(ClassConstant.v("L${LIBRARY_CLASS.replace('.', '/')};"))
+            assertThatItDoesNotRetain(ClassConstant.v("L${NON_LIBRARY_CLASS.replace('.', '/')};"))
         }
 
         it("does not recognize unknown immediates") {


### PR DESCRIPTION
Supersedes #295 and arguably a variation on #294.

Fixes the bug with `ClassConstant`s in lambdas. The changes are as follows:

* All `ClassConstant`s that start with a `(` are lambda types and are therefore filtered out. Soot just can't handle them.
* A `ClassConstant` is retained if the class it uses is a library type. At this point, it cannot contain a `(` because then it would already have been filtered out by the previous point.
* A `ClassConstant` is removed if the class it uses is a user project type. Again, it cannot contain a `(`.