### PR TITLE
Skip compilation of tests

### DIFF
--- a/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompiler.kt
+++ b/modules/mining-pipeline/java-maven-project-compiler/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/projectcompiler/javamaven/JavaMavenProjectCompiler.kt
@@ -34,7 +34,7 @@ class JavaMavenProjectCompiler(
             goals = listOf("clean", "install")
             isBatchMode = true
             javaHome = File(System.getProperty("java.home"))
-            mavenOpts = "-DskipTests=true"
+            mavenOpts = "-Dmaven.test.skip=true"
             pomFile = project.pomFile
         }
 


### PR DESCRIPTION
According to [this comment on StackOverflow](https://stackoverflow.com/questions/5784778/#comment95983536_26869885), `skipTests` will only skip execution of tests, while `maven.test.skip` will skip both compilation and execution. Since we don't look at test code, we should skip that step to speed up the process.