### PR TITLE
Allow cleaning output directory before running

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,18 @@ Schaapi allows you to mine projects from different sources, such as GitHub. In p
 <p>
 
 ```
-usage: schaapi -o <arg> -l <arg> [--skip_user_compile] [--maven_dir <arg>]
-       [--repair_maven] -u <arg> [--library_type <arg>]
-       [--pattern_detector_minimum_count <arg>]
+usage: schaapi -o <arg> [--delete_output_dir] -l <arg>
+       [--skip_user_compile] [--maven_dir <arg>] [--repair_maven] -u <arg>
+       [--library_type <arg>] [--pattern_detector_minimum_count <arg>]
        [--pattern_detector_maximum_sequence_length <arg>]
        [--pattern_minimum_library_usage_count <arg>]
        [--test_generator_disable_output] [--test_generator_timeout <arg>]
  -o,--output_dir <arg>                                 The output
                                                        directory.
+    --delete_output_dir                                Deletes the output
+                                                       directory before
+                                                       running the
+                                                       pipeline.
  -l,--library_dir <arg>                                The library
                                                        directory.
     --skip_user_compile                                Skip compilation of
@@ -82,8 +86,8 @@ usage: schaapi -o <arg> -l <arg> [--skip_user_compile] [--maven_dir <arg>]
 <p>
 
 ```
-usage: schaapi -o <arg> -l <arg> [--maven_dir <arg>] [--repair_maven]
-       --github_oauth_token <arg> [--max_projects <arg>]
+usage: schaapi -o <arg> [--delete_output_dir] -l <arg> [--maven_dir <arg>]
+       [--repair_maven] --github_oauth_token <arg> [--max_projects <arg>]
        --library_group_id <arg> --library_artifact_id <arg>
        --library_version <arg> [--sort_by_stargazers] [--sort_by_watchers]
        [--library_type <arg>] [--pattern_minimum_library_usage_count
@@ -92,6 +96,10 @@ usage: schaapi -o <arg> -l <arg> [--maven_dir <arg>] [--repair_maven]
        [--test_generator_disable_output] [--test_generator_timeout <arg>]
  -o,--output_dir <arg>                                 The output
                                                        directory.
+    --delete_output_dir                                Deletes the output
+                                                       directory before
+                                                       running the
+                                                       pipeline.
  -l,--library_dir <arg>                                The library
                                                        directory.
     --maven_dir <arg>                                  The directory to

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Schaapi allows you to mine projects from different sources, such as GitHub. In p
 <p>
 
 ```
-usage: schaapi -o <arg> [--delete_output_dir] -l <arg>
+usage: schaapi -o <arg> [--delete_old_output] -l <arg>
        [--skip_user_compile] [--maven_dir <arg>] [--repair_maven] -u <arg>
        [--library_type <arg>] [--pattern_detector_minimum_count <arg>]
        [--pattern_detector_maximum_sequence_length <arg>]
@@ -38,7 +38,7 @@ usage: schaapi -o <arg> [--delete_output_dir] -l <arg>
        [--test_generator_disable_output] [--test_generator_timeout <arg>]
  -o,--output_dir <arg>                                 The output
                                                        directory.
-    --delete_output_dir                                Deletes the output
+    --delete_old_output                                Deletes the output
                                                        directory before
                                                        running the
                                                        pipeline.
@@ -86,7 +86,7 @@ usage: schaapi -o <arg> [--delete_output_dir] -l <arg>
 <p>
 
 ```
-usage: schaapi -o <arg> [--delete_output_dir] -l <arg> [--maven_dir <arg>]
+usage: schaapi -o <arg> [--delete_old_output] -l <arg> [--maven_dir <arg>]
        [--repair_maven] --github_oauth_token <arg> [--max_projects <arg>]
        --library_group_id <arg> --library_artifact_id <arg>
        --library_version <arg> [--sort_by_stargazers] [--sort_by_watchers]
@@ -96,7 +96,7 @@ usage: schaapi -o <arg> [--delete_output_dir] -l <arg> [--maven_dir <arg>]
        [--test_generator_disable_output] [--test_generator_timeout <arg>]
  -o,--output_dir <arg>                                 The output
                                                        directory.
-    --delete_output_dir                                Deletes the output
+    --delete_old_output                                Deletes the output
                                                        directory before
                                                        running the
                                                        pipeline.

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -53,6 +53,7 @@ private fun printAsciiArt() = try {
 @Suppress("LateinitUsage") // Values cannot be determined at initialization
 abstract class CommandLineInterface {
     lateinit var outputDir: File
+    private var deleteOutputDir = false
     lateinit var libraryDir: File
 
     val optionSets: MutableList<OptionSet> = mutableListOf()
@@ -66,8 +67,12 @@ abstract class CommandLineInterface {
         val cmd = parse(args)
         optionSets.forEach { it.read(cmd) }
 
-        outputDir = File(cmd.getOptionValue('o')).apply { mkdirs() }
+        outputDir = File(cmd.getOptionValue('o'))
+        deleteOutputDir = cmd.hasOption("delete_output_dir")
         libraryDir = File(cmd.getOptionValue('l'))
+
+        if (deleteOutputDir) outputDir.deleteRecursively()
+        outputDir.mkdirs()
 
         run(cmd)
     }
@@ -89,6 +94,12 @@ abstract class CommandLineInterface {
             .desc("The output directory.")
             .hasArg()
             .required()
+            .build())
+        .addOption(Option
+            .builder()
+            .longOpt("delete_output_dir")
+            .desc("Deletes the output directory before running the pipeline.")
+            .hasArg(false)
             .build())
         .addOption(Option
             .builder("l")

--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/CommandLineInterface.kt
@@ -97,7 +97,7 @@ abstract class CommandLineInterface {
             .build())
         .addOption(Option
             .builder()
-            .longOpt("delete_output_dir")
+            .longOpt("delete_old_output")
             .desc("Deletes the output directory before running the pipeline.")
             .hasArg(false)
             .build())


### PR DESCRIPTION
Users can now give the `--delete_output_dir` option to delete the output directory before running the pipeline.