### PR TITLE
Replace Invalid Targets in Actual Active Method Body

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/ClassGenerator.kt
@@ -83,7 +83,7 @@ internal class ClassGenerator(className: String) {
         addStatementsToBody(jimpleBody, statements, methodParams)
         sootMethod.returnType = addReturnStatement(jimpleBody)
 
-        replaceInvalidTargets(statements)
+        replaceInvalidTargets(sootMethod.activeBody.units.toList())
     }
 
     private fun createSootMethod(name: String, parameters: Set<Value>) =


### PR DESCRIPTION
Before, we would replace invalid targets on the list of duplicate statements, which was a duplicate of the active body and was thrown away afterwards.

The issue was that there was no guarantee that this list of statements ended with a return statement. Therefore, if the last statement was an `if` statement with an invalid target, we replaced its body with a
reference to the last statement. This would be the `if` statement itself creating an empty while loop, instead of the intended behaviour which was a reference to the `return` or `returnvoid` of the method body.

Now, we do the same but on the active body on the statement. This is guaranteed to have a return statement as the method `addReturnStatement` was called before.

In short, it seems that we no longer have empty while loops in the generated patterns.