### PR TITLE
Prevent `IfStmt`s from having only one successor

### DIFF
--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/ControlFlowGraphGenerator.kt
@@ -58,6 +58,7 @@ internal object ControlFlowGraphGenerator {
      * Duplicates successors of [IfStmt]s that have only one successor.
      *
      * @param root the root node
+     * @return the root node
      */
     private fun postProcess(root: JimpleNode?): JimpleNode? {
         (root ?: return null).iterator().asSequence().toList()


### PR DESCRIPTION
Sometimes, a control flow graph of `JimpleNode`s contains an `IfStmt` with only one successor. When this happens, the single successor is always the next node in the method body, so in essence the then-branch and else-branch are the same node. However, soot's built-in `getSuccsOf` method checks for duplicates when returning the list of successors, and as such will return only one node.

To resolve this, I have added a `postProcess` method that will find `IfStmt`s with only one successor, and will add this successor to the list again.

The rest of the pipeline seems to have no problem with this change.