### PR TITLE
Handle IOException when opening InputStream to download GitHub project

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -133,8 +133,7 @@ internal class GitHubProjectDownloader<P : Project>(
             val connection = url.openConnection() as? HttpURLConnection ?: return null
             logger.debug { "Established a connection with '$url'." }
 
-            connection.apply { requestMethod = "GET" }
-            return connection.inputStream
+            return connection.apply { requestMethod = "GET" }.inputStream
         } catch (e: IOException) {
             logger.warn("Could not connect to project $projectName.", e.message)
             return null

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -71,7 +71,7 @@ internal class GitHubProjectDownloader<P : Project>(
             gitHubProject.extractMasterFile()
             projectPacker(gitHubProject).also { logger.debug { "Created project of $gitHubProject." } }
         } catch (e: IllegalArgumentException) {
-            logger.warn("Unable to pack $gitHubProject into project.", e)
+            logger.warn("Unable to pack $gitHubProject into project.", e.message)
             gitHubProject.deleteRecursively()
             null
         }
@@ -96,7 +96,7 @@ internal class GitHubProjectDownloader<P : Project>(
                 logger.warn { "Output file ${zipFile.path} could not be created." }
             }
         } catch (e: IOException) {
-            logger.warn("Could not save project to ${zipFile.path}.", e)
+            logger.warn("Could not save project to ${zipFile.path}.", e.message)
             return null
         }
 
@@ -114,10 +114,10 @@ internal class GitHubProjectDownloader<P : Project>(
             ZipUtil.unpack(projectZipFile, githubProject)
             logger.debug { "Successfully unzipped file ${projectZipFile.absolutePath}." }
         } catch (e: IOException) {
-            logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e)
+            logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e.message)
             return null
         } catch (e: ZipException) {
-            logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e)
+            logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e.message)
             return null
         } finally {
             projectZipFile.delete()
@@ -136,7 +136,7 @@ internal class GitHubProjectDownloader<P : Project>(
             connection.apply { requestMethod = "GET" }
             return connection.inputStream
         } catch (e: IOException) {
-            logger.warn("Could not connect to project $projectName", e)
+            logger.warn("Could not connect to project $projectName.", e.message)
             return null
         }
     }

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -126,7 +126,7 @@ internal class GitHubProjectDownloader<P : Project>(
         return if (githubProject.exists()) githubProject else null
     }
 
-    internal fun getInputStream(projectName: String): InputStream? {
+    private fun getInputStream(projectName: String): InputStream? {
         val url = getURl(projectName)
 
         try {

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -71,7 +71,7 @@ internal class GitHubProjectDownloader<P : Project>(
             gitHubProject.extractMasterFile()
             projectPacker(gitHubProject).also { logger.debug { "Created project of $gitHubProject." } }
         } catch (e: IllegalArgumentException) {
-            logger.warn("Unable to pack $gitHubProject into project.", e.message)
+            logger.warn("Unable to pack $gitHubProject into project.", e)
             gitHubProject.deleteRecursively()
             null
         }
@@ -96,7 +96,7 @@ internal class GitHubProjectDownloader<P : Project>(
                 logger.warn { "Output file ${zipFile.path} could not be created." }
             }
         } catch (e: IOException) {
-            logger.warn("Could not save project to ${zipFile.path}.", e.message)
+            logger.warn("Could not save project to ${zipFile.path}.", e)
             return null
         }
 
@@ -114,10 +114,10 @@ internal class GitHubProjectDownloader<P : Project>(
             ZipUtil.unpack(projectZipFile, githubProject)
             logger.debug { "Successfully unzipped file ${projectZipFile.absolutePath}." }
         } catch (e: IOException) {
-            logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e.message)
+            logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e)
             return null
         } catch (e: ZipException) {
-            logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e.message)
+            logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e)
             return null
         } finally {
             projectZipFile.delete()
@@ -135,7 +135,7 @@ internal class GitHubProjectDownloader<P : Project>(
 
             return connection.apply { requestMethod = "GET" }.inputStream
         } catch (e: IOException) {
-            logger.warn("Could not connect to project $projectName.", e.message)
+            logger.warn("Could not connect to project $projectName.", e)
             return null
         }
     }

--- a/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloaderTest.kt
+++ b/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloaderTest.kt
@@ -168,20 +168,6 @@ internal object GitHubProjectDownloaderTest : Spek({
     }
 
     describe("when downloading searchContent project") {
-        it("should create searchContent connection request with the correct url") {
-            val connection = GitHubProjectDownloader(emptyList(), output, ::testProjectPacker)
-                .getConnection("cafejojo/schaapi")
-
-            assertThat(connection?.url).isEqualTo(URL("https://github.com/cafejojo/schaapi/archive/master.zip"))
-        }
-
-        it("should create searchContent connection request with searchContent get request method") {
-            val connection = GitHubProjectDownloader(emptyList(), output, ::testProjectPacker)
-                .getConnection("cafejojo/schaapi")
-
-            assertThat(connection?.requestMethod).isEqualTo("GET")
-        }
-
         it("should save the unzipped file and delete the old zip file") {
             val zipFile = addZipFile("testProject", "content", Files.createTempDirectory("project-downloader").toFile())
 


### PR DESCRIPTION
Before, the input stream was opened in the `downloadAndSaveProject` method, which did not catch `IOExceptions`. These however were thrown if an input stream could not be opened.

Now, the input stream is opened directly inside the `getInputStream` function, previously the `getConnection` function, which to me makes more sense. 
From what I've read online, it seems that closing this input stream is sufficient for releasing the underlying resources of the connection, meaning that is not necessary to also close the connection itself.