### PR TITLE
Distinguish integration test classes

### DIFF
--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleUsageGraphGeneratorIntegrationTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleUsageGraphGeneratorIntegrationTest.kt
@@ -19,9 +19,10 @@ import soot.jimple.internal.JReturnVoidStmt
 import soot.jimple.internal.JTableSwitchStmt
 
 private const val TEST_CLASSES_PACKAGE = "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses"
-private val testClassesClassPath = IntegrationTest::class.java.getResource("../../../../../../").toURI().path
+private val testClassesClassPath =
+    JimpleUsageGraphGeneratorIntegrationTest::class.java.getResource("../../../../../../").toURI().path
 
-internal object IntegrationTest : Spek({
+internal object JimpleUsageGraphGeneratorIntegrationTest : Spek({
     describe("the integration of different components of the package for simple classes") {
         it("converts a simple class to a library usage graph") {
             val libraryUsageGraph = JimpleLibraryUsageGraphGenerator().generate(

--- a/modules/validation-pipeline/ci-job/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobIntegrationTest.kt
+++ b/modules/validation-pipeline/ci-job/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobIntegrationTest.kt
@@ -11,7 +11,7 @@ import org.springframework.context.ApplicationEventPublisher
 import java.io.File
 import java.nio.file.Files
 
-object IntegrationTest : Spek({
+object CIJobIntegrationTest : Spek({
     lateinit var storageDirectory: File
     lateinit var projectDirectory: File
 

--- a/modules/validation-pipeline/github-interactor/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubinteractor/GitHubInteractorIntegrationTest.kt
+++ b/modules/validation-pipeline/github-interactor/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/githubinteractor/GitHubInteractorIntegrationTest.kt
@@ -28,9 +28,9 @@ import java.util.concurrent.TimeUnit
 @ExtendWith(SpringExtension::class)
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    classes = [IntegrationTest.TestConfig::class]
+    classes = [GitHubInteractorIntegrationTest.TestConfig::class]
 )
-class IntegrationTest {
+class GitHubInteractorIntegrationTest {
     lateinit var testsStorageLocation: Path
 
     @Autowired
@@ -48,7 +48,7 @@ class IntegrationTest {
     @BeforeEach
     fun setUp() {
         System.getProperties().load(
-            IntegrationTest::class.java.getResourceAsStream("/githubtestreporter.properties")
+            GitHubInteractorIntegrationTest::class.java.getResourceAsStream("/githubtestreporter.properties")
         )
 
         testsStorageLocation = Files.createTempDirectory("schaapi-github")
@@ -73,7 +73,7 @@ class IntegrationTest {
             }
         )[1]
 
-        val requestJson = IntegrationTest::class.java
+        val requestJson = GitHubInteractorIntegrationTest::class.java
             .getResourceAsStream("/fixtures/github/check_suite_webhook.resp").bufferedReader().readText()
 
         val entity = HttpEntity(
@@ -109,7 +109,7 @@ class IntegrationTest {
             }
         )[1]
 
-        val requestJson = IntegrationTest::class.java
+        val requestJson = GitHubInteractorIntegrationTest::class.java
             .getResourceAsStream("/fixtures/github/check_run_rerequested_webhook.resp").bufferedReader().readText()
 
         val entity = HttpEntity(
@@ -135,7 +135,7 @@ class IntegrationTest {
 
     @Test
     fun `it can receive an 'installation created' web hook`() {
-        val requestJson = IntegrationTest::class.java
+        val requestJson = GitHubInteractorIntegrationTest::class.java
             .getResourceAsStream("/fixtures/github/installation_created_webhook.resp").bufferedReader().readText()
 
         val entity = HttpEntity(
@@ -155,7 +155,7 @@ class IntegrationTest {
 
     @Test
     fun `it can receive an 'installation deleted' web hook`() {
-        val requestJson = IntegrationTest::class.java
+        val requestJson = GitHubInteractorIntegrationTest::class.java
             .getResourceAsStream("/fixtures/github/installation_deleted_webhook.resp").bufferedReader().readText()
 
         val entity = HttpEntity(


### PR DESCRIPTION
Renames all `IntegrationTest` classes to make it easier to distinguish between them.