### PR TITLE
Output dependency tree on absolute path

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/MavenLibraryVersionVerifier.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/MavenLibraryVersionVerifier.kt
@@ -39,7 +39,7 @@ class MavenLibraryVersionVerifier(
         isBatchMode = true
         javaHome = File(System.getProperty("java.home"))
         mavenOpts = """
-            -DoutputFile=${getDependenciesListLocation(project)}
+            -DoutputFile=${getDependenciesListLocation(project).absolutePath}
             -Dtokens=whitespace
         """.trimIndent().replace("\n", " ")
     }


### PR DESCRIPTION
For some reason, the `_schaapi_project_dependencies.txt` was placed in the `output/project/output/project/` directory on a Linux machine. The issue was resolved by giving Maven an absolute path to output to.