### PR TITLE
Catch exceptions while constructing URLs

### DIFF
--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -104,9 +104,8 @@ internal class GitHubProjectDownloader<P : Project>(
     }
 
     private fun getInputStream(projectName: String, branchName: String): InputStream? {
-        val url = getUrl(projectName, branchName)
-
         try {
+            val url = getUrl(projectName, branchName)
             val connection = url.openConnection() as? HttpURLConnection ?: return null
             logger.debug { "Established a connection with '$url'." }
 

--- a/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloaderTest.kt
+++ b/modules/mining-pipeline/github-project-miner/src/test/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloaderTest.kt
@@ -67,7 +67,23 @@ internal object GitHubProjectDownloaderTest : Spek({
             assertThat(File(output, "$repoName-$repoNameDigest.zip").readText()).isEqualTo(zipStreamContent)
         }
 
-        it("should remove illegal characters from the repo name") {
+        it("should skip repos that do not exist") {
+            val projectNames = Stream.of("cafejojo/doesnotexist" to "master")
+
+            val projects = GitHubProjectDownloader(projectNames, output, ::testProjectPacker).download()
+
+            assertThat(projects).isEmpty()
+        }
+
+        it("should skip branches that do not exist") {
+            val projectNames = Stream.of("cafejojo/schaapi" to "thisbranchdoesnotexist")
+
+            val projects = GitHubProjectDownloader(projectNames, output, ::testProjectPacker).download()
+
+            assertThat(projects).isEmpty()
+        }
+
+        it("should remove illegal characters from the repo name in the output name") {
             val repoName = ",./<>?;':\"a[]{}-=_+!@b#$%^&*()"
             val repoNameDigest = "0ff8c4342658756c2f319f74836b5d1e"
             val zipStreamContent = "testZip"


### PR DESCRIPTION
The `URL` constructor may throw an `IOException`, for example when the URL is malformed. These exceptions should be caught.