### PR TITLE
Add loading bar for downloading user projects

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -1,6 +1,7 @@
 package org.cafejojo.schaapi.miningpipeline.miner.github
 
 import mu.KLogging
+import org.apache.commons.codec.digest.DigestUtils
 import org.cafejojo.schaapi.models.Project
 import org.zeroturnaround.zip.ZipException
 import org.zeroturnaround.zip.ZipUtil
@@ -55,7 +56,7 @@ internal class GitHubProjectDownloader<P : Project>(
         val alphaNumericRegex = Regex("[^A-Za-z0-9]")
         val zipFile = File(
             outputDirectory,
-            "${alphaNumericRegex.replace(projectName, "")}.zip"
+            "${alphaNumericRegex.replace(projectName, "")}-${DigestUtils.md5Hex(projectName)}.zip"
         )
 
         try {

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectMiner.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectMiner.kt
@@ -1,7 +1,9 @@
 package org.cafejojo.schaapi.miningpipeline.miner.github
 
+import me.tongfei.progressbar.ProgressBar
 import mu.KLogging
 import org.cafejojo.schaapi.miningpipeline.ProjectMiner
+import org.cafejojo.schaapi.miningpipeline.createProgressBarBuilder
 import org.cafejojo.schaapi.models.Project
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import org.kohsuke.github.GitHub
@@ -51,7 +53,12 @@ class GitHubProjectMiner<P : JavaMavenProject>(
             searchOptions.groupId, searchOptions.artifactId, searchOptions.version, false
         )
 
-        return GitHubProjectDownloader(projectNames, outProjects, projectPacker)
+        val projectNameStream = ProgressBar.wrap(
+            projectNames.parallelStream(),
+            createProgressBarBuilder("Downloading user projects")
+        )
+
+        return GitHubProjectDownloader(projectNameStream, outProjects, projectPacker)
             .download()
             .filter(versionVerifier::verify)
     }

--- a/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloaderTest.kt
+++ b/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloaderTest.kt
@@ -56,32 +56,34 @@ internal object GitHubProjectDownloaderTest : Spek({
     describe("When saving searchContent stream to file") {
         it("should save the contents of the file to stream") {
             val repoName = "testRepo"
-            val repoNames = listOf(repoName)
+            val repoNameDigest = "b4a4714e718a2fef94071ae2d42d87e7"
             val zipStreamContent = "testZip"
             val repoZipStream = zipStreamContent.byteInputStream()
 
-            GitHubProjectDownloader(repoNames.stream(), output, ::testProjectPacker)
+            GitHubProjectDownloader(listOf(repoName).stream(), output, ::testProjectPacker)
                 .saveZipToFile(repoZipStream, repoName)
 
-            assertThat(File(output, "$repoName.zip")).exists()
-            assertThat(File(output, "$repoName.zip").readText()).isEqualTo(zipStreamContent)
+            assertThat(File(output, "$repoName-$repoNameDigest.zip")).exists()
+            assertThat(File(output, "$repoName-$repoNameDigest.zip").readText()).isEqualTo(zipStreamContent)
         }
 
         it("should remove illegal characters from the repo name") {
             val repoName = ",./<>?;':\"a[]{}-=_+!@b#$%^&*()"
-            val repoNames = listOf(repoName)
+            val repoNameDigest = "0ff8c4342658756c2f319f74836b5d1e"
             val zipStreamContent = "testZip"
             val repoZipStream = zipStreamContent.byteInputStream()
 
-            GitHubProjectDownloader(repoNames.stream(), output, ::testProjectPacker)
+            GitHubProjectDownloader(listOf(repoName).stream(), output, ::testProjectPacker)
                 .saveZipToFile(repoZipStream, repoName)
 
-            assertThat(File(output, "ab.zip")).exists()
+            assertThat(File(output, "ab-$repoNameDigest.zip")).exists()
         }
 
         it("should be able to save multiple projects") {
             val repoName1 = "testRepo1"
             val repoName2 = "testRepo2"
+            val repoNameDigest1 = "7b3a34debd09d6bf34c5a59f742cbc86"
+            val repoNameDigest2 = "69e3cf922a4ae3c6e4010608fac69f52"
             val zip1StreamContent = "testZip1"
             val zip2StreamContent = "testZip2"
             val repo1ZipStream = zip1StreamContent.byteInputStream()
@@ -92,23 +94,23 @@ internal object GitHubProjectDownloaderTest : Spek({
                 .apply { saveZipToFile(repo1ZipStream, repoName1) }
                 .apply { saveZipToFile(repo2ZipStream, repoName2) }
 
-            assertThat(File(output, "$repoName1.zip")).exists()
-            assertThat(File(output, "$repoName2.zip")).exists()
+            assertThat(File(output, "$repoName1-$repoNameDigest1.zip")).exists()
+            assertThat(File(output, "$repoName2-$repoNameDigest2.zip")).exists()
 
-            assertThat(File(output, "$repoName1.zip").readText()).isEqualTo(zip1StreamContent)
-            assertThat(File(output, "$repoName2.zip").readText()).isEqualTo(zip2StreamContent)
+            assertThat(File(output, "$repoName1-$repoNameDigest1.zip").readText()).isEqualTo(zip1StreamContent)
+            assertThat(File(output, "$repoName2-$repoNameDigest2.zip").readText()).isEqualTo(zip2StreamContent)
         }
 
         it("should overwrite directories which exist") {
             val repoName = "testRepo"
-            val repoNames = listOf(repoName)
+            val repoNameDigest = "b4a4714e718a2fef94071ae2d42d87e7"
             val zipStreamContent = "testZip"
             val repoZipStream = zipStreamContent.byteInputStream()
-            File(output, "testRepo.zip").createNewFile()
+            File(output, "$repoName-$repoNameDigest.zip").createNewFile()
 
             assertThat(output.listFiles().size).isEqualTo(1)
 
-            GitHubProjectDownloader(repoNames.stream(), output, ::testProjectPacker)
+            GitHubProjectDownloader(listOf(repoName).stream(), output, ::testProjectPacker)
                 .saveZipToFile(repoZipStream, repoName)
 
             assertThat(output.listFiles().size).isEqualTo(1)

--- a/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
+++ b/modules/mining-pipeline/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/MiningPipeline.kt
@@ -30,10 +30,13 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
     @Suppress("TooGenericExceptionCaught") // In this case it is relevant to catch and log an Exception
     fun run(libraryProject: LP) {
         logger.info { "Compiling library project." }
-        ProgressBar("Compile library project", 1, ProgressBarStyle.ASCII).use { progressBar ->
-            libraryProjectCompiler.compile(libraryProject)
-            progressBar.step()
-        }
+        createProgressBarBuilder("Compile library project")
+            .also { it.setInitialMax(1) }
+            .build()
+            .use { progressBar ->
+                libraryProjectCompiler.compile(libraryProject)
+                progressBar.step()
+            }
         logger.info { "Compiled library project." }
 
         logger.info { "Mining has started." }
@@ -110,8 +113,17 @@ class MiningPipeline<SO : SearchOptions, UP : Project, LP : Project, N : Node>(
     }
 
     private fun <N> progressBarIterable(iterable: Iterable<N>, taskName: String): Iterable<N> =
-        ProgressBar.wrap(iterable, ProgressBarBuilder().apply {
-            setTaskName(taskName)
-            setStyle(ProgressBarStyle.ASCII)
-        })
+        ProgressBar.wrap(iterable, createProgressBarBuilder(taskName))
 }
+
+/**
+ * Creates a progress bar builder with the default settings for progress bars in the mining pipeline set.
+ *
+ * @param taskName the name of the progress bar
+ */
+fun createProgressBarBuilder(taskName: String) =
+    ProgressBarBuilder().apply {
+        setTaskName(taskName)
+        setStyle(ProgressBarStyle.ASCII)
+        setPrintStream(System.out)
+    }


### PR DESCRIPTION
While projects are being downloaded by the GitHub downloader, users receive no feedback on what's happening. This PR adds a loading bar for the duration of the downloading and unzipping of user projects.
To do this, the downloader class now takes a `Stream` instead of a simple `List`. The parallellity of this stream is determined by the supplier of the stream.

Additionally,
* loading bars are now redirected to `System.out` instead of `System.err`,
* output directories now have a digest rather than a number appended,
* a shared `createProgressBarBuilder` function is added to create a consistent layout for progress bars throughout the application,
* the method `getURl` was renamed to `getUrl`, and
* fixes an error in the tests that resulted in two temporary directories not being deleted.
