### PR TITLE
Delete faulty project files

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -115,9 +115,11 @@ internal class GitHubProjectDownloader<P : Project>(
             logger.debug { "Successfully unzipped file ${projectZipFile.absolutePath}." }
         } catch (e: IOException) {
             logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e)
+            githubProject.deleteRecursively()
             return null
         } catch (e: ZipException) {
             logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e)
+            githubProject.deleteRecursively()
             return null
         } finally {
             projectZipFile.delete()


### PR DESCRIPTION
If unzipping of a user project's code fails, parts of the zip may already have been extracted. If these directories are later used using the directory miner, Schaapi may crash when trying to read the half-extracted project.

This PR deletes the directory to which the zip is extracted if unzipping fails.