### PR TITLE
Turn off EvoSuite VFS usage

### DIFF
--- a/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
+++ b/modules/mining-pipeline/jimple-evosuite-test-generator/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/testgenerator/jimpleevosuite/EvosuiteTestGenerator.kt
@@ -39,6 +39,8 @@ internal class EvoSuiteRunner(
         "-base_dir", outputDirectory,
         "-projectCP", classpath,
         "-Dno_runtime_dependency=true",
+        "-Dvirtual_fs=false",
+        "-Dvirtual_net=false",
         "-Dsearch_budget=$generationTimeoutSeconds",
         "-Dstatistics_backend=NONE",
         "-Doutput_granularity=TESTCASE"


### PR DESCRIPTION
Currently, EvoSuite used a VFS (and a VNET) for mocking IO-related functionality in its tests. However, due to a discrepancy between the runtime behavior of EvoSuite tests and their search-time environment, this caused tests using those mock objects to fail when executed. This PR adds two options to the EvoSuiteRunner which disable the usage of virtualized file systems and network.