### PR TITLE
Really fix the Codecov yaml this time

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,5 +5,6 @@ codecov:
 coverage:
   status:
     project:
-      default
+      default:
         target: 10
+        threshold: 100


### PR DESCRIPTION
#300 and #310 didn't fix the Codecov after all, so here's my third attempt.

Turns out I forgot a `:` somewhere in the YAML, so obviously it didn't work. Additionally, I set the YAML to allow coverage drops of up to 100% without causing the Codecov check to fail.

---

I added a commit that lowered the coverage, and Codecov still passed! (I've removed the commit afterwards.)
![Lowered coverage with a passing Codecov check.](https://user-images.githubusercontent.com/13442533/42388702-a81a4b18-8146-11e8-9d8d-28db73d1b800.PNG)
