### PR TITLE
Fix issue with EvoSuite JAVA_HOME setup

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
@@ -31,24 +31,20 @@ internal class EvoSuiteRunner(
      */
     fun run() = receiveProcessOutput(buildProcess())
 
-    private fun buildProcess(): Process {
-        val processBuilder = ProcessBuilder(
-            "java",
-            "-cp", System.getProperty("java.class.path"),
-            "org.evosuite.EvoSuite",
-            "-class", fullyQualifiedClassName,
-            "-base_dir", outputDirectory,
-            "-projectCP", classpath,
-            "-Dno_runtime_dependency=true",
-            "-Dsearch_budget=$generationTimeoutSeconds",
-            "-Dstatistics_backend=NONE",
-            "-Doutput_granularity=TESTCASE"
-        )
-
-        processBuilder.environment()["JAVA_HOME"] = System.getProperty("java.home")
-
-        return processBuilder.start()
-    }
+    private fun buildProcess() = ProcessBuilder(
+        "java",
+        "-cp", System.getProperty("java.class.path"),
+        "org.evosuite.EvoSuite",
+        "-class", fullyQualifiedClassName,
+        "-base_dir", outputDirectory,
+        "-projectCP", classpath,
+        "-Dno_runtime_dependency=true",
+        "-Dsearch_budget=$generationTimeoutSeconds",
+        "-Dstatistics_backend=NONE",
+        "-Doutput_granularity=TESTCASE"
+    ).apply {
+        environment()["JAVA_HOME"] = System.getProperty("java.home")
+    }.start()
 
     private fun receiveProcessOutput(process: Process) {
         val lastLine = pipeAllLines(process.inputStream, processStandardStream)

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
@@ -31,18 +31,24 @@ internal class EvoSuiteRunner(
      */
     fun run() = receiveProcessOutput(buildProcess())
 
-    private fun buildProcess() = ProcessBuilder(
-        "java",
-        "-cp", System.getProperty("java.class.path"),
-        "org.evosuite.EvoSuite",
-        "-class", fullyQualifiedClassName,
-        "-base_dir", outputDirectory,
-        "-projectCP", classpath,
-        "-Dno_runtime_dependency=true",
-        "-Dsearch_budget=$generationTimeoutSeconds",
-        "-Dstatistics_backend=NONE",
-        "-Doutput_granularity=TESTCASE"
-    ).start()
+    private fun buildProcess(): Process {
+        val processBuilder = ProcessBuilder(
+            "java",
+            "-cp", System.getProperty("java.class.path"),
+            "org.evosuite.EvoSuite",
+            "-class", fullyQualifiedClassName,
+            "-base_dir", outputDirectory,
+            "-projectCP", classpath,
+            "-Dno_runtime_dependency=true",
+            "-Dsearch_budget=$generationTimeoutSeconds",
+            "-Dstatistics_backend=NONE",
+            "-Doutput_granularity=TESTCASE"
+        )
+
+        processBuilder.environment()["JAVA_HOME"] = System.getProperty("java.home")
+
+        return processBuilder.start()
+    }
 
     private fun receiveProcessOutput(process: Process) {
         val lastLine = pipeAllLines(process.inputStream, processStandardStream)


### PR DESCRIPTION
On my macOS setup, the smoke test failed, due to EvoSuite not finding 'tools.jar'. After some debugging, I found out that this had to do with the JAVA_HOME variable not being visible to EvoSuite. I have fixed this by setting this variable explicitly for the subprocess that we launch for EvoSuite.