### PR TITLE
Check for presence of pom.xml before packing

### DIFF
--- a/modules/application/src/main/kotlin/org/cafejojo/schaapi/OptionSets.kt
+++ b/modules/application/src/main/kotlin/org/cafejojo/schaapi/OptionSets.kt
@@ -175,7 +175,12 @@ class GitHubMavenMinerOptionSet(private val maven: MavenOptionSet) : OptionSet()
      * @return a GitHub miner for Maven projects
      */
     fun createMiner(outputDir: File) =
-        GitHubProjectMiner(token, outputDir, verifierTimeout) { JavaMavenProject(it, maven.dir) }
+        GitHubProjectMiner(token, outputDir, verifierTimeout) { dir ->
+            if (dir.listFiles { file -> file.name == "pom.xml" }.size == 1)
+                JavaMavenProject(dir, maven.dir)
+            else
+                null
+        }
 
     /**
      * Creates the mining options for mining GitHub projects.

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectDownloader.kt
@@ -23,7 +23,7 @@ import kotlin.streams.toList
 internal class GitHubProjectDownloader<P : Project>(
     private val projectNames: Stream<Pair<String, String>>,
     private val outputDirectory: File,
-    private val projectPacker: (File) -> P
+    private val projectPacker: (File) -> P?
 ) {
     private companion object : KLogging()
 

--- a/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectMiner.kt
+++ b/modules/mining-pipeline/github-project-miner/src/main/kotlin/org/cafejojo/schaapi/miningpipeline/miner/github/GitHubProjectMiner.kt
@@ -29,7 +29,7 @@ class GitHubProjectMiner<P : MavenProject>(
     private var token: String,
     private val outputDirectory: File,
     private val verifierTimeout: Long = 0L,
-    private val projectPacker: (File) -> P
+    private val projectPacker: (File) -> P?
 ) : ProjectMiner<MavenProjectSearchOptions, P> {
     private companion object : KLogging()
 


### PR DESCRIPTION
When the `GitHubProjectMiner` has found a project, it will then call run the `projectPacker` on that project. By default, the `projectPacker` is the constructor of the `JavaMavenProject` class. If the project does not contain a `pom.xml`, this constructor will throw an `IllegalArgumentException`, which will kill the entire pipeline.

To solve this, the `projectPacker` function has been changed to verify that there is a `pom.xml` before actually packing the project.