### PR TITLE
Skip projects without master branch

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -40,7 +40,7 @@ internal class GitHubProjectDownloader<P : Project>(
      */
     fun download(): List<P> =
         projectNames
-            .map { downloadAndSaveProject(it.first, it.second) }
+            .map { (projectName, branchName) -> downloadAndSaveProject(projectName, branchName) }
             .toList()
             .filterNotNull()
 

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -21,7 +21,7 @@ import kotlin.streams.toList
  * @property projectPacker packer which determines what type of [Project] to wrap the project directory in
  */
 internal class GitHubProjectDownloader<P : Project>(
-    private val projectNames: Stream<String>,
+    private val projectNames: Stream<Pair<String, String>>,
     private val outputDirectory: File,
     private val projectPacker: (File) -> P
 ) {
@@ -40,12 +40,12 @@ internal class GitHubProjectDownloader<P : Project>(
      */
     fun download(): List<P> =
         projectNames
-            .map { downloadAndSaveProject(it) }
+            .map { downloadAndSaveProject(it.first, it.second) }
             .toList()
             .filterNotNull()
 
-    private fun downloadAndSaveProject(projectName: String): P? =
-        getInputStream(projectName)?.use { inputStream ->
+    private fun downloadAndSaveProject(projectName: String, branchName: String): P? =
+        getInputStream(projectName, branchName)?.use { inputStream ->
             val gitHubProjectZip = saveZipToFile(inputStream, projectName) ?: return null
             val gitHubProject = unzip(gitHubProjectZip) ?: return null
 
@@ -103,8 +103,8 @@ internal class GitHubProjectDownloader<P : Project>(
         return if (githubProject.exists()) githubProject else null
     }
 
-    private fun getInputStream(projectName: String): InputStream? {
-        val url = getUrl(projectName)
+    private fun getInputStream(projectName: String, branchName: String): InputStream? {
+        val url = getUrl(projectName, branchName)
 
         try {
             val connection = url.openConnection() as? HttpURLConnection ?: return null
@@ -117,5 +117,6 @@ internal class GitHubProjectDownloader<P : Project>(
         }
     }
 
-    internal fun getUrl(projectName: String) = URL("https://github.com/$projectName/archive/master.zip")
+    internal fun getUrl(projectName: String, branchName: String) =
+        URL("https://github.com/$projectName/archive/$branchName.zip")
 }

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
@@ -26,7 +26,7 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
      *
      * @return list of full names of found repositories on [GitHub] based on the passed options
      */
-    fun searchContent(gitHub: GitHub): List<String> {
+    fun searchContent(gitHub: GitHub): List<Pair<String, String>> {
         val searchResults = buildGitHubSearchContent(gitHub).list()
 
         logger.info { "Found ${searchResults.totalCount} projects." }
@@ -36,7 +36,7 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
             .apply { if (sortByStargazers) sortByStargazers(this) }
             .apply { if (sortByWatchers) sortByWatchers(this) }
             .take(maxProjects)
-            .map { it.owner.fullName }
+            .map { it.owner.fullName to it.owner.defaultBranch }
 
         logger.info { "Found ${names.size} projects names using the GitHub v3 Search API." }
         return names

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
@@ -36,7 +36,7 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
             .apply { if (sortByStargazers) sortByStargazers(this) }
             .apply { if (sortByWatchers) sortByWatchers(this) }
             .take(maxProjects)
-            .map { it.owner.fullName to it.owner.defaultBranch }
+            .map { it.owner.fullName to (it.owner.defaultBranch ?: "master") }
 
         logger.info { "Found ${names.size} projects names using the GitHub v3 Search API." }
         return names

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/SearchOptions.kt
@@ -36,7 +36,10 @@ abstract class GitHubSearchOptions(private val maxProjects: Int) : SearchOptions
             .apply { if (sortByStargazers) sortByStargazers(this) }
             .apply { if (sortByWatchers) sortByWatchers(this) }
             .take(maxProjects)
-            .map { it.owner.fullName to (it.owner.defaultBranch ?: "master") }
+            .mapNotNull {
+                if (it.owner.branches.contains("master")) it.owner.fullName to "master"
+                else null
+            }
 
         logger.info { "Found ${names.size} projects names using the GitHub v3 Search API." }
         return names

--- a/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloaderTest.kt
+++ b/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloaderTest.kt
@@ -60,7 +60,7 @@ internal object GitHubProjectDownloaderTest : Spek({
             val zipStreamContent = "testZip"
             val repoZipStream = zipStreamContent.byteInputStream()
 
-            GitHubProjectDownloader(listOf(repoName).stream(), output, ::testProjectPacker)
+            GitHubProjectDownloader(Stream.of(repoName to "master"), output, ::testProjectPacker)
                 .saveZipToFile(repoZipStream, repoName)
 
             assertThat(File(output, "$repoName-$repoNameDigest.zip")).exists()
@@ -73,7 +73,7 @@ internal object GitHubProjectDownloaderTest : Spek({
             val zipStreamContent = "testZip"
             val repoZipStream = zipStreamContent.byteInputStream()
 
-            GitHubProjectDownloader(listOf(repoName).stream(), output, ::testProjectPacker)
+            GitHubProjectDownloader(Stream.of(repoName to "master"), output, ::testProjectPacker)
                 .saveZipToFile(repoZipStream, repoName)
 
             assertThat(File(output, "ab-$repoNameDigest.zip")).exists()
@@ -89,7 +89,7 @@ internal object GitHubProjectDownloaderTest : Spek({
             val repo1ZipStream = zip1StreamContent.byteInputStream()
             val repo2ZipStream = zip2StreamContent.byteInputStream()
 
-            val repoNames = listOf(repoName1, repoName2)
+            val repoNames = listOf(repoName1 to "master", repoName2 to "master")
             GitHubProjectDownloader(repoNames.stream(), output, ::testProjectPacker)
                 .apply { saveZipToFile(repo1ZipStream, repoName1) }
                 .apply { saveZipToFile(repo2ZipStream, repoName2) }
@@ -110,7 +110,7 @@ internal object GitHubProjectDownloaderTest : Spek({
 
             assertThat(output.listFiles().size).isEqualTo(1)
 
-            GitHubProjectDownloader(listOf(repoName).stream(), output, ::testProjectPacker)
+            GitHubProjectDownloader(Stream.of(repoName to "master"), output, ::testProjectPacker)
                 .saveZipToFile(repoZipStream, repoName)
 
             assertThat(output.listFiles().size).isEqualTo(1)
@@ -175,13 +175,14 @@ internal object GitHubProjectDownloaderTest : Spek({
             val zipFile = addZipFile("testProject", "content", output)
 
             val workDir = File(output, "downloads").apply { mkdirs() }
-            val downloader = spy(GitHubProjectDownloader(Stream.of("testProject"), workDir, ::testProjectPacker))
+            val downloader =
+                spy(GitHubProjectDownloader(Stream.of("testProject" to "master"), workDir, ::testProjectPacker))
             val mockHttpURLConnection = mock<HttpURLConnection> {
                 on(it.inputStream) doReturn FileInputStream(zipFile)
             }
             val mockURL = mock<URL> { on(it.openConnection()) doReturn mockHttpURLConnection }
 
-            doReturn(mockURL).`when`(downloader).getUrl("testProject")
+            doReturn(mockURL).`when`(downloader).getUrl("testProject", "master")
 
             assertThat(workDir.listFiles()).isEmpty()
 


### PR DESCRIPTION
Sometimes the GitHub project downloader would fail to download a project because it could not find the zip. Turns out this happens when the project in question does not have a `master` branch. ~~To prevent this from happening, the downloader now downloads the default branch instead.~~ Edit: Because of a bug in the GitHub API library we're using (cf. kohsuke/github-api#494), the default branch cannot currently be obtained. Therefore, the workaround is to just use the `master` branch if it exists, and to reject the user project otherwise.
