### PR TITLE
Parallelise evosuite

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ usage: schaapi -o <arg> -l <arg> [--skip_user_compile] [--maven_dir <arg>]
        [--pattern_detector_minimum_count <arg>]
        [--pattern_detector_maximum_sequence_length <arg>]
        [--pattern_minimum_library_usage_count <arg>]
-       [--test_generator_disable_output] [--test_generator_timeout <arg>]
+       [--test_generator_parallel] [--test_generator_disable_output]
+       [--test_generator_timeout <arg>]
  -o,--output_dir <arg>                                 The output
                                                        directory.
  -l,--library_dir <arg>                                The library
@@ -66,6 +67,12 @@ usage: schaapi -o <arg> -l <arg> [--skip_user_compile] [--maven_dir <arg>]
     --pattern_minimum_library_usage_count <arg>        The minimum number
                                                        of library usages
                                                        per method.
+    --test_generator_parallel                          True if test
+                                                       generator should
+                                                       run in parallel.
+                                                       Requires that test
+                                                       generator output is
+                                                       disabled.
     --test_generator_disable_output                    True if test
                                                        generator output
                                                        should be hidden.
@@ -89,7 +96,8 @@ usage: schaapi -o <arg> -l <arg> [--maven_dir <arg>] [--repair_maven]
        [--library_type <arg>] [--pattern_minimum_library_usage_count
        <arg>] [--pattern_detector_minimum_count <arg>]
        [--pattern_detector_maximum_sequence_length <arg>]
-       [--test_generator_disable_output] [--test_generator_timeout <arg>]
+       [--test_generator_parallel] [--test_generator_disable_output]
+       [--test_generator_timeout <arg>]
  -o,--output_dir <arg>                                 The output
                                                        directory.
  -l,--library_dir <arg>                                The library
@@ -140,6 +148,12 @@ usage: schaapi -o <arg> -l <arg> [--maven_dir <arg>] [--repair_maven]
                                                        of sequences to be
                                                        considered for
                                                        pattern detection.
+    --test_generator_parallel                          True if test
+                                                       generator should
+                                                       run in parallel.
+                                                       Requires that test
+                                                       generator output is
+                                                       disabled.
     --test_generator_disable_output                    True if test
                                                        generator output
                                                        should be hidden.

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/OptionSets.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/OptionSets.kt
@@ -20,6 +20,7 @@ import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimplePathEnumerator
 import org.cafejojo.schaapi.models.project.JavaMavenProject
 import org.cafejojo.schaapi.models.project.JavaProject
 import java.io.File
+import kotlin.system.exitProcess
 
 /**
  * A piece of behavior for a [CommandLineInterface] that can "translate" parsed command-line arguments into components
@@ -37,6 +38,8 @@ abstract class OptionSet {
 
     /**
      * Reads parsed command-line options into the fields of this [OptionSet].
+     *
+     * This function will call [exitProcess] if the command-line options are invalid.
      *
      * @param cmd the parsed command-line options
      */
@@ -152,6 +155,7 @@ class GitHubMavenMinerOptionSet(private val maven: MavenOptionSet) : OptionSet()
 
         if (sortByStargazers && sortByWatchers) {
             logger.error { "Cannot sort repositories on both stargazers and watchers." }
+            exitProcess(-1)
         }
     }
 
@@ -337,6 +341,7 @@ class JimpleEvoSuiteTestGeneratorOptionSet : OptionSet() {
 
         if (parallel && !disableOutput) {
             logger.error { "Cannot run test generator in parallel if output is not disabled." }
+            exitProcess(-1)
         }
     }
 

--- a/modules/application/src/module-integration-test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
+++ b/modules/application/src/module-integration-test/kotlin/org/cafejojo/schaapi/SchaapiSmokeTest.kt
@@ -35,9 +35,9 @@ internal class SchaapiSmokeTest : Spek({
             "--test_generator_timeout", "3"
         ))
 
-        assertThat(target.resolve("patterns/org/cafejojo/schaapi/patterns/Patterns_0.class")).isFile()
+        assertThat(target.resolve("patterns/pattern0/org/cafejojo/schaapi/patterns/Pattern_0.class")).isFile()
         assertThat(
-            target.resolve("tests/evosuite-tests/org/cafejojo/schaapi/patterns/Patterns_0_ESTest_0.java")
+            target.resolve("tests/evosuite-tests/org/cafejojo/schaapi/patterns/Pattern_0_ESTest_0.java")
         ).isFile()
     }
 })

--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/TestGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/TestGenerator.kt
@@ -1,59 +1,82 @@
 package org.cafejojo.schaapi.miningpipeline.testgenerator.jimpleevosuite
 
+import me.tongfei.progressbar.ProgressBar
 import mu.KLogging
 import org.cafejojo.schaapi.miningpipeline.Pattern
 import org.cafejojo.schaapi.miningpipeline.TestGenerator
+import org.cafejojo.schaapi.miningpipeline.createProgressBarBuilder
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import org.cafejojo.schaapi.models.project.JavaProject
 import java.io.File
 import java.io.PrintStream
 
 private const val DEFAULT_PATTERN_CLASS_PACKAGE = "org.cafejojo.schaapi.patterns"
-private const val DEFAULT_PATTERN_CLASS_NAME_PREFIX = "Patterns"
+private const val DEFAULT_PATTERN_CLASS_NAME_PREFIX = "Pattern"
 
 /**
  * Represents the test generator that generates tests based on patterns.
  */
 class TestGenerator(
     private val library: JavaProject,
-    private val outputDirectory: File,
+    outputDirectory: File,
     private val timeout: Int,
+    private val parallel: Boolean = false,
     private val processStandardStream: PrintStream? = null,
     private val processErrorStream: PrintStream? = null
 ) : TestGenerator<JimpleNode> {
     private companion object : KLogging()
 
-    override fun generate(patterns: List<Pattern<JimpleNode>>) {
-        val outputPatterns = outputDirectory.resolve("patterns/").apply { mkdirs() }
-        val outputTests = outputDirectory.resolve("tests/").apply { mkdirs() }
+    private val outputPatterns = outputDirectory.resolve("patterns/").apply { mkdirs() }
+    private val outputTests = outputDirectory.resolve("tests/").apply { mkdirs() }
 
+    override fun generate(patterns: List<Pattern<JimpleNode>>) {
+        writePatterns(patterns)
+        generateTests(patterns)
+    }
+
+    private fun writePatterns(patterns: List<Pattern<JimpleNode>>) {
         logger.info { "Writing patterns to class files." }
+
         if (patterns.isEmpty()) {
             logger.warn { "No patterns were found in the user programs." }
 
-            ClassGenerator("$DEFAULT_PATTERN_CLASS_PACKAGE.${DEFAULT_PATTERN_CLASS_NAME_PREFIX}_NONE").apply {
-                writeToFile(outputPatterns.absolutePath)
-            }
-        } else {
-            patterns.forEachIndexed { index, pattern ->
-                ClassGenerator("$DEFAULT_PATTERN_CLASS_PACKAGE.${DEFAULT_PATTERN_CLASS_NAME_PREFIX}_$index").apply {
-                    val method = generateMethod("pattern$index", pattern)
+            ClassGenerator("$DEFAULT_PATTERN_CLASS_PACKAGE.${DEFAULT_PATTERN_CLASS_NAME_PREFIX}_NONE")
+                .apply { writeToFile(patternPath(0)) }
+        }
+
+        ProgressBar.wrap(patterns, createProgressBarBuilder("Creating pattern classes"))
+            .forEachIndexed { i, pattern ->
+                ClassGenerator("$DEFAULT_PATTERN_CLASS_PACKAGE.${DEFAULT_PATTERN_CLASS_NAME_PREFIX}_$i").apply {
+                    val method = generateMethod("pattern$i", pattern)
                     optimizeMethod(method)
-                    writeToFile(outputPatterns.absolutePath)
+                    writeToFile(patternPath(i))
                 }
             }
-        }
-        logger.info { "Finished writing patterns to class files." }
 
+        logger.info { "Finished writing patterns to class files." }
+    }
+
+    private fun generateTests(patterns: List<Pattern<JimpleNode>>) {
         logger.info { "Running EvoSuite." }
-        EvoSuiteRunner(
-            fullyQualifiedClassPrefix = DEFAULT_PATTERN_CLASS_PACKAGE,
-            classpath = outputPatterns.absolutePath + File.pathSeparator + library.classpath,
-            outputDirectory = outputTests.absolutePath,
-            generationTimeoutSeconds = timeout,
-            processStandardStream = processStandardStream,
-            processErrorStream = processErrorStream
-        ).run()
+
+        val progressBarBuilder = createProgressBarBuilder("Generating tests")
+        val patternIndices = (0 until patterns.size).toList()
+            .let { if (parallel) it.parallelStream() else it.stream() }
+            .let { if (processStandardStream == null) ProgressBar.wrap(it, progressBarBuilder) else it }
+
+        patternIndices.forEach { index ->
+            EvoSuiteRunner(
+                fullyQualifiedClassPrefix = DEFAULT_PATTERN_CLASS_PACKAGE,
+                classpath = patternPath(index) + File.pathSeparator + library.classpath,
+                outputDirectory = outputTests.absolutePath,
+                generationTimeoutSeconds = timeout,
+                processStandardStream = processStandardStream,
+                processErrorStream = processErrorStream
+            ).run()
+        }
+
         logger.info { "Finished running EvoSuite." }
     }
+
+    private fun patternPath(index: Int) = File(outputPatterns, "pattern$index").absolutePath
 }


### PR DESCRIPTION
### This PR depends on #368 

This PR parallelises EvoSuite. This parallelisation is disabled unless the `--test_generator_parallel` option is given. This option requires that `--test_generator_disable_output` is also given. Parallel EvoSuite ran 3 times as fast on my machine with an artificial project.

Because EvoSuite will always generate tests for all classes in a directory, the pattern classes had to be separated by directory. Therefore, instead of having two patterns in `patterns/`, one pattern will be in `patterns/pattern0/` and the other in `patterns/pattern1/`. This will make navigation harder, but I could not find another way to tell EvoSuite to run an instance per pattern.

Additionally, progress bars have been added for writing patterns to classes and for generating tests, respectively. The progress bar for test generation is only displayed if EvoSuite output is disabled.

Finally, this PR will make non-parallel EvoSuite slightly slower because a new EvoSuite instance has to be started for each pattern. The overhead is in the order of a few seconds per pattern.

<sub>Also, I changed the names of pattern classes from `PatternsX.class` to `PatternX.class`.</sub>
