### PR TITLE
Disable Detekt's UnnecessaryApply rule

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -27,6 +27,8 @@ style:
     active: false
   UnnecessaryAbstractClass:
     active: false
+  UnnecessaryApply:
+    active: false
   UnusedPrivateMember:
     active: false
 


### PR DESCRIPTION
For some reason, Detekt enabled the newly added `UnnecessaryApply` rule even though we didn't update Detekt. I have suppressed the `UnnecessaryApply` rule globally because it gives a warning for _every_ `apply` found in the codebase because it _might_ not be useful, which makes the rule extremely useless.