### PR TITLE
Simplify GitHub project extraction process

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -45,8 +45,8 @@ internal class GitHubProjectDownloader<P : Project>(
 
     private fun downloadAndSaveProject(projectName: String): P? =
         getInputStream(projectName)?.use { inputStream ->
-            val githubProjectZip = saveZipToFile(inputStream, projectName) ?: return null
-            val gitHubProject = unzip(githubProjectZip) ?: return null
+            val gitHubProjectZip = saveZipToFile(inputStream, projectName) ?: return null
+            val gitHubProject = unzip(gitHubProjectZip) ?: return null
 
             return projectPacker(gitHubProject)
         }

--- a/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloaderTest.kt
+++ b/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloaderTest.kt
@@ -127,7 +127,7 @@ internal object GitHubProjectDownloaderTest : Spek({
             val zipFile = addZipFile("testZipDirectory", "test text")
             val unzippedFile = GitHubProjectDownloader(emptyList(), output, ::testProjectPacker).unzip(zipFile)
 
-            assertThat(unzippedFile?.listFiles()?.first()?.listFiles()?.first()?.readText()).isEqualTo("test text")
+            assertThat(unzippedFile?.listFiles()?.first()?.readText()).isEqualTo("test text")
         }
 
         it("should delete the zip file after extraction") {


### PR DESCRIPTION
Rather than extracting the archives downloaded by the GitHub miner and then moving the output up one directory, this PR simplifies the process so that the extraction happen to the correct directory right away.

This has two consequences:

1. It prevents a (probably Windows-only) bug where you get an access denied exception while moving the files up one directory.
2. The extraction process is faster because you don't need to move all those files.
