### PR TITLE
Clean up MiningPipeline class and handle LibraryUsageGraphExceptions

### DIFF
--- a/modules/application/build.gradle
+++ b/modules/application/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compile project(":mining-pipeline:ccspan-pattern-detector")
 
     compile group: "commons-cli", name: "commons-cli", version: commonsCliVersion
+    compile group: "com.google.guava", name: "guava", version: guavaVersion
 }
 
 // Distribution

--- a/modules/application/build.gradle
+++ b/modules/application/build.gradle
@@ -21,7 +21,6 @@ dependencies {
     compile project(":mining-pipeline:ccspan-pattern-detector")
 
     compile group: "commons-cli", name: "commons-cli", version: commonsCliVersion
-    compile group: "com.google.guava", name: "guava", version: guavaVersion
 }
 
 // Distribution

--- a/modules/application/gradle.properties
+++ b/modules/application/gradle.properties
@@ -1,1 +1,2 @@
 commonsCliVersion = 1.4
+guavaVersion      = 25.1-jre

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/DirectoryMiningCommandLineInterface.kt
@@ -43,13 +43,14 @@ internal class DirectoryMiningCommandLineInterface : CommandLineInterface() {
                     outputDirectory = outputDir,
                     projectMiner = directory.createMiner(),
                     searchOptions = directory.createOptions(),
+                    libraryProject = libraryProject,
                     libraryProjectCompiler = JavaMavenProjectCompiler(true),
                     userProjectCompiler = JavaMavenProjectCompiler(),
                     libraryUsageGraphGenerator = jimpleLibraryUsageGraphGenerator,
                     patternDetector = patternDetector.createPatternDetector(),
                     patternFilter = patternFilter.createPatternFilter(libraryProject),
                     testGenerator = testGenerator.createTestGenerator(outputDir, libraryProject)
-                ).run(libraryProject)
+                ).run()
             }
             ProjectType.JAVA_JAR -> {
                 val libraryProject = JavaJarProject(libraryDir)
@@ -58,13 +59,14 @@ internal class DirectoryMiningCommandLineInterface : CommandLineInterface() {
                     outputDirectory = outputDir,
                     projectMiner = directory.createMiner(),
                     searchOptions = directory.createOptions(),
+                    libraryProject = libraryProject,
                     libraryProjectCompiler = JavaJarProjectCompiler(),
                     userProjectCompiler = JavaMavenProjectCompiler(),
                     libraryUsageGraphGenerator = jimpleLibraryUsageGraphGenerator,
                     patternDetector = patternDetector.createPatternDetector(),
                     patternFilter = patternFilter.createPatternFilter(libraryProject),
                     testGenerator = testGenerator.createTestGenerator(outputDir, libraryProject)
-                ).run(libraryProject)
+                ).run()
             }
         }
 

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/GitHubMiningCommandLineInterface.kt
@@ -43,13 +43,14 @@ internal class GitHubMiningCommandLineInterface : CommandLineInterface() {
                     outputDirectory = outputDir,
                     projectMiner = gitHub.createMiner(outputDir),
                     searchOptions = gitHub.createOptions(),
+                    libraryProject = libraryProject,
                     libraryProjectCompiler = JavaMavenProjectCompiler(true),
                     userProjectCompiler = JavaMavenProjectCompiler(),
                     libraryUsageGraphGenerator = jimpleLibraryUsageGraphGenerator,
                     patternDetector = patternDetector.createPatternDetector(),
                     patternFilter = patternFilter.createPatternFilter(libraryProject),
                     testGenerator = testGenerator.createTestGenerator(outputDir, libraryProject)
-                ).run(libraryProject)
+                ).run()
             }
             ProjectType.JAVA_JAR -> {
                 val libraryProject = JavaJarProject(libraryDir)
@@ -58,13 +59,14 @@ internal class GitHubMiningCommandLineInterface : CommandLineInterface() {
                     outputDirectory = outputDir,
                     projectMiner = gitHub.createMiner(outputDir),
                     searchOptions = gitHub.createOptions(),
+                    libraryProject = libraryProject,
                     libraryProjectCompiler = JavaJarProjectCompiler(),
                     userProjectCompiler = JavaMavenProjectCompiler(),
                     libraryUsageGraphGenerator = jimpleLibraryUsageGraphGenerator,
                     patternDetector = patternDetector.createPatternDetector(),
                     patternFilter = patternFilter.createPatternFilter(libraryProject),
                     testGenerator = testGenerator.createTestGenerator(outputDir, libraryProject)
-                ).run(libraryProject)
+                ).run()
             }
         }
 

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanPatternDetector.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanPatternDetector.kt
@@ -14,7 +14,7 @@ class CCSpanPatternDetector<N : Node>(
     private val enumerator: (N) -> PathEnumerator<N>,
     private val comparator: GeneralizedNodeComparator<N>
 ) : PatternDetector<N> {
-    override fun findPatterns(graphs: List<N>): List<Pattern<N>> {
+    override fun findPatterns(graphs: Iterable<N>): Iterable<Pattern<N>> {
         val sequences = graphs.flatMap { enumerator(it).enumerate() }
         return CCSpan(sequences, minimumCount, comparator).findFrequentPatterns()
     }

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/build.gradle
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/build.gradle
@@ -12,4 +12,5 @@ dependencies {
     compile group: "ca.mcgill.sable", name: "soot", version: sootVersion, {
         exclude group: "org.slf4j", module: "slf4j-simple"
     }
+    compile group: "me.tongfei", name: "progressbar", version: progressBarVersion
 }

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/gradle.properties
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/gradle.properties
@@ -1,2 +1,3 @@
 evosuiteMasterVersion = 1.0.6
+progressBarVersion    = 0.7.0
 sootVersion           = 3.1.0

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/TestGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/TestGenerator.kt
@@ -1,9 +1,9 @@
 package org.cafejojo.schaapi.miningpipeline.testgenerator.jimpleevosuite
 
-import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
-import org.cafejojo.schaapi.models.project.JavaProject
 import org.cafejojo.schaapi.miningpipeline.Pattern
 import org.cafejojo.schaapi.miningpipeline.TestGenerator
+import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
+import org.cafejojo.schaapi.models.project.JavaProject
 import java.io.File
 import java.io.PrintStream
 
@@ -19,7 +19,7 @@ class TestGenerator(
     private val processStandardStream: PrintStream? = null,
     private val processErrorStream: PrintStream? = null
 ) : TestGenerator<JimpleNode> {
-    override fun generate(patterns: List<Pattern<JimpleNode>>): File {
+    override fun generate(patterns: Iterable<Pattern<JimpleNode>>): File {
         val outputPatterns = outputDirectory.resolve("patterns/").apply { mkdirs() }
         val outputTests = outputDirectory.resolve("tests/").apply { mkdirs() }
 

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
@@ -1,5 +1,6 @@
 package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple
 
+import org.cafejojo.schaapi.miningpipeline.LibraryUsageGraphGenerationException
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import soot.Body
 import soot.jimple.Stmt
@@ -39,7 +40,7 @@ internal object ControlFlowGraphGenerator {
             return mappedUnits[unit]
         }
 
-        if (unit !is Stmt) throw IllegalArgumentException("Unit must be a statement.")
+        if (unit !is Stmt) throw LibraryUsageGraphGenerationException("Unit must be a statement.")
 
         val node = JimpleNode(unit)
 
@@ -59,9 +60,7 @@ internal object ControlFlowGraphGenerator {
  * @return the root of the control flow graph.
  */
 private fun UnitGraph.rootUnitIfExists(): SootUnit =
-    if (heads.isEmpty()) throw NoRootInControlFlowGraphException() else heads[0]
+    if (heads.isEmpty())
+        throw LibraryUsageGraphGenerationException("The control flow graph does not contain a root unit.")
+    else heads[0]
 
-/**
- * Exception for control flow graphs that have no root [SootUnit].
- */
-private class NoRootInControlFlowGraphException : Exception("The control flow graph does not contain a root unit.")

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
@@ -63,4 +63,3 @@ private fun UnitGraph.rootUnitIfExists(): SootUnit =
     if (heads.isEmpty())
         throw LibraryUsageGraphGenerationException("The control flow graph does not contain a root unit.")
     else heads[0]
-

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
@@ -3,6 +3,7 @@ package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple
 import org.cafejojo.schaapi.miningpipeline.LibraryUsageGraphGenerationException
 import org.cafejojo.schaapi.miningpipeline.LibraryUsageGraphGenerator
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.BranchStatementFilter
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.FilterException
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.RecursiveGotoFilter
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.StatementFilter
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.processors.UserUsageProcessor
@@ -99,7 +100,7 @@ class JimpleLibraryUsageGraphGenerator : LibraryUsageGraphGenerator<JavaProject,
                 BranchStatementFilter(libraryProject),
                 RecursiveGotoFilter()
             ).forEach { it.apply(methodBody) }
-        } catch (e: Exception) {
+        } catch (e: FilterException) {
             throw LibraryUsageGraphGenerationException("An exception occurred while filtering.", e)
         }
 

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/BranchStatementFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/BranchStatementFilter.kt
@@ -51,7 +51,7 @@ internal class BranchStatementFilter(project: JavaProject) : Filter {
         fun getConditionValue(statement: Unit): Value = when (statement) {
             is IfStmt -> statement.condition
             is SwitchStmt -> statement.key
-            else -> throw IllegalArgumentException("Cannot get value of unsupported statement.")
+            else -> throw FilterException("Cannot get value of unsupported statement.")
         }
     }
 

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/Filter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/Filter.kt
@@ -13,3 +13,5 @@ interface Filter {
      */
     fun apply(body: Body)
 }
+
+internal typealias FilterException = Exception

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/Filter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/Filter.kt
@@ -14,4 +14,4 @@ interface Filter {
     fun apply(body: Body)
 }
 
-internal typealias FilterException = Exception
+internal open class FilterException(override val message: String?) : Exception(message)

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/filters/ValueFilter.kt
@@ -204,4 +204,4 @@ private class UserUsageValueFilterRule(private val libraryProject: JavaProject) 
 /**
  * Exception for encountered values that are not supported by the [ClassValueFilterRule].
  */
-internal class UnsupportedValueException(message: String) : Exception(message)
+internal class UnsupportedValueException(message: String) : FilterException(message)

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/CsvWriter.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/CsvWriter.kt
@@ -19,7 +19,7 @@ class CsvWriter<N : Node>(output: File) {
      *
      * @param graphs graphs whose node counts will be written to file
      */
-    fun writeGraphSizes(graphs: List<N>) =
+    fun writeGraphSizes(graphs: Iterable<N>) =
         writeToFile("graphSize.csv", graphs, { graph: N -> graph.count() }, "graph_size")
 
     /**
@@ -27,7 +27,7 @@ class CsvWriter<N : Node>(output: File) {
      *
      * @param patterns patterns whose lengths will be written to file
      */
-    fun writePatternLengths(patterns: List<Pattern<N>>) =
+    fun writePatternLengths(patterns: Iterable<Pattern<N>>) =
         writeToFile("patterns.csv", patterns, { pattern: Pattern<N> -> pattern.size }, "pattern_length")
 
     /**
@@ -35,10 +35,10 @@ class CsvWriter<N : Node>(output: File) {
      *
      * @param patterns patterns whose lengths will be written to file
      */
-    fun writeFilteredPatternLengths(patterns: List<Pattern<N>>) =
+    fun writeFilteredPatternLengths(patterns: Iterable<Pattern<N>>) =
         writeToFile("filteredPatterns.csv", patterns, { pattern: Pattern<N> -> pattern.size }, "pattern_length")
 
-    private fun <P> writeToFile(output: String, items: List<P>, mapToInt: (P) -> Int, type: String) =
+    private fun <P> writeToFile(output: String, items: Iterable<P>, mapToInt: (P) -> Int, type: String) =
         File(dataFile, output).writer().use { fileWriter ->
             fileWriter.write("$type,count\n")
             items

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/LibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/LibraryUsageGraphGenerator.kt
@@ -17,4 +17,7 @@ interface LibraryUsageGraphGenerator<in LP : Project, in UP : Project, out N : N
     fun generate(libraryProject: LP, userProject: UP): List<N>
 }
 
-class LibraryUsageGraphGenerationException(message: String? = null, e: Throwable? = null) : RuntimeException(message, e)
+/**
+ * Exception thrown when something went wrong during the creation of a library usage graph.
+ */
+typealias LibraryUsageGraphGenerationException = RuntimeException

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/LibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/LibraryUsageGraphGenerator.kt
@@ -16,3 +16,5 @@ interface LibraryUsageGraphGenerator<in LP : Project, in UP : Project, out N : N
      */
     fun generate(libraryProject: LP, userProject: UP): List<N>
 }
+
+class LibraryUsageGraphGenerationException(message: String? = null, e: Throwable? = null) : RuntimeException(message, e)

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/LibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/LibraryUsageGraphGenerator.kt
@@ -20,4 +20,4 @@ interface LibraryUsageGraphGenerator<in LP : Project, in UP : Project, out N : N
 /**
  * Exception thrown when something went wrong during the creation of a library usage graph.
  */
-typealias LibraryUsageGraphGenerationException = RuntimeException
+class LibraryUsageGraphGenerationException(override val message: String?) : RuntimeException(message)

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
@@ -15,6 +15,7 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
     private val outputDirectory: File,
     private val projectMiner: ProjectMiner<SO, UP>,
     private val searchOptions: SO,
+    private val libraryProject: LP,
     private val libraryProjectCompiler: ProjectCompiler<LP>,
     private val userProjectCompiler: ProjectCompiler<UP>,
     private val libraryUsageGraphGenerator: LibraryUsageGraphGenerator<LP, UP, N>,
@@ -22,108 +23,122 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
     private val patternFilter: PatternFilter<N>,
     private val testGenerator: TestGenerator<N>
 ) {
-    private companion object : KLogging()
+    private companion object : KLogging() {
+        private inline fun <reified T : Iterable<*>, R> T.next(map: (T) -> R, message: String): R =
+            map(progressBarIterable(this, message) as? T ?: this)
+
+        /**
+         * Calls the specified function [map] on each element in `this` and returns the result as an iterable.
+         *
+         * Catches exceptions of type [E] and logs these. All other exceptions are thrown.
+         */
+        @Suppress("TooGenericExceptionCaught", "InstanceOfCheckForException") // This is intended behaviour
+        private inline fun <reified E : RuntimeException, T, R : Any>
+            Iterable<T>.next(map: (T) -> R, message: String): Iterable<R> =
+            progressBarIterable(this, message).mapNotNull {
+                try {
+                    map(it)
+                } catch (e: RuntimeException) {
+                    if (e is E) logger.warn { e.message } else throw e
+                    null
+                }
+            }
+
+        /**
+         * Calls the specified function [map] on each element in `this` and returns the result as an flat mapped
+         * iterable.
+         *
+         * Catches exceptions of type [E] and logs these. All other exceptions are thrown.
+         */
+        @Suppress("TooGenericExceptionCaught", "InstanceOfCheckForException") // This is intended behaviour
+        private inline fun <reified E : Exception, P, Q, T : Iterable<P>>
+            T.nextFlatMap(map: (P) -> Iterable<Q>, message: String): Iterable<Q> =
+            progressBarIterable(this, message).mapNotNull {
+                try {
+                    map(it)
+                } catch (e: RuntimeException) {
+                    if (e is E) logger.warn { e.message } else throw e
+                    null
+                }
+            }.flatten()
+
+        private fun <N> progressBarIterable(iterable: Iterable<N>, taskName: String): Iterable<N> =
+            ProgressBar.wrap(iterable, ProgressBarBuilder().apply {
+                setTaskName(taskName)
+                setStyle(ProgressBarStyle.ASCII)
+            })
+    }
+
+    private val csvWriter = CsvWriter<N>(outputDirectory)
 
     /**
      * Executes all steps in the pipeline.
      */
     @Suppress("TooGenericExceptionCaught") // In this case it is relevant to catch and log an Exception
-    fun run(libraryProject: LP) {
+    fun run() = try {
+        compileLibraryUsageProject()
+
+        logger.info { "Mining has started." }
+        logger.info { "Output directory is ${outputDirectory.absolutePath}." }
+
+        mineProjects()
+            .compileUserProjects()
+            .generateLibraryUsageGraphs()
+            .findAndFilterPatterns()
+            .generateTests()
+    } catch (e: Exception) {
+        logger.error("A critical error occurred during the mining process causing it to be aborted.", e)
+    } finally {
+        logger.info { "Mining has finished." }
+    }
+
+    private fun compileLibraryUsageProject() {
         logger.info { "Compiling library project." }
         ProgressBar("Compile library Project", 1, ProgressBarStyle.ASCII).use { progressBar ->
             libraryProjectCompiler.compile(libraryProject)
             progressBar.step()
         }
         logger.info { "Compiled library project." }
-
-        logger.info { "Mining has started." }
-        logger.info { "Output directory is ${outputDirectory.absolutePath}." }
-
-        val csvWriter = CsvWriter<N>(outputDirectory)
-
-        try {
-            searchOptions
-                .also { logger.info { "Started mining projects." } }
-                .next(projectMiner::mine)
-                .also { logger.info { "Successfully mined ${it.size} projects." } }
-
-                .also { logger.info { "Started compiling ${it.size} projects." } }
-                .nextCatchExceptions<CompilationException, UP, UP>(userProjectCompiler::compile, "Compiling projects")
-                .also { logger.info { "Successfully compiled ${it.count()} projects." } }
-
-                .also { logger.info { "Started generating library usage graphs for ${it.count()} projects." } }
-                .nextFlatMap<LibraryUsageGraphGenerationException, UP, N, Iterable<UP>>(
-                    { libraryUsageGraphGenerator.generate(libraryProject, it) },
-                    "Generating library-usage graphs")
-                .also { logger.info { "Successfully generated ${it.size} library usage graphs." } }
-                .also { csvWriter.writeGraphSizes(it) }
-
-                .also { logger.info { "Started finding patterns in ${it.size} library usage graphs." } }
-                .next(patternDetector::findPatterns, "Finding patterns")
-                .also { logger.info { "Successfully found ${it.size} patterns." } }
-                .also { csvWriter.writePatternLengths(it) }
-
-                .also { logger.info { "Started filtering ${it.size} patterns." } }
-                .next(patternFilter::filter, "Filtering patterns")
-                .also { logger.info { "${it.size} patterns remain after filtering." } }
-                .also { csvWriter.writeFilteredPatternLengths(it) }
-
-                .also { logger.info { "Started generating test for ${it.size} usage patterns." } }
-                .next(testGenerator::generate)
-                .also { logger.info { "Test generation has finished." } }
-            logger.info { "Tests have been successfully generated." }
-        } catch (e: Exception) {
-            logger.error("A critical error occurred during the mining process causing it to be aborted.", e)
-        } finally {
-            logger.info { "Mining has finished." }
-        }
     }
 
-    /**
-     * Calls the specified function [map] with `this` value as its argument and returns its result.
-     */
-    private fun <T, R> T.next(map: (T) -> R): R = map(this)
+    private fun mineProjects(): Iterable<UP> {
+        logger.info { "Started mining projects." }
+        return projectMiner.mine(searchOptions).also { logger.info { "Successfully mined ${it.count()} projects." } }
+    }
 
-    private inline fun <reified T : Iterable<*>, R> T.next(map: (T) -> R, message: String): R =
-        map(progressBarIterable(this, message) as? T ?: this)
+    private fun Iterable<UP>.compileUserProjects(): Iterable<UP> {
+        logger.info { "Started compiling ${this.count()} projects." }
+        return this.next<CompilationException, UP, UP>(userProjectCompiler::compile, "Compiling Projects")
+            .also { logger.info { "Successfully compiled ${it.count()} projects." } }
+    }
 
-    /**
-     * Calls the specified function [map] on each element in `this` and returns the result as an flat mapped iterable.
-     *
-     * Catches exceptions of type [E] and logs these. All other exceptions are thrown.
-     */
-    @Suppress("TooGenericExceptionCaught", "InstanceOfCheckForException") // This is intended behaviour
-    private inline fun <reified E : Exception, P, Q, T : Iterable<P>>
-        T.nextFlatMap(map: (P) -> Iterable<Q>, message: String): List<Q> =
-        progressBarIterable(this, message).mapNotNull {
-            try {
-                map(it)
-            } catch (e: RuntimeException) {
-                if (e is E) logger.warn { e.message } else throw e
-                null
-            }
-        }.flatten()
+    private fun Iterable<UP>.generateLibraryUsageGraphs(): Iterable<N> {
+        logger.info { "Started generating library usage graphs for ${this.count()} projects." }
+        val lugs = this.nextFlatMap<LibraryUsageGraphGenerationException, UP, N, Iterable<UP>>(
+            { libraryUsageGraphGenerator.generate(libraryProject, it) }, "Generating library-usage graphs")
 
-    /**
-     * Calls the specified function [map] on each element in `this` and returns the result as an iterable.
-     *
-     * Catches exceptions of type [E] and logs these. All other exceptions are thrown.
-     */
-    @Suppress("TooGenericExceptionCaught", "InstanceOfCheckForException") // This is intended behaviour
-    private inline fun <reified E : RuntimeException, T, R : Any>
-        Iterable<T>.nextCatchExceptions(map: (T) -> R, message: String): Iterable<R> =
-        progressBarIterable(this, message).mapNotNull {
-            try {
-                map(it)
-            } catch (e: RuntimeException) {
-                if (e is E) logger.warn { e.message } else throw e
-                null
-            }
-        }
+        logger.info { "Successfully generated ${lugs.count()} library usage graphs." }
+        csvWriter.writeGraphSizes(lugs)
 
-    private fun <N> progressBarIterable(iterable: Iterable<N>, taskName: String): Iterable<N> =
-        ProgressBar.wrap(iterable, ProgressBarBuilder().apply {
-            setTaskName(taskName)
-            setStyle(ProgressBarStyle.ASCII)
-        })
+        return lugs
+    }
+
+    private fun Iterable<N>.findAndFilterPatterns(): Iterable<Pattern<N>> {
+        logger.info { "Started finding patterns in ${this.count()} library usage graphs." }
+        val patterns = this.next(patternDetector::findPatterns, "Finding patterns")
+        logger.info { "Successfully found ${patterns.count()} patterns." }
+        csvWriter.writePatternLengths(patterns)
+
+        logger.info { "Started filtering ${patterns.count()} patterns." }
+        val filtered = patterns.next(patternFilter::filter, "Filtering Patterns")
+        logger.info { "${filtered.size} patterns remain after filtering." }
+        csvWriter.writeFilteredPatternLengths(filtered)
+
+        return filtered
+    }
+
+    private fun Iterable<Pattern<N>>.generateTests(): File {
+        logger.info { "Started generating test for ${this.count()} usage patterns." }
+        return testGenerator.generate(this).also { logger.info { "Test generation has finished." } }
+    }
 }

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
@@ -87,6 +87,12 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
     private inline fun <reified T : Iterable<*>, R> T.next(map: (T) -> R, message: String): R =
         map(progressBarIterable(this, message) as? T ?: this)
 
+    /**
+     * Calls the specified function [map] on each element in `this` and returns the result as an flat mapped iterable.
+     *
+     * Catches exceptions of type [E] and logs these. All other exceptions are thrown.
+     */
+    @Suppress("TooGenericExceptionCaught", "InstanceOfCheckForException") // This is intended behaviour
     private inline fun <reified E : Exception, P, Q, T : Iterable<P>>
         T.nextFlatMap(map: (P) -> Iterable<Q>, message: String): List<Q> =
         progressBarIterable(this, message).mapNotNull {

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
@@ -39,7 +39,8 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
                 try {
                     map(it)
                 } catch (e: RuntimeException) {
-                    if (e is E) logger.warn { e.message } else throw e
+                    if (e !is E) throw e
+                    logger.warn { e.message }
                     null
                 }
             }
@@ -57,7 +58,8 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
                 try {
                     map(it)
                 } catch (e: RuntimeException) {
-                    if (e is E) logger.warn { e.message } else throw e
+                    if (e !is E) throw e
+                    logger.warn { e.message }
                     null
                 }
             }.flatten()
@@ -104,7 +106,8 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
 
     private fun mineProjects(): Iterable<UP> {
         logger.info { "Started mining projects." }
-        return projectMiner.mine(searchOptions).also { logger.info { "Successfully mined ${it.count()} projects." } }
+        return projectMiner.mine(searchOptions)
+            .also { logger.info { "Successfully mined ${it.count()} projects." } }
     }
 
     private fun Iterable<UP>.compileUserProjects(): Iterable<UP> {
@@ -116,7 +119,9 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
     private fun Iterable<UP>.generateLibraryUsageGraphs(): Iterable<N> {
         logger.info { "Started generating library usage graphs for ${this.count()} projects." }
         val lugs = this.nextFlatMap<LibraryUsageGraphGenerationException, UP, N, Iterable<UP>>(
-            { libraryUsageGraphGenerator.generate(libraryProject, it) }, "Generating library-usage graphs")
+            map = { libraryUsageGraphGenerator.generate(libraryProject, it) },
+            message = "Generating library-usage graphs"
+        )
 
         logger.info { "Successfully generated ${lugs.count()} library usage graphs." }
         csvWriter.writeGraphSizes(lugs)

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/PatternDetector.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/PatternDetector.kt
@@ -12,5 +12,5 @@ interface PatternDetector<N : Node> {
      * @param graphs a list of graphs, where each graph is represented by a [Node]
      * @return the list of detected patterns
      */
-    fun findPatterns(graphs: List<N>): List<Pattern<N>>
+    fun findPatterns(graphs: Iterable<N>): Iterable<Pattern<N>>
 }

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/PatternFilter.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/PatternFilter.kt
@@ -14,5 +14,6 @@ class PatternFilter<N : Node>(private vararg val rules: PatternFilterRule<N>) {
      * @param patterns the list of patterns to be filtered
      * @return the patterns that were retained by the filters
      */
-    fun filter(patterns: List<Pattern<N>>) = patterns.filter { pattern -> rules.all { rule -> rule.retain(pattern) } }
+    fun filter(patterns: Iterable<Pattern<N>>) =
+        patterns.filter { pattern -> rules.all { rule -> rule.retain(pattern) } }
 }

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/ProjectMiner.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/ProjectMiner.kt
@@ -9,5 +9,5 @@ interface ProjectMiner<in S : SearchOptions, out P : Project> {
     /**
      * Mines projects.
      */
-    fun mine(searchOptions: S): List<P>
+    fun mine(searchOptions: S): Iterable<P>
 }

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/TestGenerator.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/TestGenerator.kt
@@ -13,5 +13,5 @@ interface TestGenerator<in N : Node> {
      * @param patterns a list of [Pattern]s
      * @return a test file containing all generated tests
      */
-    fun generate(patterns: List<Pattern<N>>): File
+    fun generate(patterns: Iterable<Pattern<N>>): File
 }


### PR DESCRIPTION
First, the readability of the `MiningPipeline` is improved  by splitting everything up into private methods. Previously, having everything in one method was sufficient. However, due to the added functionality this method has become too large in my opinion, hence the split.

Better exception handling has been added the the `LibraryUsageGraph` generator by catching all non-critical exceptions:
* A `LibraryUsageGraphGenerationException` has been added to the interface, all of which are catched in the `MiningPipeline` before moving onto the next project
* A `FilterException` has been added, which is then wrapped in a `LibraryUsageGraphGenerationException` before being thrown further

Last, the interfaces of the pipeline steps have been changed so they accept iterables and return iterables. This simplifies the `MiningPipeline` class. Furthermore, this makes more sense, as for a pipeline it does not matter what the underlying collection is, as long as it is iterable. Thus, this improves extendability.

Admittedly the extra exception in `LibraryUsageGraph` could've been done in a seperate PR. However, changing the interfaces and improving the `MiningPipeline` are rather intertwined in my opinion.