### PR TITLE
Replace `:` with `_` during unpacking

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -111,7 +111,7 @@ internal class GitHubProjectDownloader<P : Project>(
         }
 
         try {
-            ZipUtil.unpack(projectZipFile, githubProject)
+            ZipUtil.unpack(projectZipFile, githubProject) { it.replace(":", "_") }
             logger.debug { "Successfully unzipped file ${projectZipFile.absolutePath}." }
         } catch (e: IOException) {
             logger.warn("Could not unzip ${projectZipFile.absolutePath}.", e)


### PR DESCRIPTION
While unzipping projects obtained during the GitHub mining process, unpacking will fail on Windows if the zip contains a directory with a colon in its name. This PR prevents that from happening by telling the unpacking library to replace colons with underscores while unpacking, similar to how Windows' native unzipper and 7zip handle colons.