### PR TITLE
Resolve false-positive "empty jar" warning

### DIFF
--- a/modules/mining-pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javajar/JavaJarProjectCompiler.kt
+++ b/modules/mining-pipeline/java-jar-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javajar/JavaJarProjectCompiler.kt
@@ -12,11 +12,12 @@ import java.util.jar.JarInputStream
 class JavaJarProjectCompiler : ProjectCompiler<JavaJarProject> {
     private companion object : KLogging()
 
-    override fun compile(project: JavaJarProject) = with(project) {
-        classNames = findClasses(JarInputStream(FileInputStream(project.classDir)))
-        if (classes.isEmpty()) logger.warn { "Jar project at ${projectDir.path} is empty." }
-        project
-    }
+    override fun compile(project: JavaJarProject) =
+        with(project) {
+            classNames = findClasses(JarInputStream(FileInputStream(project.classDir)))
+            if (classNames.isEmpty()) logger.warn { "Jar project at ${projectDir.path} is empty." }
+            project
+        }
 
     private fun findClasses(jarInputStream: JarInputStream): Set<String> {
         val classNames = mutableSetOf<String>()


### PR DESCRIPTION
Prevents the `Jar project at {path} is empty.` message from being displayed when the jar in question is not actually empty. The issue was that the check for the message checked the wrong variable (`classes` instead of `classNames`) 🤦‍♂️ 

I also reformatted the code because it took me way too long to spot the `with(project)`.