### PR TITLE
Fix appender configurability

### DIFF
--- a/modules/application/src/main/resources/logback.xml
+++ b/modules/application/src/main/resources/logback.xml
@@ -2,6 +2,9 @@
     <timestamp key="bySecond" datePattern="yyyyMMdd'T'HHmmss"/>
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
         <encoder>
             <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
@@ -16,8 +19,6 @@
 
     <root level="info">
         <appender-ref ref="FILE"/>
-    </root>
-    <logger name="console" level="error">
         <appender-ref ref="STDOUT"/>
-    </logger>
+    </root>
 </configuration>


### PR DESCRIPTION
Changes the logger configuration such that they can be configured independently. Before, changing the `level=` in either logger didn't actually affect the log levels for some reason. With this PR, the console logger's log level can be changed by changing the threshold of the filter.