### PR TITLE
Loosen strict type requirement in miner

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectMiner.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectMiner.kt
@@ -5,7 +5,7 @@ import mu.KLogging
 import org.cafejojo.schaapi.miningpipeline.ProjectMiner
 import org.cafejojo.schaapi.miningpipeline.createProgressBarBuilder
 import org.cafejojo.schaapi.models.Project
-import org.cafejojo.schaapi.models.project.JavaMavenProject
+import org.cafejojo.schaapi.models.project.MavenProject
 import org.kohsuke.github.GitHub
 import java.io.File
 
@@ -22,7 +22,7 @@ import java.io.File
  * is created
  * @property projectPacker packer which determines what type of [Project] to wrap the project directory in
  */
-class GitHubProjectMiner<P : JavaMavenProject>(
+class GitHubProjectMiner<P : MavenProject>(
     private var token: String,
     private val outputDirectory: File,
     private val projectPacker: (File) -> P

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/MavenLibraryVersionVerifier.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/MavenLibraryVersionVerifier.kt
@@ -3,7 +3,7 @@ package org.cafejojo.schaapi.miningpipeline.miner.github
 import mu.KLogging
 import org.apache.maven.shared.invoker.DefaultInvocationRequest
 import org.apache.maven.shared.invoker.DefaultInvoker
-import org.cafejojo.schaapi.models.project.JavaMavenProject
+import org.cafejojo.schaapi.models.project.MavenProject
 import java.io.File
 
 /**
@@ -29,11 +29,11 @@ class MavenLibraryVersionVerifier(
      *
      * @param project a user project of the library
      */
-    fun verify(project: JavaMavenProject) =
+    fun verify(project: MavenProject) =
         if (createMavenInvoker(project).execute(createMavenInvocationRequest(project)).exitCode != 0) false
         else getDependencies(project).any { it.startsWith(query) }
 
-    private fun createMavenInvocationRequest(project: JavaMavenProject) = DefaultInvocationRequest().apply {
+    private fun createMavenInvocationRequest(project: MavenProject) = DefaultInvocationRequest().apply {
         baseDirectory = project.projectDir
         goals = listOf("dependency:tree")
         isBatchMode = true
@@ -44,15 +44,15 @@ class MavenLibraryVersionVerifier(
         """.trimIndent().replace("\n", " ")
     }
 
-    private fun createMavenInvoker(project: JavaMavenProject) = DefaultInvoker().also {
+    private fun createMavenInvoker(project: MavenProject) = DefaultInvoker().also {
         if (displayOutput) it.setOutputHandler(logger::info) else it.setOutputHandler(null)
         it.mavenHome = project.mavenDir
         it.workingDirectory = project.projectDir
     }
 
-    private fun getDependenciesListLocation(project: JavaMavenProject) =
+    private fun getDependenciesListLocation(project: MavenProject) =
         File(project.projectDir, "_schaapi_project_dependencies.txt")
 
-    private fun getDependencies(project: JavaMavenProject) =
+    private fun getDependencies(project: MavenProject) =
         getDependenciesListLocation(project).readText().trim().split("\\s+".toRegex()).drop(1)
 }


### PR DESCRIPTION
This PR resolves what is currently the only compilation warning in the codebase by making the type requirement in the GitHub miner less strict. After all, the miner doesn't care whether the code is written in Java, it just wants it to be a Maven project so that it can find the `pom.xml`.