### PR TITLE
Do not require Codecov checks to pass

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,3 @@
 codecov:
   notify:
-    require_ci_to_pass: yes
+    require_ci_to_pass: no


### PR DESCRIPTION
For some reason Codecov started displaying build stati on PRs and made the PR fail if the coverage didn't increase enough. This PR disables that again.
