### PR TITLE
Remove incorrect logger argument

### DIFF
--- a/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompiler.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompiler.kt
@@ -36,7 +36,6 @@ class JavaMavenProjectCompiler(private val displayOutput: Boolean = false) : Pro
 
         val invoker = DefaultInvoker().also {
             if (displayOutput) it.setOutputHandler(logger::info) else it.setOutputHandler(null)
-            it.setOutputHandler { logger.info(it) }
             it.mavenHome = project.mavenDir
             it.workingDirectory = project.projectDir
         }


### PR DESCRIPTION
No matter what was passed to the if above, the output handler still
received a logger meaning that there was always output. This behaviour
has been fixed.