### PR TITLE
If a Statement is a Static Invoke, Check Method Reference Declaring Class

### DIFF
--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/OptionSets.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/OptionSets.kt
@@ -12,7 +12,7 @@ import org.cafejojo.schaapi.miningpipeline.miner.github.GitHubProjectMiner
 import org.cafejojo.schaapi.miningpipeline.miner.github.MavenProjectSearchOptions
 import org.cafejojo.schaapi.miningpipeline.patterndetector.ccspan.CCSpanPatternDetector
 import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.IncompleteInitPatternFilterRule
-import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.InsufficientLibraryUsageFilter
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.InsufficientLibraryUsageFilterRule
 import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.LengthPatternFilterRule
 import org.cafejojo.schaapi.miningpipeline.testgenerator.jimpleevosuite.TestGenerator
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.GeneralizedNodeComparator
@@ -293,7 +293,7 @@ class PatternFilterOptionSet : OptionSet() {
     fun createPatternFilter(libraryProject: JavaProject) = PatternFilter(
         IncompleteInitPatternFilterRule(),
         LengthPatternFilterRule(),
-        InsufficientLibraryUsageFilter(libraryProject, minLibraryUsageCount)
+        InsufficientLibraryUsageFilterRule(libraryProject, minLibraryUsageCount)
     )
 
     private companion object {

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/build.gradle
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/build.gradle
@@ -4,6 +4,7 @@ repositories {
 
 dependencies {
     compile project(":mining-pipeline")
+    compile project(":mining-pipeline:jimple-pattern-filter")
 
     compile group: "org.cafejojo.schaapi.models", name: "java-project", version: version
     compile group: "org.cafejojo.schaapi.models", name: "jimple-library-usage-graph", version: version

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/JimpleLibraryUsageGraphGenerator.kt
@@ -2,9 +2,9 @@ package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple
 
 import mu.KLogging
 import org.cafejojo.schaapi.miningpipeline.LibraryUsageGraphGenerator
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.BranchStatementFilter
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.RecursiveGotoFilter
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.StatementFilter
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters.BranchStatementFilter
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters.RecursiveGotoFilter
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters.StatementFilter
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.processors.UserUsageProcessor
 import org.cafejojo.schaapi.models.DfsIterator
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessor.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessor.kt
@@ -1,6 +1,6 @@
 package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.processors
 
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.UserUsageValueFilter
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters.UserUsageValueFilter
 import org.cafejojo.schaapi.models.project.JavaProject
 import soot.Body
 import soot.BooleanType

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/Helpers.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/Helpers.kt
@@ -9,7 +9,6 @@ import soot.SootMethod
 import soot.jimple.StaticInvokeExpr
 import java.io.File
 
-internal const val NON_LIBRARY_CLASS = "java.lang.String"
 internal const val USER_CLASS =
     "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.users.SimpleTest"
 internal const val LIBRARY_CLASS =

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/Helpers.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/Helpers.kt
@@ -1,7 +1,19 @@
 package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple
 
+import com.nhaarman.mockito_kotlin.doReturn
+import com.nhaarman.mockito_kotlin.mock
 import org.cafejojo.schaapi.models.project.JavaProject
+import soot.Modifier
+import soot.SootClass
+import soot.SootMethod
+import soot.jimple.StaticInvokeExpr
 import java.io.File
+
+internal const val NON_LIBRARY_CLASS = "java.lang.String"
+internal const val USER_CLASS =
+    "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.users.SimpleTest"
+internal const val LIBRARY_CLASS =
+    "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.Object1"
 
 internal data class TestProject(
     override var classpath: String = "",
@@ -14,7 +26,15 @@ internal data class TestProject(
     override var classes: Set<File> = emptySet()
 }
 
-internal val libraryClasses = setOf(
-    "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.Object1"
-)
+internal val libraryClasses = setOf(LIBRARY_CLASS)
 internal val libraryProject = TestProject(classNames = libraryClasses)
+
+internal fun constructInvokeExprMock(declaringClassName: String): StaticInvokeExpr {
+    val clazz = SootClass(declaringClassName, Modifier.PUBLIC)
+    val method = mock<SootMethod> {
+        on { declaringClass } doReturn clazz
+    }
+    return mock {
+        on { getMethod() } doReturn method
+    }
+}

--- a/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessorTest.kt
+++ b/modules/mining-pipeline/jimple-library-usage-graph-generator/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/usagegraphgenerator/jimple/processors/UserUsageProcessorTest.kt
@@ -7,9 +7,9 @@ import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.verify
 import org.assertj.core.api.Assertions.assertThat
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.LIBRARY_CLASS
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.USER_CLASS
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters.constructInvokeExprMock
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.LIBRARY_CLASS
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.USER_CLASS
+import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.constructInvokeExprMock
 import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.libraryProject
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/InsufficientLibraryUsageFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/InsufficientLibraryUsageFilterRule.kt
@@ -6,6 +6,7 @@ import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleValueVisitor
 import org.cafejojo.schaapi.models.project.JavaProject
 import soot.Value
+import soot.jimple.StaticInvokeExpr
 import soot.jimple.internal.JStaticInvokeExpr
 
 /**
@@ -35,21 +36,27 @@ class InsufficientLibraryUsageFilter(libraryProject: JavaProject, private val mi
  */
 class LibraryUsageVisitor(private val libraryProject: JavaProject) : JimpleValueVisitor<Boolean>() {
     /**
-     * Returns true iff the type of [value] is for a library class or [JStaticInvokeExpr] declaring class is for a
-     * library.
+     * Returns true iff the type of [value] is for a library class.
      *
      * @param value a [Value]
      * @return true iff the type of [value] is for a library class
      */
-    override fun applyDefault(value: Value) = isLibraryClass(value.type.toString()) ||
-        (value is JStaticInvokeExpr) && isLibraryClass(value.methodRef.declaringClass().toString())
+    override fun applyDefault(value: Value) = isLibraryClass(value.type.toString())
 
     /**
-     * Returns true iff [result1] or [result2] are true.
+     * Returns true iff [JStaticInvokeExpr] declaring class is for a library.
+     *
+     * @param value a [StaticInvokeExpr]
+     * @return true iff [JStaticInvokeExpr] declaring class is for a library
+     */
+    override fun apply(value: StaticInvokeExpr) = isLibraryClass(value.methodRef.declaringClass().toString())
+
+    /**
+     * Returns true iff [result1] or [result2] is true.
      *
      * @param result1 a [Boolean]
      * @param result2 a [Boolean]
-     * @return true iff [result1] or [result2] are true
+     * @return true iff [result1] or [result2] is true
      */
     override fun accumulate(result1: Boolean, result2: Boolean) = result1 || result2
 

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/InsufficientLibraryUsageFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/InsufficientLibraryUsageFilterRule.kt
@@ -16,15 +16,14 @@ class InsufficientLibraryUsageFilterRule(
     private val libraryProject: JavaProject,
     private val minUseCount: Int
 ) : PatternFilterRule<JimpleNode> {
+    private val statementFilter = StatementFilter(libraryProject)
+
     /**
      * Returns true iff there are at least [minUseCount] nodes in [pattern] that use classes from the library project.
      *
      * @param pattern the pattern to check for library usages
      * @return true iff there are at least [minUseCount] nodes in [pattern] that use classes from the library project
      */
-    override fun retain(pattern: Pattern<JimpleNode>): Boolean {
-        val statementFilter = StatementFilter(libraryProject)
-
-        return pattern.count { statementFilter.retain(it.statement) } >= minUseCount
-    }
+    override fun retain(pattern: Pattern<JimpleNode>) =
+        pattern.count { statementFilter.retain(it.statement) } >= minUseCount
 }

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/InsufficientLibraryUsageFilterRule.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/InsufficientLibraryUsageFilterRule.kt
@@ -2,12 +2,9 @@ package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple
 
 import org.cafejojo.schaapi.miningpipeline.Pattern
 import org.cafejojo.schaapi.miningpipeline.PatternFilterRule
+import org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters.StatementFilter
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleNode
-import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleValueVisitor
 import org.cafejojo.schaapi.models.project.JavaProject
-import soot.Value
-import soot.jimple.StaticInvokeExpr
-import soot.jimple.internal.JStaticInvokeExpr
 
 /**
  * Filters out patterns that do not have enough calls to the library project.
@@ -15,56 +12,19 @@ import soot.jimple.internal.JStaticInvokeExpr
  * @param libraryProject the project that should be used
  * @property minUseCount the minimum number of usages per pattern to be qualified as a "sufficient user"
  */
-class InsufficientLibraryUsageFilter(libraryProject: JavaProject, private val minUseCount: Int) :
-    PatternFilterRule<JimpleNode> {
-    private val libraryUsageVisitor = LibraryUsageVisitor(libraryProject)
-
+class InsufficientLibraryUsageFilterRule(
+    private val libraryProject: JavaProject,
+    private val minUseCount: Int
+) : PatternFilterRule<JimpleNode> {
     /**
      * Returns true iff there are at least [minUseCount] nodes in [pattern] that use classes from the library project.
      *
      * @param pattern the pattern to check for library usages
      * @return true iff there are at least [minUseCount] nodes in [pattern] that use classes from the library project
      */
-    override fun retain(pattern: Pattern<JimpleNode>) =
-        pattern.count { node -> node.getTopLevelValues().any { libraryUsageVisitor.visit(it) } } >= minUseCount
-}
+    override fun retain(pattern: Pattern<JimpleNode>): Boolean {
+        val statementFilter = StatementFilter(libraryProject)
 
-/**
- * A visitor that determines whether a given [Value] uses [libraryProject].
- *
- * @property libraryProject the project that should be used
- */
-class LibraryUsageVisitor(private val libraryProject: JavaProject) : JimpleValueVisitor<Boolean>() {
-    /**
-     * Returns true iff the type of [value] is for a library class.
-     *
-     * @param value a [Value]
-     * @return true iff the type of [value] is for a library class
-     */
-    override fun applyDefault(value: Value) = isLibraryClass(value.type.toString())
-
-    /**
-     * Returns true iff [JStaticInvokeExpr] declaring class is for a library.
-     *
-     * @param value a [StaticInvokeExpr]
-     * @return true iff [JStaticInvokeExpr] declaring class is for a library
-     */
-    override fun apply(value: StaticInvokeExpr) = isLibraryClass(value.methodRef.declaringClass().toString())
-
-    /**
-     * Returns true iff [result1] or [result2] is true.
-     *
-     * @param result1 a [Boolean]
-     * @param result2 a [Boolean]
-     * @return true iff [result1] or [result2] is true
-     */
-    override fun accumulate(result1: Boolean, result2: Boolean) = result1 || result2
-
-    /**
-     * Returns true iff [className] is a class defined in [libraryProject].
-     *
-     * @param className a class name
-     * @return true iff [className] is a class defined in [libraryProject]
-     */
-    private fun isLibraryClass(className: String) = libraryProject.classNames.contains(className)
+        return pattern.count { statementFilter.retain(it.statement) } >= minUseCount
+    }
 }

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/BranchStatementFilter.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/BranchStatementFilter.kt
@@ -28,7 +28,7 @@ class BranchStatementFilter(project: JavaProject) : Filter {
             changed = false
 
             body.units.snapshotIterator().asSequence()
-                .filter(Companion::isBranchStatement)
+                .filter(::isBranchStatement)
                 .map { BranchStatement(body, it) }
                 .filter { !retain(it) }
                 .forEach {

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/BranchStatementFilter.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/BranchStatementFilter.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters
 
 import org.cafejojo.schaapi.models.project.JavaProject
 import soot.Body
@@ -18,7 +18,7 @@ import soot.toolkits.graph.UnitGraph
  *
  * @param project library project
  */
-internal class BranchStatementFilter(project: JavaProject) : Filter {
+class BranchStatementFilter(project: JavaProject) : Filter {
     internal val valueFilter = ValueFilter(project)
 
     override fun apply(body: Body) {
@@ -28,7 +28,7 @@ internal class BranchStatementFilter(project: JavaProject) : Filter {
             changed = false
 
             body.units.snapshotIterator().asSequence()
-                .filter(::isBranchStatement)
+                .filter(Companion::isBranchStatement)
                 .map { BranchStatement(body, it) }
                 .filter { !retain(it) }
                 .forEach {
@@ -42,13 +42,13 @@ internal class BranchStatementFilter(project: JavaProject) : Filter {
         branch.hasNonEmptyBranches || valueFilter.retain(getConditionValue(branch.statement))
 
     private companion object {
-        fun isBranchStatement(statement: Unit) = when (statement) {
+        internal fun isBranchStatement(statement: Unit) = when (statement) {
             is IfStmt -> true
             is SwitchStmt -> true
             else -> false
         }
 
-        fun getConditionValue(statement: Unit): Value = when (statement) {
+        internal fun getConditionValue(statement: Unit): Value = when (statement) {
             is IfStmt -> statement.condition
             is SwitchStmt -> statement.key
             else -> throw IllegalArgumentException("Cannot get value of unsupported statement.")

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/Filter.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/Filter.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters
 
 import soot.Body
 

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/RecursiveGotoFilter.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/RecursiveGotoFilter.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters
 
 import soot.Body
 import soot.Unit
@@ -7,7 +7,7 @@ import soot.jimple.GotoStmt
 /**
  * Removes recursive [GotoStmt]s.
  */
-internal class RecursiveGotoFilter : Filter {
+class RecursiveGotoFilter : Filter {
     /**
      * Removes recursive [GotoStmt]s.
      *

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/StatementFilter.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/StatementFilter.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters
 
 import org.cafejojo.schaapi.models.project.JavaProject
 import soot.Body
@@ -17,7 +17,7 @@ import soot.jimple.ThrowStmt
  *
  * @param project library project
  */
-internal class StatementFilter(project: JavaProject) : Filter {
+class StatementFilter(project: JavaProject) : Filter {
     private val valueFilter = ValueFilter(project)
     private val userUsageFilter = UserUsageValueFilter(project)
 

--- a/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/ValueFilter.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/ValueFilter.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters
 
 import mu.KLogging
 import org.cafejojo.schaapi.models.libraryusagegraph.jimple.JimpleValueVisitor
@@ -32,7 +32,7 @@ import soot.jimple.toolkits.thread.synchronization.NewStaticLock
  *
  * @property filterRules the rules to apply to the values
  */
-internal open class ValueFilter(private val filterRules: List<ValueFilterRule>) {
+open class ValueFilter(private val filterRules: List<ValueFilterRule>) {
     constructor(libraryProject: JavaProject) : this(
         listOf(
             ClassValueFilterRule(),
@@ -57,13 +57,12 @@ internal open class ValueFilter(private val filterRules: List<ValueFilterRule>) 
 /**
  * Filters [Value]s based only on their usage of classes from user projects.
  */
-internal class UserUsageValueFilter(libraryProject: JavaProject) :
-    ValueFilter(listOf(UserUsageValueFilterRule(libraryProject)))
+class UserUsageValueFilter(libraryProject: JavaProject) : ValueFilter(listOf(UserUsageValueFilterRule(libraryProject)))
 
 /**
  * Describes how a [Value] should be filtered.
  */
-internal abstract class ValueFilterRule : JimpleValueVisitor<Boolean>() {
+abstract class ValueFilterRule : JimpleValueVisitor<Boolean>() {
     companion object : KLogging()
 
     /**

--- a/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/InsufficientLibraryUsageFilterRuleTest.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/InsufficientLibraryUsageFilterRuleTest.kt
@@ -13,7 +13,7 @@ import soot.Value
 import soot.jimple.Jimple
 
 /**
- * Unit tests for [InsufficientLibraryUsageFilter].
+ * Unit tests for [InsufficientLibraryUsageFilterRule].
  */
 internal object InsufficientLibraryUsageFilterRuleTest : Spek({
     fun createLocal(name: String, type: String) = Jimple.v().newLocal(name, RefType.v(type))
@@ -23,13 +23,13 @@ internal object InsufficientLibraryUsageFilterRuleTest : Spek({
     fun createEqExpr(op1: Value, op2: Value) = Jimple.v().newEqExpr(op1, op2)
 
     describe("insufficient library usage filter") {
-        lateinit var filter: InsufficientLibraryUsageFilter
+        lateinit var filter: InsufficientLibraryUsageFilterRule
 
         beforeEachTest {
             val project = mock<JavaProject> {
                 on { it.classNames } doReturn setOf("ClassA", "ClassB", "ClassC")
             }
-            filter = InsufficientLibraryUsageFilter(project, 2)
+            filter = InsufficientLibraryUsageFilterRule(project, 2)
         }
 
         it("filters out empty patterns") {
@@ -71,7 +71,7 @@ internal object InsufficientLibraryUsageFilterRuleTest : Spek({
         it("retains patterns with exactly enough usages") {
             val pattern = listOf(
                 createAssignStmt(createLocal("localA", "ClassA"), createLocal("localB", "ClassB")),
-                createAssignStmt(createLocal("localC", "ClassC"), createLocal("localD", "InvalidA"))
+                createAssignStmt(createLocal("localC", "ClassC"), createLocal("localD", "ClassA"))
             ).map { JimpleNode(it) }
 
             assertThat(filter.retain(pattern)).isTrue()

--- a/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/Helpers.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/Helpers.kt
@@ -1,11 +1,13 @@
-package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
+import org.cafejojo.schaapi.models.project.JavaProject
 import soot.Modifier
 import soot.SootClass
 import soot.SootMethod
 import soot.jimple.StaticInvokeExpr
+import java.io.File
 
 internal const val NON_LIBRARY_CLASS = "java.lang.String"
 internal const val USER_CLASS =
@@ -22,3 +24,19 @@ internal fun constructInvokeExprMock(declaringClassName: String): StaticInvokeEx
         on { getMethod() } doReturn method
     }
 }
+
+internal data class TestProject(
+    override var classpath: String = "",
+    override var classNames: Set<String> = emptySet()
+) : JavaProject {
+    override val classDir: File = File(".")
+    override val dependencyDir: File = File(".")
+    override var dependencies: Set<File> = emptySet()
+    override val projectDir: File = File(".")
+    override var classes: Set<File> = emptySet()
+}
+
+internal val libraryClasses = setOf(
+    "org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.testclasses.library.Object1"
+)
+internal val libraryProject = TestProject(classNames = libraryClasses)

--- a/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/RecursiveGotoFilterTest.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/RecursiveGotoFilterTest.kt
@@ -1,4 +1,4 @@
-package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters
 
 import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.doReturn

--- a/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/StatementFilterTest.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/StatementFilterTest.kt
@@ -1,9 +1,8 @@
-package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.libraryProject
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it

--- a/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/ValueFilterTest.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/ValueFilterTest.kt
@@ -139,8 +139,7 @@ internal object ValueFilterTest : Spek({
         }
 
         it("does not recognize unknown new expressions") {
-            assertThatItDoesNotRecognize(
-                mock<AnyNewExpr>())
+            assertThatItDoesNotRecognize(mock<AnyNewExpr>())
         }
 
         it("filters cast expressions") {
@@ -163,16 +162,13 @@ internal object ValueFilterTest : Spek({
         }
 
         it("does not recognize unknown expressions") {
-            assertThatItDoesNotRecognize(
-                mock<Expr>())
+            assertThatItDoesNotRecognize(mock<Expr>())
         }
     }
 
     describe("filtering of ref values based on library usage") {
-        val libraryClass =
-            constructDeclaringClass(LIBRARY_CLASS)
-        val nonLibraryClass =
-            constructDeclaringClass(NON_LIBRARY_CLASS)
+        val libraryClass = constructDeclaringClass(LIBRARY_CLASS)
+        val nonLibraryClass = constructDeclaringClass(NON_LIBRARY_CLASS)
 
         val libraryField = mock<SootField> {
             on { declaringClass } doReturn libraryClass
@@ -212,13 +208,11 @@ internal object ValueFilterTest : Spek({
         }
 
         it("does not recognize unknown refs") {
-            assertThatItDoesNotRecognize(
-                mock<Ref>())
+            assertThatItDoesNotRecognize(mock<Ref>())
         }
 
         it("does not recognize unknown concrete refs") {
-            assertThatItDoesNotRecognize(
-                mock<ConcreteRef>())
+            assertThatItDoesNotRecognize(mock<ConcreteRef>())
         }
     }
 
@@ -238,19 +232,12 @@ internal object ValueFilterTest : Spek({
         }
 
         it("filters class constants") {
-            assertThatItRetains(
-                ClassConstant.v("L${LIBRARY_CLASS.replace(
-                    '.',
-                    '/')};"))
-            assertThatItDoesNotRetain(
-                ClassConstant.v("L${NON_LIBRARY_CLASS.replace(
-                    '.',
-                    '/')};"))
+            assertThatItRetains(ClassConstant.v("L${LIBRARY_CLASS.replace('.', '/')};"))
+            assertThatItDoesNotRetain(ClassConstant.v("L${NON_LIBRARY_CLASS.replace('.', '/')};"))
         }
 
         it("does not recognize unknown immediates") {
-            assertThatItDoesNotRecognize(
-                mock<Immediate>())
+            assertThatItDoesNotRecognize(mock<Immediate>())
         }
     }
 
@@ -268,8 +255,7 @@ internal object ValueFilterTest : Spek({
 
     describe("filtering of unrecognized values based on library usage") {
         it("does not recognize unknown values") {
-            assertThatItDoesNotRecognize(
-                mock {})
+            assertThatItDoesNotRecognize(mock {})
         }
     }
 

--- a/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/ValueFilterTest.kt
+++ b/modules/mining-pipeline/jimple-pattern-filter/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/patternfilter/jimple/libraryusagefilters/ValueFilterTest.kt
@@ -1,9 +1,8 @@
-package org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.filters
+package org.cafejojo.schaapi.miningpipeline.patternfilter.jimple.libraryusagefilters
 
 import com.nhaarman.mockito_kotlin.doReturn
 import com.nhaarman.mockito_kotlin.mock
 import org.assertj.core.api.Assertions.assertThat
-import org.cafejojo.schaapi.miningpipeline.usagegraphgenerator.jimple.libraryProject
 import org.jetbrains.spek.api.Spek
 import org.jetbrains.spek.api.dsl.describe
 import org.jetbrains.spek.api.dsl.it
@@ -140,7 +139,8 @@ internal object ValueFilterTest : Spek({
         }
 
         it("does not recognize unknown new expressions") {
-            assertThatItDoesNotRecognize(mock<AnyNewExpr>())
+            assertThatItDoesNotRecognize(
+                mock<AnyNewExpr>())
         }
 
         it("filters cast expressions") {
@@ -163,13 +163,16 @@ internal object ValueFilterTest : Spek({
         }
 
         it("does not recognize unknown expressions") {
-            assertThatItDoesNotRecognize(mock<Expr>())
+            assertThatItDoesNotRecognize(
+                mock<Expr>())
         }
     }
 
     describe("filtering of ref values based on library usage") {
-        val libraryClass = constructDeclaringClass(LIBRARY_CLASS)
-        val nonLibraryClass = constructDeclaringClass(NON_LIBRARY_CLASS)
+        val libraryClass =
+            constructDeclaringClass(LIBRARY_CLASS)
+        val nonLibraryClass =
+            constructDeclaringClass(NON_LIBRARY_CLASS)
 
         val libraryField = mock<SootField> {
             on { declaringClass } doReturn libraryClass
@@ -209,11 +212,13 @@ internal object ValueFilterTest : Spek({
         }
 
         it("does not recognize unknown refs") {
-            assertThatItDoesNotRecognize(mock<Ref>())
+            assertThatItDoesNotRecognize(
+                mock<Ref>())
         }
 
         it("does not recognize unknown concrete refs") {
-            assertThatItDoesNotRecognize(mock<ConcreteRef>())
+            assertThatItDoesNotRecognize(
+                mock<ConcreteRef>())
         }
     }
 
@@ -233,12 +238,19 @@ internal object ValueFilterTest : Spek({
         }
 
         it("filters class constants") {
-            assertThatItRetains(ClassConstant.v("L${LIBRARY_CLASS.replace('.', '/')};"))
-            assertThatItDoesNotRetain(ClassConstant.v("L${NON_LIBRARY_CLASS.replace('.', '/')};"))
+            assertThatItRetains(
+                ClassConstant.v("L${LIBRARY_CLASS.replace(
+                    '.',
+                    '/')};"))
+            assertThatItDoesNotRetain(
+                ClassConstant.v("L${NON_LIBRARY_CLASS.replace(
+                    '.',
+                    '/')};"))
         }
 
         it("does not recognize unknown immediates") {
-            assertThatItDoesNotRecognize(mock<Immediate>())
+            assertThatItDoesNotRecognize(
+                mock<Immediate>())
         }
     }
 
@@ -256,7 +268,8 @@ internal object ValueFilterTest : Spek({
 
     describe("filtering of unrecognized values based on library usage") {
         it("does not recognize unknown values") {
-            assertThatItDoesNotRecognize(mock {})
+            assertThatItDoesNotRecognize(
+                mock {})
         }
     }
 


### PR DESCRIPTION
In the InsufficientLibraryUsageFilterRule filter. This fix ensures that we also include patterns which only have static calls the library, which would otherwise have been filtered away.

Furthermore:
* When accumulating visits, return true iff either is true