### PR TITLE
Fix implicit references to 'it' in JLUGGenerator

### DIFF
--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
@@ -42,14 +42,14 @@ class JimpleLibraryUsageGraphGenerator : LibraryUsageGraphGenerator<JavaProject,
     override fun generate(libraryProject: JavaProject, userProject: JavaProject): List<JimpleNode> {
         setUpSootEnvironment(libraryProject, userProject)
 
-        return userProject.classNames.flatMap {
-            val sootClass = createSootClass(it)
+        return userProject.classNames.flatMap { className ->
+            val sootClass = createSootClass(className)
 
             sootClass.methods
                 .filter { it.isConcrete }.also { lugStatistics.concreteMethods += it.size }
                 .map { generateMethodGraph(libraryProject, it) }
-                .filter {
-                    DfsIterator(it).asSequence().toList().any {
+                .filter { methodGraph ->
+                    DfsIterator(methodGraph).asSequence().toList().any {
                         it !is JimpleNode || !isMeaninglessStatementWithoutContext(it.statement)
                     }
                 }


### PR DESCRIPTION
In the JLUGGenerator, some nested it constructs made implicit references to shadowed `it` variables (causing warnings). I have replaced these instances in outer scopes with explicit names to prevent these namespace collisions.