### PR TITLE
Change List to Iterable in all Interfaces

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -27,6 +27,8 @@ style:
     active: false
   UnnecessaryAbstractClass:
     active: false
+  UnnecessaryApply:
+    active: false
   UnusedPrivateMember:
     active: false
 

--- a/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanPatternDetector.kt
+++ b/modules/mining-pipeline/ccspan-pattern-detector/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patterndetector/ccspan/CCSpanPatternDetector.kt
@@ -14,7 +14,7 @@ class CCSpanPatternDetector<N : Node>(
     private val enumerator: (N) -> PathEnumerator<N>,
     private val comparator: GeneralizedNodeComparator<N>
 ) : PatternDetector<N> {
-    override fun findPatterns(graphs: List<N>): List<Pattern<N>> {
+    override fun findPatterns(graphs: Iterable<N>): Iterable<Pattern<N>> {
         val sequences = graphs.flatMap { enumerator(it).enumerate() }
         return CCSpan(sequences, minimumCount, comparator).findFrequentPatterns()
     }

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/CsvWriter.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/CsvWriter.kt
@@ -27,7 +27,7 @@ class CsvWriter<N : Node>(output: File) {
      *
      * @param patterns patterns whose lengths will be written to file
      */
-    fun writePatternLengths(patterns: List<Pattern<N>>) =
+    fun writePatternLengths(patterns: Iterable<Pattern<N>>) =
         writeToFile("patterns.csv", patterns, { pattern: Pattern<N> -> pattern.size }, "pattern_length")
 
     /**
@@ -35,10 +35,10 @@ class CsvWriter<N : Node>(output: File) {
      *
      * @param patterns patterns whose lengths will be written to file
      */
-    fun writeFilteredPatternLengths(patterns: List<Pattern<N>>) =
+    fun writeFilteredPatternLengths(patterns: Iterable<Pattern<N>>) =
         writeToFile("filteredPatterns.csv", patterns, { pattern: Pattern<N> -> pattern.size }, "pattern_length")
 
-    private fun <P> writeToFile(output: String, items: List<P>, mapToInt: (P) -> Int, type: String) =
+    private fun <P> writeToFile(output: String, items: Iterable<P>, mapToInt: (P) -> Int, type: String) =
         File(dataFile, output).writer().use { fileWriter ->
             fileWriter.write("$type,count\n")
             items

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/LibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/LibraryUsageGraphGenerator.kt
@@ -14,5 +14,5 @@ interface LibraryUsageGraphGenerator<in LP : Project, in UP : Project, out N : N
      * @param userProject library user project
      * @return list of graphs
      */
-    fun generate(libraryProject: LP, userProject: UP): List<N>
+    fun generate(libraryProject: LP, userProject: UP): Iterable<N>
 }

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
@@ -45,9 +45,9 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
             searchOptions
                 .also { logger.info { "Started mining projects." } }
                 .next(projectMiner::mine)
-                .also { logger.info { "Successfully mined ${it.size} projects." } }
+                .also { logger.info { "Successfully mined ${it.count()} projects." } }
 
-                .also { logger.info { "Started compiling ${it.size} projects." } }
+                .also { logger.info { "Started compiling ${it.count()} projects." } }
                 .nextCatchExceptions<CompilationException, UP, UP>(userProjectCompiler::compile, "Compiling projects")
                 .also { logger.info { "Successfully compiled ${it.count()} projects." } }
 
@@ -59,10 +59,10 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
 
                 .also { logger.info { "Started finding patterns in ${it.size} library usage graphs." } }
                 .next(patternDetector::findPatterns, "Finding patterns")
-                .also { logger.info { "Successfully found ${it.size} patterns." } }
+                .also { logger.info { "Successfully found ${it.count()} patterns." } }
                 .also { csvWriter.writePatternLengths(it) }
 
-                .also { logger.info { "Started filtering ${it.size} patterns." } }
+                .also { logger.info { "Started filtering ${it.count()} patterns." } }
                 .next(patternFilter::filter, "Filtering patterns")
                 .also { logger.info { "${it.size} patterns remain after filtering." } }
                 .also { csvWriter.writeFilteredPatternLengths(it) }

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/PatternDetector.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/PatternDetector.kt
@@ -12,5 +12,5 @@ interface PatternDetector<N : Node> {
      * @param graphs a list of graphs, where each graph is represented by a [Node]
      * @return the list of detected patterns
      */
-    fun findPatterns(graphs: List<N>): List<Pattern<N>>
+    fun findPatterns(graphs: Iterable<N>): Iterable<Pattern<N>>
 }

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/PatternFilter.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/PatternFilter.kt
@@ -14,5 +14,6 @@ class PatternFilter<N : Node>(private vararg val rules: PatternFilterRule<N>) {
      * @param patterns the list of patterns to be filtered
      * @return the patterns that were retained by the filters
      */
-    fun filter(patterns: List<Pattern<N>>) = patterns.filter { pattern -> rules.all { rule -> rule.retain(pattern) } }
+    fun filter(patterns: Iterable<Pattern<N>>) =
+        patterns.filter { pattern -> rules.all { rule -> rule.retain(pattern) } }
 }

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/ProjectMiner.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/ProjectMiner.kt
@@ -9,5 +9,5 @@ interface ProjectMiner<in S : SearchOptions, out P : Project> {
     /**
      * Mines projects.
      */
-    fun mine(searchOptions: S): List<P>
+    fun mine(searchOptions: S): Iterable<P>
 }


### PR DESCRIPTION
A small code quality PR.

* Change List to Iterable in CsvWriter, so the project still compiles
* Use the count() method in MiningPipeline instead of size property

The reasoning is that in a pipeline we only wish that we are given
objects which are iterable. Whether the underlying structure is a list
or not is not relevant.