### PR TITLE
Practically ignore Codecov checks

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,9 @@
 codecov:
   notify:
     require_ci_to_pass: no
+
+coverage:
+  status:
+    project:
+      default
+        target: 10


### PR DESCRIPTION
#300 didn't exactly work, so here's another attempt. From now on, Codecov will pass as long as we still have 10% coverage afterwards. I deliberately didn't choose 0% or 1% because you know how it is with edge cases.
