### PR TITLE
Update usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,32 +20,108 @@
 Schaapi requires JRE 8 and has been tested on Windows and Unix systems.
 
 ## Usage
-Execute `./gradlew :application:run` with the following command line options:
+Run the JAR as `schaapi.jar <args>` or run a local build with `gradlew :application:run --args='<args>'`.
+
+Schaapi recognizes two pipeline "flavors" which have their own behavior. Click the flavor below for a list of command-line options.
+
+<details>
+<summary>Directory flavor options</summary>
+<p>
 
 ```
-usage: schaapi -o <arg> -l <arg> -u <arg> [--maven_dir <arg>]
-       [--repair_maven] [--pattern_detector_minimum_count <arg>]
+usage: schaapi -o <arg> -l <arg> [--maven_dir <arg>] [--repair_maven] -u
+       <arg> [--library_type <arg>] [--pattern_detector_minimum_count
+       <arg>] [--pattern_detector_maximum_sequence_length <arg>]
+       [--pattern_minimum_library_usage_count <arg>]
+       [--test_generator_enable_output] [--test_generator_timeout <arg>]
+ -o,--output_dir <arg>                                 The output
+                                                       directory.
+ -l,--library_dir <arg>                                The library
+                                                       directory.
+    --maven_dir <arg>                                  The directory to
+                                                       run Maven from.
+    --repair_maven                                     Repairs the Maven
+                                                       installation.
+ -u,--user_base_dir <arg>                              The directory
+                                                       containing user
+                                                       project
+                                                       directories.
+    --library_type <arg>                               The type of
+                                                       library.
+    --pattern_detector_minimum_count <arg>             The minimum number
+                                                       of occurrences for
+                                                       a statement to be
+                                                       considered
+                                                       frequent.
+    --pattern_detector_maximum_sequence_length <arg>   The maximum length
+                                                       of sequences to be
+                                                       considered for
+                                                       pattern detection.
+    --pattern_minimum_library_usage_count <arg>        The minimum number
+                                                       of library usages
+                                                       per method.
+    --test_generator_enable_output                     True if test
+                                                       generator output
+                                                       should be shown.
+    --test_generator_timeout <arg>                     The time limit for
+                                                       the test generator.
+```
+
+</p>
+</details>
+
+<details>
+<summary>GitHub flavor options</summary>
+<p>
+
+```
+usage: schaapi -o <arg> -l <arg> [--maven_dir <arg>] [--repair_maven]
+       --github_oauth_token <arg> [--max_projects <arg>]
+       --library_group_id <arg> --library_artifact_id <arg>
+       --library_version <arg> [--sort_by_stargazers] [--sort_by_watchers]
+       [--library_type <arg>] [--pattern_minimum_library_usage_count
+       <arg>] [--pattern_detector_minimum_count <arg>]
        [--pattern_detector_maximum_sequence_length <arg>]
        [--test_generator_enable_output] [--test_generator_timeout <arg>]
  -o,--output_dir <arg>                                 The output
                                                        directory.
  -l,--library_dir <arg>                                The library
                                                        directory.
- -u,--user_base_dir <arg>                              The directory containing user
-                                                       project directories.
- -g,--library_group_id <arg>                           Group id of library projects 
-                                                       should have dependency on.
- -a,--library_artifact_id <arg>                        Artifact id of library projects 
-                                                       should have dependency on.
- -v,--library_version <arg>                            Version of library projects 
-                                                       should have a dependency on.
- -m,--max_projects <arg>                               Maximum amount of projects to 
-                                                       download from GitHub. 
-    --flavor <arg>                                     The flavor of the desired pipeline.
     --maven_dir <arg>                                  The directory to
                                                        run Maven from.
     --repair_maven                                     Repairs the Maven
                                                        installation.
+    --github_oauth_token <arg>                         Token of GitHub
+                                                       account used for
+                                                       searching.
+    --max_projects <arg>                               Maximum amount of
+                                                       projects to
+                                                       download from
+                                                       GitHub.
+    --library_group_id <arg>                           Group id of library
+                                                       mined projects
+                                                       should have a
+                                                       dependency on.
+    --library_artifact_id <arg>                        Artifact id of
+                                                       library mined
+                                                       projects should
+                                                       have a dependency
+                                                       on.
+    --library_version <arg>                            Version of library
+                                                       mined projects
+                                                       should have a
+                                                       dependency on.
+    --sort_by_stargazers                               True if GitHub
+                                                       projects should be
+                                                       sorted by stars.
+    --sort_by_watchers                                 True if GitHub
+                                                       projects should be
+                                                       sorted by watchers.
+    --library_type <arg>                               The type of
+                                                       library.
+    --pattern_minimum_library_usage_count <arg>        The minimum number
+                                                       of library usages
+                                                       per method.
     --pattern_detector_minimum_count <arg>             The minimum number
                                                        of occurrences for
                                                        a statement to be
@@ -60,11 +136,10 @@ usage: schaapi -o <arg> -l <arg> -u <arg> [--maven_dir <arg>]
                                                        should be shown.
     --test_generator_timeout <arg>                     The time limit for
                                                        the test generator.
-    --sort_by_stargazers                               Mine projects on GitHub with
-                                                       the most stargazers.
-    --sort_by_watchers                                 Mine projects on GitHub with
-                                                       the most watchers.
 ```
+
+</p>
+</details>
 
 ## Pipeline Stages
 ### 1 Mining Pipeline

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 Schaapi requires JRE 8 and has been tested on Windows and Unix systems.
 
 ## Usage
-Run the JAR as `schaapi.jar <args>` or run a local build with `gradlew :application:run --args='<args>'`.
+Run the JAR as `java -jar schaapi.jar <args>` or run a local build with `gradlew :application:run --args='<args>'`.
 
 Schaapi recognizes two pipeline "flavors" which have their own behavior. Click the flavor below for a list of command-line options.
 


### PR DESCRIPTION
Fixes three things in the README:
1. Adds instructions for running as a JAR.
2. Usage instructions for Gradle now actually work!
3. CLI options have been updated.

[Click here to view the new README](https://github.com/cafejojo/schaapi/blob/readme-usage-instructions/README.md)