### PR TITLE
Allow enabling debug output on command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Schaapi requires JRE 8 and has been tested on Windows and Unix systems.
 ## Usage
 Run the JAR as `java -jar schaapi.jar <flavor> <args>` or run a local build with `gradlew :application:run --args='<flavor> <args>'`.
 
+Set the system property `log.level` to `debug` to enable debug output in the log file. 
+
 ### Pipeline Flavor
 Schaapi allows you to mine projects from different sources, such as GitHub. In particular, it recognizes two such pipeline "flavors": `directory` (locally sourced projects) and `github` (projects mined from GitHub). Each of these have their own behavior and options. Click on one of the flavors below for a list of command-line options.
 

--- a/modules/application/build.gradle
+++ b/modules/application/build.gradle
@@ -24,6 +24,12 @@ dependencies {
     compile group: "commons-cli", name: "commons-cli", version: commonsCliVersion
 }
 
+// Application
+run {
+    if (System.getProperty("log.level") != null)
+        systemProperty "log.level", System.getProperty("log.level")
+}
+
 // Distribution
 inspectClassesForKotlinIC.enabled = false // Workaround for https://youtrack.jetbrains.com/issue/KT-24956
 

--- a/modules/application/src/main/resources/logback.xml
+++ b/modules/application/src/main/resources/logback.xml
@@ -17,7 +17,7 @@
         </encoder>
     </appender>
 
-    <root level="info">
+    <root level="${log.level:-info}">
         <appender-ref ref="FILE"/>
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
Users can now enable debug output in the log file by setting the `log.level` system property to `debug`. We barely have any debug log statements at the moment, but that will be the subject of a future PR.