### PR TITLE
Work around Detekt SwallowedException errors

### DIFF
--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -40,6 +40,7 @@ fun main(args: Array<String>) {
 private fun printAsciiArt() = try {
     println(CommandLineInterface::class.java.getResource("/schaapi-ascii-art.txt")?.readText())
 } catch (e: IOException) {
+    KLogging().logger.warn("Failed to load Schaapi ASCII art.", e)
     println("Schaapi")
 }
 

--- a/modules/mining-pipeline/directory-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/directory/DirectoryProjectMinerTest.kt
+++ b/modules/mining-pipeline/directory-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/directory/DirectoryProjectMinerTest.kt
@@ -77,6 +77,7 @@ internal object DirectoryProjectMinerTest : Spek({
     }
 })
 
+@Suppress("SwallowedException") // Expected behavior
 fun Path.hideFileOnWindows() {
     try {
         Files.setAttribute(this, "dos:hidden", true, LinkOption.NOFOLLOW_LINKS)

--- a/modules/validation-pipeline/github-interactor/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubinteractor/githubapi/CustomHttpClient.kt
+++ b/modules/validation-pipeline/github-interactor/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/githubinteractor/githubapi/CustomHttpClient.kt
@@ -47,7 +47,7 @@ import javax.net.ssl.HttpsURLConnection
  * removed.
  */
 @Service
-@Suppress("TooGenericExceptionCaught")
+@Suppress("TooGenericExceptionCaught", "SwallowedException") // Expected behavior
 internal class CustomHttpClient(private val proxy: Proxy? = null) : Client {
     init {
         allowMethods("PATCH")


### PR DESCRIPTION
For some reason Detekt is now failing on `SwallowedException` even though that wasn't a thing before. As a result, all new builds fail.

Where appropriate, this has been fixed.