### PR TITLE
Remove user notification pipeline step from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ usage: schaapi github -o <arg> -l <arg> [--maven_dir <arg>] [--repair_maven]
 | -------------------------- | --- |
 | **2.1 Execute Tests**      | Run generated tests against a new library version |
 | **2.2 Notify Developers**  | Notify library developer of possibly affected users |
-| **2.3 Notify Users**       | Notify library users of breaking changes |
 
 #### 2.1 Execute Tests
 | | |
@@ -212,13 +211,6 @@ usage: schaapi github -o <arg> -l <arg> [--maven_dir <arg>] [--repair_maven]
 | | |
 | ------------------ | ------------- |
 | Description        | Notify library developer of possibly affected users |
-| Interface          | `--` |
-| Implementations    | |
-
-#### 2.3 Notify Users
-| | |
-| ------------------ | ------------- |
-| Description        | Notify affected library users of possibly breaking changes |
 | Interface          | `--` |
 | Implementations    | |
 


### PR DESCRIPTION
As described in our [thesis](https://repository.tudelft.nl/islandora/object/uuid:cca5e4ea-3d00-4ae3-877a-b302829e7f08?collection=education), there are a lot of ethical complications when notifying users. Also, since it is not included in our implementation it does not make sense to mention it as a pipeline step in the README.