### PR TITLE
Make CI job truly asynchronous

### DIFF
--- a/modules/validation-pipeline/ci-job/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobInitiator.kt
+++ b/modules/validation-pipeline/ci-job/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobInitiator.kt
@@ -1,13 +1,11 @@
 package org.cafejojo.schaapi.validationpipeline.cijob
 
-import org.cafejojo.schaapi.validationpipeline.CIJobException
 import org.cafejojo.schaapi.validationpipeline.events.CIJobFailedEvent
 import org.cafejojo.schaapi.validationpipeline.events.CIJobSucceededEvent
 import org.cafejojo.schaapi.validationpipeline.events.ValidationRequestReceivedEvent
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.context.event.EventListener
 import org.springframework.stereotype.Component
-import java.util.concurrent.ExecutionException
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
@@ -24,16 +22,13 @@ class CIJobInitiator(private val publisher: ApplicationEventPublisher) {
      * Listens to [ValidationRequestReceivedEvent] events.
      */
     @EventListener
-    @Suppress("InstanceOfCheckForException")
-    fun handleValidateRequestReceivedEvent(event: ValidationRequestReceivedEvent) =
-        try {
-            executorService.submit(CIJob(event.metadata.getIdentifier(), event.directory, event.downloadUrl))
-                .get()
-                .let { testResults -> publisher.publishEvent(CIJobSucceededEvent(testResults, event.metadata)) }
-        } catch (exception: ExecutionException) {
-            exception.cause.let {
-                if (it !is CIJobException) throw exception
-                publisher.publishEvent(CIJobFailedEvent(it, event.metadata))
-            }
-        }
+    fun handleValidateRequestReceivedEvent(event: ValidationRequestReceivedEvent) = executorService.submit(
+            CIJob(
+                event.metadata.getIdentifier(),
+                event.directory,
+                event.downloadUrl,
+                { testResults -> publisher.publishEvent(CIJobSucceededEvent(testResults, event.metadata)) },
+                { ciJobException -> publisher.publishEvent(CIJobFailedEvent(ciJobException, event.metadata)) }
+            )
+        )
 }

--- a/modules/validation-pipeline/ci-job/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobIntegrationTest.kt
+++ b/modules/validation-pipeline/ci-job/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobIntegrationTest.kt
@@ -41,7 +41,7 @@ object CIJobIntegrationTest : Spek({
 
         initiator.handleValidateRequestReceivedEvent(
             ValidationRequestReceivedEvent(projectDirectory, downloadUrl, FakeMetadata(commitHash))
-        )
+        ).get()
 
         assertThat(event).isNotNull()
         event?.apply {
@@ -61,7 +61,7 @@ object CIJobIntegrationTest : Spek({
 
         initiator.handleValidateRequestReceivedEvent(
             ValidationRequestReceivedEvent(projectDirectory, downloadUrl, FakeMetadata(commitHash))
-        )
+        ).get()
 
         assertThat(event).isNotNull()
         event?.apply {

--- a/modules/validation-pipeline/ci-job/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobTest.kt
+++ b/modules/validation-pipeline/ci-job/src/test/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJobTest.kt
@@ -27,9 +27,9 @@ object CIJobTest : Spek({
         val commitHash = "ced7a679ba6337977d99effccdb4ac66b3ba34e0"
         val downloadUrl = "https://github.com/cafejojo/dummy-simple-maven-library/archive/$commitHash.zip"
 
-        val ciJob = CIJob(commitHash, projectDirectory, downloadUrl)
+        val ciJob = CIJob(commitHash, projectDirectory, downloadUrl, {}, {})
 
-        val testResults = ciJob.call()
+        val testResults = ciJob.executeJobSteps()
 
         assertThat(File(projectDirectory, "builds/$commitHash/README.md")).exists()
         assertThat(testResults.totalCount).isEqualTo(1)
@@ -39,9 +39,9 @@ object CIJobTest : Spek({
     it("throws an exception when the source code cannot be downloaded") {
         val downloadUrl = "https://non-existing-domain.test/files.zip"
 
-        val ciJob = CIJob("id", projectDirectory, downloadUrl)
+        val ciJob = CIJob("id", projectDirectory, downloadUrl, {}, {})
 
-        assertThatThrownBy { ciJob.call() }
+        assertThatThrownBy { ciJob.executeJobSteps() }
             .isInstanceOf(CIJobException::class.java)
             .hasMessageContaining("could not be downloaded")
             .hasMessageContaining(downloadUrl)
@@ -50,9 +50,9 @@ object CIJobTest : Spek({
     it("throws an exception when the source code cannot be extracted") {
         val downloadUrl = "https://httpbin.org/image"
 
-        val ciJob = CIJob("id", projectDirectory, downloadUrl)
+        val ciJob = CIJob("id", projectDirectory, downloadUrl, {}, {})
 
-        assertThatThrownBy { ciJob.call() }
+        assertThatThrownBy { ciJob.executeJobSteps() }
             .isInstanceOf(CIJobException::class.java)
             .hasMessageContaining("unzipping")
     }
@@ -61,9 +61,9 @@ object CIJobTest : Spek({
         val commitHash = "29fecd2f7391023d907957ed42949ca2bf6fedcc" // failing commit
         val downloadUrl = "https://github.com/cafejojo/dummy-simple-maven-library/archive/$commitHash.zip"
 
-        val ciJob = CIJob("id", projectDirectory, downloadUrl)
+        val ciJob = CIJob("id", projectDirectory, downloadUrl, {}, {})
 
-        assertThatThrownBy { ciJob.call() }
+        assertThatThrownBy { ciJob.executeJobSteps() }
             .isInstanceOf(CIJobException::class.java)
             .hasMessageContaining("library source code")
             .hasMessageContaining("compile")
@@ -79,9 +79,9 @@ object CIJobTest : Spek({
         val commitHash = "ced7a679ba6337977d99effccdb4ac66b3ba34e0" // passing commit
         val downloadUrl = "https://github.com/cafejojo/dummy-simple-maven-library/archive/$commitHash.zip"
 
-        val ciJob = CIJob("id", projectDirectory, downloadUrl)
+        val ciJob = CIJob("id", projectDirectory, downloadUrl, {}, {})
 
-        assertThatThrownBy { ciJob.call() }
+        assertThatThrownBy { ciJob.executeJobSteps() }
             .isInstanceOf(CIJobException::class.java)
             .hasMessageContaining("test compilation")
             .hasMessageContaining("boolean result = Patterns.pattern0(35);")
@@ -91,9 +91,9 @@ object CIJobTest : Spek({
         val commitHash = "78ab65330411737209587d790f94f12e3d9a95d0" // failing commit
         val downloadUrl = "https://github.com/cafejojo/dummy-simple-maven-library/archive/$commitHash.zip"
 
-        val ciJob = CIJob("id", projectDirectory, downloadUrl)
+        val ciJob = CIJob("id", projectDirectory, downloadUrl, {}, {})
 
-        val testResults = ciJob.call()
+        val testResults = ciJob.executeJobSteps()
 
         assertThat(testResults.totalCount).isEqualTo(1)
         assertThat(testResults.failureCount).isEqualTo(1)


### PR DESCRIPTION
Due to a design flaw in the previous version, running the CI job was not async. This meant that the connection from GitHub to our application remained open for a long time while posting a new web hook.