### PR TITLE
Only log error messages to the console

### DIFF
--- a/modules/application/src/main/resources/logback.xml
+++ b/modules/application/src/main/resources/logback.xml
@@ -14,8 +14,8 @@
         </encoder>
     </appender>
 
-    <root level="info">
-        <appender-ref ref="STDOUT" />
-        <appender-ref ref="FILE" />
+    <root>
+        <appender-ref ref="STDOUT" level="error"/>
+        <appender-ref ref="FILE" level="info"/>
     </root>
 </configuration>

--- a/modules/application/src/main/resources/logback.xml
+++ b/modules/application/src/main/resources/logback.xml
@@ -14,8 +14,10 @@
         </encoder>
     </appender>
 
-    <root>
-        <appender-ref ref="STDOUT" level="error"/>
-        <appender-ref ref="FILE" level="info"/>
+    <root level="info">
+        <appender-ref ref="FILE"/>
     </root>
+    <logger name="console" level="error">
+        <appender-ref ref="STDOUT"/>
+    </logger>
 </configuration>

--- a/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompiler.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompiler.kt
@@ -34,10 +34,11 @@ class JavaMavenProjectCompiler(private val displayOutput: Boolean = false) : Pro
             pomFile = project.pomFile
         }
 
-        val invoker = DefaultInvoker().apply {
-            if (displayOutput) setOutputHandler { logger.info(it) } else setOutputHandler(null)
-            mavenHome = project.mavenDir
-            workingDirectory = project.projectDir
+        val invoker = DefaultInvoker().also {
+            if (displayOutput) it.setOutputHandler(logger::info) else it.setOutputHandler(null)
+            it.setOutputHandler { logger.info(it) }
+            it.mavenHome = project.mavenDir
+            it.workingDirectory = project.projectDir
         }
 
         val result = invoker.execute(request)


### PR DESCRIPTION
All messages are still logged to file.

All information should now be conveyed to the user using progress bars (see #301).
If the user wants to see detailed info they shoud look at the log files themselves.