### PR TITLE
Catch LUG exceptions

### DIFF
--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
@@ -92,6 +92,7 @@ class JimpleLibraryUsageGraphGenerator : LibraryUsageGraphGenerator<JavaProject,
      * @param method method for which to generate the graph
      * @return library usage graph
      */
+    @Suppress("TooGenericExceptionCaught") // Soot throws generic exceptions
     private fun generateMethodGraph(libraryProject: JavaProject, method: SootMethod): JimpleNode? {
         val methodBody: Body
         try {

--- a/modules/validation-pipeline/ci-job/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJob.kt
+++ b/modules/validation-pipeline/ci-job/src/main/kotlin/org/cafejojo/schaapi/validationpipeline/cijob/CIJob.kt
@@ -25,7 +25,6 @@ class CIJob(
     private val successReporter: (TestResults) -> Any,
     private val failureReporter: (CIJobException) -> Any
 ) : Runnable {
-
     private val zipFile = File(projectDirectory, "builds").let { it.mkdirs(); File(it, "$identifier.zip") }
     private val newProjectFiles = File(projectDirectory, "builds/$identifier").also { it.mkdirs() }
     private val testsDirectory = File(projectDirectory, "tests")


### PR DESCRIPTION
Exceptions in the library-usage graph generator are now caught so that Schaapi does not crash. Furthermore, exceptions in the retrieving of individual methods are caught at the method-level, so that other methods in the same class will still have a LUG.