### PR TITLE
Exclude hidden files from directory pipeline

### DIFF
--- a/modules/mining-pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/directory/DirectoryProjectMiner.kt
+++ b/modules/mining-pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/directory/DirectoryProjectMiner.kt
@@ -14,7 +14,7 @@ class DirectoryProjectMiner<P : Project>(private val projectPacker: (File) -> P)
     ProjectMiner<DirectorySearchOptions, P> {
     override fun mine(searchOptions: DirectorySearchOptions) =
         searchOptions.directory.listFiles()
-            ?.filter { it.isHidden }
+            ?.filterNot { it.isHidden }
             ?.map { projectPacker(it) }
             ?: emptyList()
 }

--- a/modules/mining-pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/directory/DirectoryProjectMiner.kt
+++ b/modules/mining-pipeline/directory-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/directory/DirectoryProjectMiner.kt
@@ -13,5 +13,8 @@ import java.io.File
 class DirectoryProjectMiner<P : Project>(private val projectPacker: (File) -> P) :
     ProjectMiner<DirectorySearchOptions, P> {
     override fun mine(searchOptions: DirectorySearchOptions) =
-        searchOptions.directory.listFiles()?.map { projectPacker(it) } ?: emptyList()
+        searchOptions.directory.listFiles()
+            ?.filter { it.isHidden }
+            ?.map { projectPacker(it) }
+            ?: emptyList()
 }


### PR DESCRIPTION
This is mainly for the `.DS_store` macOS file, which should not be considered by our tool.